### PR TITLE
Do you need the AND or the Backgrounding Operator?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ run-server:
 	./build/heimdalld rest-server 
 
 start-server:
-	mkdir -p ./logs &&
-	./build/heimdalld rest-server > ./logs/heimdalld-rest-server.log &&
+	mkdir -p ./logs &
+	./build/heimdalld rest-server > ./logs/heimdalld-rest-server.log &
 
 start:
 	mkdir -p ./logs


### PR DESCRIPTION
Got an Error with the AND operator -->
mkdir -p ./logs &&
/bin/sh: 1: Syntax error: end of file unexpected
Makefile:69: recipe for target 'start-server' failed
make: *** [start-server] Error 2