### PR TITLE
MAT-677 - Handle block not found

### DIFF
--- a/checkpoint/handler.go
+++ b/checkpoint/handler.go
@@ -57,7 +57,16 @@ func handleMsgCheckpoint(ctx sdk.Context, msg types.MsgCheckpoint, k Keeper, con
 	// k.Logger(ctx).Debug("Received checkpoint from buffer", "Checkpoint", checkpointBuffer.String())
 
 	// validate checkpoint
-	if !types.ValidateCheckpoint(msg.StartBlock, msg.EndBlock, msg.RootHash) {
+	validCheckpoint, err := types.ValidateCheckpoint(msg.StartBlock, msg.EndBlock, msg.RootHash)
+	if err != nil {
+		k.Logger(ctx).Error("Error validating checkpoint",
+			"Error", err,
+			"StartBlock", msg.StartBlock,
+			"EndBlock", msg.EndBlock)
+		return common.ErrBadBlockDetails(k.Codespace()).Result()
+	}
+
+	if !validCheckpoint {
 		k.Logger(ctx).Error("RootHash is not valid",
 			"StartBlock", msg.StartBlock,
 			"EndBlock", msg.EndBlock,


### PR DESCRIPTION
Issue - https://github.com/maticnetwork/heimdall/issues/154

Currently, if blocks are not found we validate the transaction with the blocks found, instead of throwing Roothash doesnt match error we should throw blocks not found error.

