### PR TITLE
MAT-1354 - Side-channel replay attack

### DIFF
--- a/bor/keeper.go
+++ b/bor/keeper.go
@@ -130,6 +130,12 @@ func (k *Keeper) GetSpan(ctx sdk.Context, id uint64) (*hmTypes.Span, error) {
 	return &span, nil
 }
 
+func (k *Keeper) HasSpan(ctx sdk.Context, id uint64) bool {
+	store := ctx.KVStore(k.storeKey)
+	spanKey := GetSpanKey(id)
+	return store.Has(spanKey)
+}
+
 // GetAllSpans fetches all indexed by id from store
 func (k *Keeper) GetAllSpans(ctx sdk.Context) (spans []*hmTypes.Span) {
 	// iterate through spans and create span update array

--- a/bor/side_handler.go
+++ b/bor/side_handler.go
@@ -106,6 +106,12 @@ func PostHandleMsgEventSpan(ctx sdk.Context, k Keeper, msg types.MsgProposeSpan,
 		return common.ErrSideTxValidation(k.Codespace()).Result()
 	}
 
+	// check for replay
+	if k.HasSpan(ctx, msg.ID) {
+		k.Logger(ctx).Debug("Skipping new span as it's already processed")
+		return hmCommon.ErrOldTx(k.Codespace()).Result()
+	}
+
 	k.Logger(ctx).Debug("Persisting span state", "sideTxResult", sideTxResult)
 
 	// freeze for new span

--- a/clerk/side_handler.go
+++ b/clerk/side_handler.go
@@ -111,6 +111,12 @@ func PostHandleMsgEventRecord(ctx sdk.Context, k Keeper, msg types.MsgEventRecor
 		return common.ErrSideTxValidation(k.Codespace()).Result()
 	}
 
+	// check for replay
+	if k.HasEventRecord(ctx, msg.ID) {
+		k.Logger(ctx).Debug("Skipping new clerk record as it's already processed")
+		return hmCommon.ErrOldTx(k.Codespace()).Result()
+	}
+
 	k.Logger(ctx).Debug("Persisting clerk state", "sideTxResult", sideTxResult)
 
 	// sequence id


### PR DESCRIPTION
**Problem Statement**

With Side-channel, as msg validations are done in `handler` and state update is done in `side_handler`, same msg  replayed multiple times will pass validations  in handler and updates state in side_handler.



**Solution**
Check in side_handler if msg is already processed before state update. 

1. Staking — check sequence
2. Bor — check if new span is there with id
3. Clerk — check if record is there with id
4. Topup — check sequence