### PR TITLE
fix poll interval issue

### DIFF
--- a/helper/toml.go
+++ b/helper/toml.go
@@ -58,6 +58,8 @@ child_chain_block_interval = "{{ .ChildBlockInterval }}"
 checkpoint_poll_interval = "{{ .CheckpointerPollInterval }}" 
 syncer_poll_interval = "{{ .SyncerPollInterval }}"
 noack_poll_interval = "{{ .NoACKPollInterval }}"
+clerk_polling_interval = "{{ .ClerkPollingInterval }}" 
+span_polling_interval = "{{ .SpanPollingInterval }}" 
 
 
 ##### Checkpoint Length Config #####


### PR DESCRIPTION
Default poll interval is not set for clerk and span service as respective config missing in toml.go.  