### PR TITLE
MAT-533 - don't propose checkpoint if current validator's checkpoint …

### DIFF
--- a/bridge/pier/checkpoint.go
+++ b/bridge/pier/checkpoint.go
@@ -282,7 +282,7 @@ func (c *Checkpointer) sendRequest(newHeader *types.Header) {
 	end := expectedCheckpointState.newEnd
 
 	if bufferedCheckpoint != nil && bufferedCheckpoint.proposer.Equals(hmtypes.BytesToHeimdallAddress(helper.GetAddress())) && bufferedCheckpoint.start == start {
-		c.Logger.Info("Checkpoint already proposed by current validator with same start block", "validatorAddress", bufferedCheckpoint.proposer, "startBlock", start)
+		c.Logger.Info("Checkpoint already proposed to heimdall by us", "proposer", bufferedCheckpoint.proposer, "startBlock", start, "endBlock", end)
 		return
 	}
 

--- a/bridge/pier/checkpoint.go
+++ b/bridge/pier/checkpoint.go
@@ -280,6 +280,12 @@ func (c *Checkpointer) sendRequest(newHeader *types.Header) {
 
 	start := expectedCheckpointState.newStart
 	end := expectedCheckpointState.newEnd
+
+	if bufferedCheckpoint != nil && bufferedCheckpoint.proposer.Equals(hmtypes.BytesToHeimdallAddress(helper.GetAddress())) && bufferedCheckpoint.start == start {
+		c.Logger.Info("Checkpoint already proposed by current validator with same start block", "validatorAddress", bufferedCheckpoint.proposer, "startBlock", start)
+		return
+	}
+
 	if err := c.sendCheckpointToHeimdall(start, end); err != nil {
 		c.Logger.Error("Error while sending checkpoint", "error", err)
 	}
@@ -381,7 +387,7 @@ func (c *Checkpointer) fetchBufferedCheckpoint() (*HeimdallCheckpoint, error) {
 		return nil, err
 	}
 
-	bufferedCheckpoint := NewHeimdallCheckpoint(_checkpoint.StartBlock, _checkpoint.EndBlock)
+	bufferedCheckpoint := NewHeimdallCheckpoint(_checkpoint.StartBlock, _checkpoint.EndBlock, _checkpoint.Proposer)
 	return bufferedCheckpoint, nil
 }
 
@@ -394,7 +400,7 @@ func (c *Checkpointer) fetchCommittedCheckpoint() (*HeimdallCheckpoint, error) {
 		return nil, err
 	}
 
-	return NewHeimdallCheckpoint(_checkpoint.StartBlock, _checkpoint.EndBlock), nil
+	return NewHeimdallCheckpoint(_checkpoint.StartBlock, _checkpoint.EndBlock, _checkpoint.Proposer), nil
 }
 
 // fetches checkpoint from given URL

--- a/bridge/pier/types.go
+++ b/bridge/pier/types.go
@@ -3,6 +3,8 @@ package pier
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/maticnetwork/heimdall/types"
 )
 
 // HeaderBlock header block
@@ -26,9 +28,10 @@ func (c ContractCheckpoint) String() string {
 
 // HeimdallCheckpoint heimdall checkpoint
 type HeimdallCheckpoint struct {
-	start uint64
-	end   uint64
-	found bool
+	start    uint64
+	end      uint64
+	proposer types.HeimdallAddress
+	found    bool
 }
 
 // NewContractCheckpoint creates contract checkpoint
@@ -41,9 +44,10 @@ func NewContractCheckpoint(_newStart uint64, _newEnd uint64, _currentHeaderBlock
 }
 
 // NewHeimdallCheckpoint creates new heimdall checkpoint object
-func NewHeimdallCheckpoint(_start uint64, _end uint64) *HeimdallCheckpoint {
+func NewHeimdallCheckpoint(_start uint64, _end uint64, _proposer types.HeimdallAddress) *HeimdallCheckpoint {
 	return &HeimdallCheckpoint{
-		start: _start,
-		end:   _end,
+		start:    _start,
+		end:      _end,
+		proposer: _proposer,
 	}
 }


### PR DESCRIPTION
…is present in buffer


checkpoint optimization - 
currently validator keeps proposing checkpoint transactions with increased checkpoint size on each poll interval increasing the fee cost. 
validator should propose new checkpoint only if his checkpoint is not in buffer.