### PR TITLE
fix: bind monitoring ports to localhost

### DIFF
--- a/monitoring/docker/docker-compose.yml
+++ b/monitoring/docker/docker-compose.yml
@@ -4,13 +4,12 @@ volumes:
   grafana_data: {}
 
 services:
-
   prometheus:
     image: prom/prometheus
     container_name: prometheus
     network_mode: host
     ports:
-      - 9090:9090
+      - 127.0.0.1:9090:9090
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
 
@@ -19,7 +18,7 @@ services:
     container_name: grafana
     network_mode: host
     ports:
-      - "3000:3000"
+      - 127.0.0.1:3000:3000
     volumes:
       - ./provisioning:/etc/grafana/provisioning
       - ./dashboards:/var/lib/grafana/dashboards


### PR DESCRIPTION
If we don't provide `127.0.0.1`, it binds to `0.0.0.0` by default.