### PR TITLE
Dockerfile for CS1001

### DIFF
--- a/docker/Dockerfile.CS1001
+++ b/docker/Dockerfile.CS1001
@@ -1,0 +1,51 @@
+# Start from a Debian image with the latest version of Go installed
+# and a workspace (GOPATH) configured at /go.
+FROM golang:latest
+
+# update available packages
+RUN apt-get update -y && apt-get upgrade -y && apt install build-essential -y
+
+RUN apt-get install vim -y
+
+# setup dep
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+# create go src directory and clone heimdall
+RUN mkdir -p /go/src/github.com/maticnetwork/ \
+  && cd /go/src/github.com/maticnetwork/
+
+# change work directory
+WORKDIR /go/src/github.com/maticnetwork/
+
+# ADD . /go/src/github.com/maticnetwork/heimdall/
+RUN git clone https://github.com/maticnetwork/heimdall.git
+
+# change work directory
+WORKDIR /go/src/github.com/maticnetwork/heimdall
+
+# checkout by tag
+RUN git checkout CS-1001
+
+# run dep
+ RUN make dep
+
+# GOBIN required for go install
+ENV GOBIN $GOPATH/bin
+
+# run build
+RUN make install
+
+# initialize heimdall
+ RUN heimdalld init
+
+# add volumes
+VOLUME ["/root/.heimdalld", "./logs", "./build"]
+
+# change working dir
+WORKDIR /go/src/github.com/maticnetwork/
+
+# clone public testnets
+RUN git clone https://github.com/maticnetwork/public-testnets.git
+
+# Expose Ports
+EXPOSE 1317 26656 26657


### PR DESCRIPTION
This PR includes

Docker image for Counter Stage-0. Commit-id and config files are added in Dockerfile.

To run node, user just has to 
1. run the container.
2. update API_KEY, persistent_peers
3. start heimdall, rest-server