### PR TITLE
MAT-1189: bug: return err instead of nil for init validator

### DIFF
--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -307,12 +307,12 @@ func InitializeNodeValidatorFiles(
 
 	pvKeyFile := config.PrivValidatorKeyFile()
 	if err := common.EnsureDir(filepath.Dir(pvKeyFile), 0777); err != nil {
-		return nodeID, valPubKey, priv, nil
+		return nodeID, valPubKey, priv, err
 	}
 
 	pvStateFile := config.PrivValidatorStateFile()
 	if err := common.EnsureDir(filepath.Dir(pvStateFile), 0777); err != nil {
-		return nodeID, valPubKey, priv, nil
+		return nodeID, valPubKey, priv, err
 	}
 
 	FilePv := privval.LoadOrGenFilePV(pvKeyFile, pvStateFile)


### PR DESCRIPTION
func InitializeNodeValidatorFiles was returning nil instead of err in a few cases.