### PR TITLE
Adds --auto-configure for checkpoint

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -330,7 +330,7 @@ func NewHeimdallApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.Ba
 		supply.NewAppModule(app.SupplyKeeper, &app.caller),
 		gov.NewAppModule(app.GovKeeper, app.SupplyKeeper),
 		staking.NewAppModule(app.StakingKeeper, &app.caller),
-		checkpoint.NewAppModule(app.CheckpointKeeper, &app.caller),
+		checkpoint.NewAppModule(app.CheckpointKeeper, app.StakingKeeper, &app.caller),
 		bor.NewAppModule(app.BorKeeper, &app.caller),
 		clerk.NewAppModule(app.ClerkKeeper, &app.caller),
 		topup.NewAppModule(app.TopupKeeper, &app.caller),
@@ -352,23 +352,6 @@ func NewHeimdallApp(logger log.Logger, db dbm.DB, baseAppOptions ...func(*bam.Ba
 
 	// register message routes and query routes
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter())
-
-	// register message routes
-	// app.Router().
-	// 	AddRoute(bankTypes.RouterKey, bank.NewHandler(app.bankKeeper, &app.caller)).
-	// 	AddRoute(checkpointTypes.RouterKey, checkpoint.NewHandler(app.checkpointKeeper, &app.caller)).
-	// 	AddRoute(stakingTypes.RouterKey, staking.NewHandler(app.stakingKeeper, &app.caller)).
-	// 	AddRoute(borTypes.RouterKey, bor.NewHandler(app.borKeeper)).
-	// 	AddRoute(clerkTypes.RouterKey, clerk.NewHandler(app.clerkKeeper, &app.caller))
-
-	// app.QueryRouter().
-	// 	AddRoute(authTypes.QuerierRoute, auth.NewQuerier(app.AccountKeeper)).
-	// 	AddRoute(bankTypes.QuerierRoute, bank.NewQuerier(app.bankKeeper)).
-	// 	AddRoute(supplyTypes.QuerierRoute, supply.NewQuerier(app.supplyKeeper)).
-	// 	AddRoute(stakingTypes.QuerierRoute, staking.NewQuerier(app.stakingKeeper)).
-	// 	AddRoute(checkpointTypes.QuerierRoute, checkpoint.NewQuerier(app.checkpointKeeper)).
-	// 	AddRoute(borTypes.QuerierRoute, bor.NewQuerier(app.borKeeper)).
-	// 	AddRoute(clerkTypes.QuerierRoute, clerk.NewQuerier(app.clerkKeeper))
 
 	// mount the multistore and load the latest state
 	app.MountKVStores(keys)

--- a/checkpoint/client/cli/flags.go
+++ b/checkpoint/client/cli/flags.go
@@ -9,4 +9,5 @@ const (
 	FlagHeaderNumber       = "header"
 	FlagCheckpointTxHash   = "txhash"
 	FlagCheckpointLogIndex = "log-index"
+	FlagAutoConfigure      = "auto-configure"
 )

--- a/checkpoint/client/cli/tx.go
+++ b/checkpoint/client/cli/tx.go
@@ -59,6 +59,7 @@ func SendCheckpointTx(cdc *codec.Codec) *cobra.Command {
 					return err
 				}
 
+				// broadcast this checkpoint
 				return helper.BroadcastMsgsWithCLI(cliCtx, []sdk.Msg{newCheckpointMsg})
 			}
 

--- a/checkpoint/module.go
+++ b/checkpoint/module.go
@@ -17,6 +17,7 @@ import (
 	checkpointRest "github.com/maticnetwork/heimdall/checkpoint/client/rest"
 	"github.com/maticnetwork/heimdall/checkpoint/types"
 	"github.com/maticnetwork/heimdall/helper"
+	"github.com/maticnetwork/heimdall/staking"
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
@@ -88,14 +89,16 @@ type AppModule struct {
 	AppModuleBasic
 
 	keeper         Keeper
+	stakingKeeper  staking.Keeper
 	contractCaller helper.IContractCaller
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(keeper Keeper, contractCaller helper.IContractCaller) AppModule {
+func NewAppModule(keeper Keeper, sk staking.Keeper, contractCaller helper.IContractCaller) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{},
 		keeper:         keeper,
+		stakingKeeper:  sk,
 		contractCaller: contractCaller,
 	}
 }
@@ -125,7 +128,7 @@ func (AppModule) QuerierRoute() string {
 
 // NewQuerierHandler returns the auth module sdk.Querier.
 func (am AppModule) NewQuerierHandler() sdk.Querier {
-	return NewQuerier(am.keeper)
+	return NewQuerier(am.keeper, am.stakingKeeper)
 }
 
 // InitGenesis performs genesis initialization for the auth module. It returns

--- a/checkpoint/querier.go
+++ b/checkpoint/querier.go
@@ -1,7 +1,6 @@
 package checkpoint
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -20,8 +19,6 @@ func NewQuerier(keeper Keeper, stakingKeeper staking.Keeper) sdk.Querier {
 		switch path[0] {
 		case types.QueryParams:
 			return handleQueryParams(ctx, req, keeper)
-		case types.QueryProposer:
-			return handleQueryIsCheckpointProposer(ctx, req, stakingKeeper)
 		case types.QueryAckCount:
 			return handleQueryAckCount(ctx, req, keeper)
 		case types.QueryCheckpoint:
@@ -149,21 +146,6 @@ func handleQueryNextCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 	bz, err := json.Marshal(checkpointMsg)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not marshall checkpoint msg. Error:%v", err), err.Error()))
-	}
-	return bz, nil
-}
-
-func handleQueryIsCheckpointProposer(ctx sdk.Context, req abci.RequestQuery, sk staking.Keeper) ([]byte, sdk.Error) {
-	// get validator set
-	validatorSet := sk.GetValidatorSet(ctx)
-	proposer := validatorSet.GetProposer()
-	var isProposer bool
-	if bytes.Compare(proposer.Bytes(), helper.GetAddress()) == 0 {
-		isProposer = true
-	}
-	bz, err := json.Marshal(isProposer)
-	if err != nil {
-		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("cannot not marshall. Error %v", err), err.Error()))
 	}
 	return bz, nil
 }

--- a/checkpoint/querier.go
+++ b/checkpoint/querier.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/maticnetwork/heimdall/checkpoint/types"
 	"github.com/maticnetwork/heimdall/common"
+	"github.com/maticnetwork/heimdall/helper"
+	"github.com/maticnetwork/heimdall/staking"
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
 // NewQuerier creates a querier for auth REST endpoints
-func NewQuerier(keeper Keeper) sdk.Querier {
+func NewQuerier(keeper Keeper, stakingKeeper staking.Keeper) sdk.Querier {
 	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, sdk.Error) {
 		switch path[0] {
 		case types.QueryParams:
@@ -28,6 +30,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 			return handleQueryLastNoAck(ctx, req, keeper)
 		case types.QueryCheckpointList:
 			return handleQueryCheckpointList(ctx, req, keeper)
+		case types.QueryNextCheckpoint:
+			return handleQueryNextCheckpoint(ctx, req, keeper, stakingKeeper)
 		default:
 			return nil, sdk.ErrUnknownRequest("unknown auth query endpoint")
 		}
@@ -110,6 +114,35 @@ func handleQueryCheckpointList(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
+	}
+	return bz, nil
+}
+
+func handleQueryNextCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Keeper, sk staking.Keeper) ([]byte, sdk.Error) {
+	// get validator set
+	validatorSet := sk.GetValidatorSet(ctx)
+	proposer := validatorSet.GetProposer()
+	ackCount := keeper.GetACKCount(ctx)
+	headerIndex := (ackCount - 1) * (helper.GetConfig().ChildBlockInterval)
+	lastCheckpoint, err := keeper.GetCheckpointByIndex(ctx, headerIndex)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint by index %v", headerIndex), err.Error()))
+	}
+	start := lastCheckpoint.EndBlock + 1
+	end := start + helper.GetConfig().AvgCheckpointLength
+	rootHash, err := types.GetHeaders(start, end)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch headers for start:%v end:%v error:%v", start, end, err), err.Error()))
+	}
+	accs := sk.GetAllDividendAccounts(ctx)
+	accRootHash, err := types.GetAccountRootHash(accs)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not get generate account root hash. Error:%v", err), err.Error()))
+	}
+	checkpointMsg := types.NewMsgCheckpointBlock(proposer.Signer, start, start+helper.GetConfig().AvgCheckpointLength, hmTypes.BytesToHeimdallHash(rootHash), hmTypes.BytesToHeimdallHash(accRootHash))
+	bz, err := json.Marshal(checkpointMsg)
+	if err != nil {
+		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not marshall checkpoint msg. Error:%v", err), err.Error()))
 	}
 	return bz, nil
 }

--- a/checkpoint/types/querier.go
+++ b/checkpoint/types/querier.go
@@ -8,7 +8,7 @@ const (
 	QueryCheckpointBuffer = "checkpoint-buffer"
 	QueryLastNoAck        = "last-no-ack"
 	QueryCheckpointList   = "checkpoint-list"
-	QueryNextCheckpoint   = "next-list"
+	QueryNextCheckpoint   = "next-checkpoint"
 )
 
 // QueryCheckpointParams defines the params for querying accounts.

--- a/checkpoint/types/querier.go
+++ b/checkpoint/types/querier.go
@@ -10,6 +10,8 @@ const (
 	QueryCheckpointList   = "checkpoint-list"
 	QueryNextCheckpoint   = "next-checkpoint"
 	QueryProposer         = "is-proposer"
+	QueryCurrentProposer  = "current-proposer"
+	StakingQuerierRoute   = "staking"
 )
 
 // QueryCheckpointParams defines the params for querying accounts.

--- a/checkpoint/types/querier.go
+++ b/checkpoint/types/querier.go
@@ -8,6 +8,7 @@ const (
 	QueryCheckpointBuffer = "checkpoint-buffer"
 	QueryLastNoAck        = "last-no-ack"
 	QueryCheckpointList   = "checkpoint-list"
+	QueryNextCheckpoint   = "next-list"
 )
 
 // QueryCheckpointParams defines the params for querying accounts.

--- a/checkpoint/types/querier.go
+++ b/checkpoint/types/querier.go
@@ -9,6 +9,7 @@ const (
 	QueryLastNoAck        = "last-no-ack"
 	QueryCheckpointList   = "checkpoint-list"
 	QueryNextCheckpoint   = "next-checkpoint"
+	QueryProposer         = "is-proposer"
 )
 
 // QueryCheckpointParams defines the params for querying accounts.

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -147,7 +147,6 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 
 func handleQueryCurrentProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	proposer := keeper.GetCurrentProposer(ctx)
-
 	bz, err := json.Marshal(proposer)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))


### PR DESCRIPTION
Fixes #266 

- Adds a new flag --auto-configure for checkpoint module: This creates the next checkpoint based on the current state of the node and broadcasts it. 

Example command:
```
$ heimdallcli tx checkpoint send-checkpoint --auto-configure=true --chain-id=heimdall-ODAMAV
```

Unfortunately, I had to pass staking keeper to the querier for this one. 