### PR TITLE
MAT-1132 - Sidechannel confirmations

### DIFF
--- a/bridge/setu/listener/maticchain.go
+++ b/bridge/setu/listener/maticchain.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/maticnetwork/bor/core/types"
-	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/helper"
 )
 
@@ -62,14 +61,7 @@ func (ml *MaticChainListener) ProcessHeader(newHeader *types.Header) {
 		return
 	}
 
-	chainmanagerParams, err := util.GetChainmanagerParams(ml.cliCtx)
-	if err != nil {
-		ml.Logger.Error("Error fetching chain manager params", "error", err)
-		return
-	}
-
-	confirmationTime := chainmanagerParams.TxConfirmationTime
-	ml.sendTaskWithDelay("sendCheckpointToHeimdall", headerBytes, confirmationTime)
+	ml.sendTaskWithDelay("sendCheckpointToHeimdall", headerBytes, 0)
 }
 
 func (ml *MaticChainListener) sendTaskWithDelay(taskName string, headerBytes []byte, delay time.Duration) {

--- a/bridge/setu/listener/rootchain.go
+++ b/bridge/setu/listener/rootchain.go
@@ -101,10 +101,12 @@ func (rl *RootChainListener) ProcessHeader(newHeader *types.Header) {
 
 	// confirmation
 	confirmationBlocks := big.NewInt(0).SetUint64(requiredConfirmations)
-	confirmationBlocks = confirmationBlocks.Add(confirmationBlocks, big.NewInt(1))
-	if latestNumber.Uint64() > confirmationBlocks.Uint64() {
-		latestNumber = latestNumber.Sub(latestNumber, confirmationBlocks)
+
+	if latestNumber.Cmp(confirmationBlocks) <= 0 {
+		rl.Logger.Error("Block number less than Confirmations required", "blockNumber", latestNumber.Uint64, "confirmationsRequired", confirmationBlocks.Uint64)
+		return
 	}
+	latestNumber = latestNumber.Sub(latestNumber, confirmationBlocks)
 
 	// default fromBlock
 	fromBlock := latestNumber

--- a/bridge/setu/listener/rootchain.go
+++ b/bridge/setu/listener/rootchain.go
@@ -98,15 +98,12 @@ func (rl *RootChainListener) ProcessHeader(newHeader *types.Header) {
 	// adding into queue
 	rl.headerQueue.PushBack(newHeader)
 
-	// current time
-	currentTime := uint64(time.Now().UTC().Unix())
-
 	// fetch context
 	rootchainContext, err := rl.getRootChainContext()
 	if err != nil {
 		return
 	}
-	confirmationTime := uint64(rootchainContext.ChainmanagerParams.TxConfirmationTime.Seconds())
+	requiredConfirmations := rootchainContext.ChainmanagerParams.MainchainTxConfirmations
 
 	var start *big.Int
 	var end *big.Int
@@ -115,7 +112,7 @@ func (rl *RootChainListener) ProcessHeader(newHeader *types.Header) {
 	for rl.headerQueue.Len() > 0 {
 		e := rl.headerQueue.Front() // First element
 		h := e.Value.(*types.Header)
-		if h.Time+confirmationTime > currentTime {
+		if newHeader.Number.Uint64()-h.Number.Uint64() > requiredConfirmations {
 			break
 		}
 		if start == nil {

--- a/bridge/setu/listener/rootchain.go
+++ b/bridge/setu/listener/rootchain.go
@@ -2,7 +2,6 @@ package listener
 
 import (
 	"bytes"
-	"container/list"
 	"context"
 	"encoding/json"
 	"math/big"
@@ -31,8 +30,6 @@ type RootChainListener struct {
 	// ABIs
 	abis []*abi.ABI
 
-	// queue
-	headerQueue    *list.List
 	stakingInfoAbi *abi.ABI
 }
 
@@ -53,7 +50,6 @@ func NewRootChainListener() *RootChainListener {
 	}
 	rootchainListener := &RootChainListener{
 		abis:           abis,
-		headerQueue:    list.New(),
 		stakingInfoAbi: &contractCaller.StakingInfoABI,
 	}
 	return rootchainListener
@@ -95,39 +91,24 @@ func (rl *RootChainListener) Start() error {
 func (rl *RootChainListener) ProcessHeader(newHeader *types.Header) {
 	rl.Logger.Debug("New block detected", "blockNumber", newHeader.Number)
 
-	// adding into queue
-	rl.headerQueue.PushBack(newHeader)
-
 	// fetch context
 	rootchainContext, err := rl.getRootChainContext()
 	if err != nil {
 		return
 	}
 	requiredConfirmations := rootchainContext.ChainmanagerParams.MainchainTxConfirmations
+	latestNumber := newHeader.Number
 
-	var start *big.Int
-	var end *big.Int
-
-	// check start and end header
-	for rl.headerQueue.Len() > 0 {
-		e := rl.headerQueue.Front() // First element
-		h := e.Value.(*types.Header)
-		if newHeader.Number.Uint64()-h.Number.Uint64() > requiredConfirmations {
-			break
-		}
-		if start == nil {
-			start = h.Number
-		}
-		end = h.Number
-		rl.headerQueue.Remove(e) // Dequeue
-	}
-
-	if start == nil {
-		return
+	// confirmation
+	confirmationBlocks := big.NewInt(0).SetUint64(requiredConfirmations)
+	confirmationBlocks = confirmationBlocks.Add(confirmationBlocks, big.NewInt(1))
+	if latestNumber.Uint64() > confirmationBlocks.Uint64() {
+		latestNumber = latestNumber.Sub(latestNumber, confirmationBlocks)
 	}
 
 	// default fromBlock
-	fromBlock := start
+	fromBlock := latestNumber
+
 	// get last block from storage
 	hasLastBlock, _ := rl.storageClient.Has([]byte(lastRootBlockKey), nil)
 	if hasLastBlock {
@@ -138,15 +119,15 @@ func (rl *RootChainListener) ProcessHeader(newHeader *types.Header) {
 		}
 		rl.Logger.Debug("Got last block from bridge storage", "lastBlock", string(lastBlockBytes))
 		if result, err := strconv.ParseUint(string(lastBlockBytes), 10, 64); err == nil {
+			if result >= newHeader.Number.Uint64() {
+				return
+			}
 			fromBlock = big.NewInt(0).SetUint64(result + 1)
 		}
 	}
 
 	// to block
-	toBlock := end
-
-	// debug log
-	rl.Logger.Info("Processing header", "fromBlock", fromBlock, "toBlock", toBlock)
+	toBlock := latestNumber
 
 	if toBlock.Cmp(fromBlock) == -1 {
 		fromBlock = toBlock
@@ -157,7 +138,7 @@ func (rl *RootChainListener) ProcessHeader(newHeader *types.Header) {
 		rl.Logger.Error("rl.storageClient.Put", "Error", err)
 	}
 
-	// query log
+	// query events
 	rl.queryAndBroadcastEvents(rootchainContext, fromBlock, toBlock)
 }
 

--- a/chainmanager/querier_test.go
+++ b/chainmanager/querier_test.go
@@ -77,7 +77,8 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	json.Unmarshal(res, &params)
 
 	// match reponse params
-	require.Equal(t, defaultParams.TxConfirmationTime, params.TxConfirmationTime)
+	require.Equal(t, defaultParams.MainchainTxConfirmations, params.MainchainTxConfirmations)
+	require.Equal(t, defaultParams.MaticchainTxConfirmations, params.MaticchainTxConfirmations)
 	require.Equal(t, defaultParams.ChainParams, params.ChainParams)
 
 	{

--- a/chainmanager/simulation/genesis.go
+++ b/chainmanager/simulation/genesis.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/maticnetwork/heimdall/chainmanager/types"
@@ -15,7 +14,9 @@ import (
 
 // Parameter keys
 const (
-	TxConfirmationTime    = "tx_confirmation_time"
+	MainchainTxConfirmations  = "mainchain_tx_confirmations"
+	MaticchainTxConfirmations = "maticchain_tx_confirmations"
+
 	BorChainID            = "bor_chain_id"
 	MaticTokenAddress     = "matic_token_address"
 	StakingManagerAddress = "staking_manager_address"
@@ -28,10 +29,12 @@ const (
 	ValidatorSetAddress  = "validator_set_address"
 )
 
-func GenTxConfirmationTime() time.Duration {
-	// create seed
-	seed := rand.New(rand.NewSource(int64(rand.Int())))
-	return time.Duration(simulation.RandTimestamp(seed).Unix())
+func GenMainchainTxConfirmations(r *rand.Rand) uint64 {
+	return uint64(simulation.RandIntBetween(r, 1, 100))
+}
+
+func GenMaticchainTxConfirmations(r *rand.Rand) uint64 {
+	return uint64(simulation.RandIntBetween(r, 1, 100))
 }
 
 func GenHeimdallAddress() hmTypes.HeimdallAddress {
@@ -44,9 +47,14 @@ func GenBorChainId(r *rand.Rand) string {
 }
 
 func RandomizedGenState(simState *module.SimulationState) {
-	var txConfirmationTime time.Duration
-	simState.AppParams.GetOrGenerate(simState.Cdc, TxConfirmationTime, &txConfirmationTime, simState.Rand,
-		func(r *rand.Rand) { txConfirmationTime = GenTxConfirmationTime() },
+	var mainchainTxConfirmations uint64
+	simState.AppParams.GetOrGenerate(simState.Cdc, MainchainTxConfirmations, &mainchainTxConfirmations, simState.Rand,
+		func(r *rand.Rand) { mainchainTxConfirmations = GenMainchainTxConfirmations(r) },
+	)
+
+	var maticchainTxConfirmations uint64
+	simState.AppParams.GetOrGenerate(simState.Cdc, MaticchainTxConfirmations, &maticchainTxConfirmations, simState.Rand,
+		func(r *rand.Rand) { maticchainTxConfirmations = GenMaticchainTxConfirmations(r) },
 	)
 
 	var borChainID string
@@ -71,7 +79,7 @@ func RandomizedGenState(simState *module.SimulationState) {
 		StateReceiverAddress:  stateReceiverAddress,
 		ValidatorSetAddress:   validatorSetAddress,
 	}
-	params := types.NewParams(txConfirmationTime, chainParams)
+	params := types.NewParams(mainchainTxConfirmations, maticchainTxConfirmations, chainParams)
 	chainManagerGenesis := types.NewGenesisState(params)
 	fmt.Printf("Selected randomly generated chainmanager parameters:\n%s\n", codec.MustMarshalJSONIndent(simState.Cdc, chainManagerGenesis))
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(chainManagerGenesis)

--- a/chainmanager/simulation/params.go
+++ b/chainmanager/simulation/params.go
@@ -10,17 +10,23 @@ import (
 )
 
 const (
-	KeyTxConfirmationTime = "TxConfirmationTime"
-	KeyChainParams        = "ChainParams"
+	KeyMainchainTxConfirmations  = "MainchainTxConfirmations"
+	KeyMaticchainTxConfirmations = "MaticchainTxConfirmations"
+	KeyChainParams               = "ChainParams"
 )
 
 // ParamChanges defines the parameters that can be modified by param change proposals
 // on the simulation
 func ParamChanges(r *rand.Rand) []simtypes.ParamChange {
 	return []simtypes.ParamChange{
-		simulation.NewSimParamChange(types.ModuleName, KeyTxConfirmationTime,
+		simulation.NewSimParamChange(types.ModuleName, KeyMainchainTxConfirmations,
 			func(r *rand.Rand) string {
-				return fmt.Sprintf("\"%d\"", GenTxConfirmationTime())
+				return fmt.Sprintf("\"%d\"", GenMainchainTxConfirmations(r))
+			},
+		),
+		simulation.NewSimParamChange(types.ModuleName, KeyMaticchainTxConfirmations,
+			func(r *rand.Rand) string {
+				return fmt.Sprintf("\"%d\"", GenMaticchainTxConfirmations(r))
 			},
 		),
 		simulation.NewSimParamChange(types.ModuleName, KeyChainParams,

--- a/chainmanager/types/params.go
+++ b/chainmanager/types/params.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/maticnetwork/heimdall/helper"
 	"github.com/maticnetwork/heimdall/params/subspace"
@@ -13,7 +12,8 @@ import (
 
 // Default parameter values
 const (
-	DefaultTxConfirmationTime time.Duration = 6 * 14 * time.Second
+	DefaultMainchainTxConfirmations  uint64 = 6
+	DefaultMaticchainTxConfirmations uint64 = 10
 )
 
 var (
@@ -23,8 +23,9 @@ var (
 
 // Parameter keys
 var (
-	KeyTxConfirmationTime = []byte("TxConfirmationTime")
-	KeyChainParams        = []byte("ChainParams")
+	KeyMainchainTxConfirmations  = []byte("MainchainTxConfirmations")
+	KeyMaticchainTxConfirmations = []byte("MaticchainTxConfirmations")
+	KeyChainParams               = []byte("ChainParams")
 )
 
 var _ subspace.ParamSet = &Params{}
@@ -58,15 +59,17 @@ func (cp ChainParams) String() string {
 
 // Params defines the parameters for the chainmanager module.
 type Params struct {
-	TxConfirmationTime time.Duration `json:"tx_confirmation_time" yaml:"tx_confirmation_time"` // tx confirmation duration
-	ChainParams        ChainParams   `json:"chain_params" yaml:"chain_params"`
+	MainchainTxConfirmations  uint64      `json:"mainchain_tx_confirmations" yaml:"mainchain_tx_confirmations"`
+	MaticchainTxConfirmations uint64      `json:"maticchain_tx_confirmations" yaml:"maticchain_tx_confirmations"`
+	ChainParams               ChainParams `json:"chain_params" yaml:"chain_params"`
 }
 
 // NewParams creates a new Params object
-func NewParams(txConfirmationTime time.Duration, chainParams ChainParams) Params {
+func NewParams(mainchainTxConfirmations uint64, maticchainTxConfirmations uint64, chainParams ChainParams) Params {
 	return Params{
-		TxConfirmationTime: txConfirmationTime,
-		ChainParams:        chainParams,
+		MainchainTxConfirmations:  mainchainTxConfirmations,
+		MaticchainTxConfirmations: maticchainTxConfirmations,
+		ChainParams:               chainParams,
 	}
 }
 
@@ -75,7 +78,8 @@ func NewParams(txConfirmationTime time.Duration, chainParams ChainParams) Params
 // nolint
 func (p *Params) ParamSetPairs() subspace.ParamSetPairs {
 	return subspace.ParamSetPairs{
-		{KeyTxConfirmationTime, &p.TxConfirmationTime},
+		{KeyMainchainTxConfirmations, &p.MainchainTxConfirmations},
+		{KeyMaticchainTxConfirmations, &p.MaticchainTxConfirmations},
 		{KeyChainParams, &p.ChainParams},
 	}
 }
@@ -91,7 +95,8 @@ func (p Params) Equal(p2 Params) bool {
 func (p Params) String() string {
 	var sb strings.Builder
 	sb.WriteString("Params: \n")
-	sb.WriteString(fmt.Sprintf("TxConfirmationTime: %d\n", p.TxConfirmationTime))
+	sb.WriteString(fmt.Sprintf("MainchainTxConfirmations: %d\n", p.MainchainTxConfirmations))
+	sb.WriteString(fmt.Sprintf("MaticchainTxConfirmations: %d\n", p.MaticchainTxConfirmations))
 	sb.WriteString(fmt.Sprintf("ChainParams: %s\n", p.ChainParams.String()))
 	return sb.String()
 }
@@ -149,7 +154,8 @@ func ParamKeyTable() subspace.KeyTable {
 // DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return Params{
-		TxConfirmationTime: DefaultTxConfirmationTime,
+		MainchainTxConfirmations:  DefaultMainchainTxConfirmations,
+		MaticchainTxConfirmations: DefaultMaticchainTxConfirmations,
 		ChainParams: ChainParams{
 			BorChainID:           helper.DefaultBorChainID,
 			StateReceiverAddress: DefaultStateReceiverAddress,

--- a/checkpoint/client/cli/tx.go
+++ b/checkpoint/client/cli/tx.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -213,7 +212,7 @@ func SendCheckpointACKTx(cdc *codec.Codec) *cobra.Command {
 			}
 
 			// get main tx receipt
-			receipt, err := contractCallerObj.GetConfirmedTxReceipt(time.Now().UTC(), txHash.EthHash(), chainmanagerParams.TxConfirmationTime)
+			receipt, err := contractCallerObj.GetConfirmedTxReceipt(txHash.EthHash(), chainmanagerParams.MainchainTxConfirmations)
 			if err != nil || receipt == nil {
 				return errors.New("Transaction is not confirmed yet. Please wait for sometime and try again")
 			}

--- a/clerk/querier.go
+++ b/clerk/querier.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -89,7 +88,7 @@ func handleQueryRecordSequence(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 	}
 
 	// get main tx receipt
-	receipt, _ := contractCallerObj.GetConfirmedTxReceipt(time.Now().UTC(), hmTypes.HexToHeimdallHash(params.TxHash).EthHash(), chainParams.TxConfirmationTime)
+	receipt, _ := contractCallerObj.GetConfirmedTxReceipt(hmTypes.HexToHeimdallHash(params.TxHash).EthHash(), chainParams.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("Transaction is not confirmed yet. Please wait for sometime and try again"))
 	}

--- a/clerk/side_handler.go
+++ b/clerk/side_handler.go
@@ -58,7 +58,7 @@ func SideHandleMsgEventRecord(ctx sdk.Context, k Keeper, msg types.MsgEventRecor
 	chainParams := params.ChainParams
 
 	// get confirmed tx receipt
-	receipt, err := contractCaller.GetConfirmedTxReceipt(ctx.BlockTime(), msg.TxHash.EthHash(), params.TxConfirmationTime)
+	receipt, err := contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), params.MainchainTxConfirmations)
 	if receipt == nil || err != nil {
 		return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWaitFrConfirmation)
 	}

--- a/common/error.go
+++ b/common/error.go
@@ -3,7 +3,6 @@ package common
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -113,10 +112,6 @@ func ErrNoACK(codespace sdk.CodespaceType, expiresAt uint64) sdk.Error {
 
 func ErrNoConn(codespace sdk.CodespaceType) sdk.Error {
 	return newError(codespace, CodeNoConn, "Unable to connect to chain")
-}
-
-func ErrWaitForConfirmation(codespace sdk.CodespaceType, txConfirmationTime time.Duration) sdk.Error {
-	return newError(codespace, CodeWaitFrConfirmation, fmt.Sprintf("Please wait for %v confirmation time before sending transaction", txConfirmationTime))
 }
 
 func ErrNoCheckpointFound(codespace sdk.CodespaceType) sdk.Error {

--- a/helper/config.go
+++ b/helper/config.go
@@ -63,7 +63,6 @@ const (
 	DefaultSpanPollingInterval      = 1 * time.Minute
 
 	DefaultChildBlockInterval = 10000 // difference between 2 indexes of header blocks
-	DefaultTxConfirmationTime = 6 * 14 * time.Second
 	DefaultMainchainGasLimit  = uint64(5000000)
 
 	DefaultBorChainID string = "15001"

--- a/helper/mocks/IContractCaller.go
+++ b/helper/mocks/IContractCaller.go
@@ -22,8 +22,6 @@ import (
 
 	statesender "github.com/maticnetwork/heimdall/contracts/statesender"
 
-	time "time"
-
 	types "github.com/maticnetwork/bor/core/types"
 
 	validatorset "github.com/maticnetwork/heimdall/contracts/validatorset"
@@ -372,13 +370,13 @@ func (_m *IContractCaller) GetCheckpointSign(txHash common.Hash) ([]byte, []byte
 	return r0, r1, r2, r3
 }
 
-// GetConfirmedTxReceipt provides a mock function with given fields: _a0, _a1, _a2
-func (_m *IContractCaller) GetConfirmedTxReceipt(_a0 time.Time, _a1 common.Hash, _a2 time.Duration) (*types.Receipt, error) {
-	ret := _m.Called(_a0, _a1, _a2)
+// GetConfirmedTxReceipt provides a mock function with given fields: _a0, _a1
+func (_m *IContractCaller) GetConfirmedTxReceipt(_a0 common.Hash, _a1 uint64) (*types.Receipt, error) {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 *types.Receipt
-	if rf, ok := ret.Get(0).(func(time.Time, common.Hash, time.Duration) *types.Receipt); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(common.Hash, uint64) *types.Receipt); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.Receipt)
@@ -386,8 +384,8 @@ func (_m *IContractCaller) GetConfirmedTxReceipt(_a0 time.Time, _a1 common.Hash,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(time.Time, common.Hash, time.Duration) error); ok {
-		r1 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(1).(func(common.Hash, uint64) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -607,6 +605,29 @@ func (_m *IContractCaller) GetRootChainInstance(rootchainAddress common.Address)
 	return r0, r1
 }
 
+// GetRootHash provides a mock function with given fields: start, end, checkpointLength
+func (_m *IContractCaller) GetRootHash(start uint64, end uint64, checkpointLength uint64) ([]byte, error) {
+	ret := _m.Called(start, end, checkpointLength)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(uint64, uint64, uint64) []byte); ok {
+		r0 = rf(start, end, checkpointLength)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(uint64, uint64, uint64) error); ok {
+		r1 = rf(start, end, checkpointLength)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSpanDetails provides a mock function with given fields: id, _a1
 func (_m *IContractCaller) GetSpanDetails(id *big.Int, _a1 *validatorset.Validatorset) (*big.Int, *big.Int, *big.Int, error) {
 	ret := _m.Called(id, _a1)
@@ -784,13 +805,13 @@ func (_m *IContractCaller) GetValidatorSetInstance(validatorSetAddress common.Ad
 	return r0, r1
 }
 
-// IsTxConfirmed provides a mock function with given fields: _a0, _a1, _a2
-func (_m *IContractCaller) IsTxConfirmed(_a0 time.Time, _a1 common.Hash, _a2 time.Duration) bool {
-	ret := _m.Called(_a0, _a1, _a2)
+// IsTxConfirmed provides a mock function with given fields: _a0, _a1
+func (_m *IContractCaller) IsTxConfirmed(_a0 common.Hash, _a1 uint64) bool {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(time.Time, common.Hash, time.Duration) bool); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(common.Hash, uint64) bool); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
@@ -798,13 +819,13 @@ func (_m *IContractCaller) IsTxConfirmed(_a0 time.Time, _a1 common.Hash, _a2 tim
 	return r0
 }
 
-// SendCheckpoint provides a mock function with given fields: voteSignBytes, sigs, txData, rootchainAddress, rootChainInstance
-func (_m *IContractCaller) SendCheckpoint(voteSignBytes []byte, sigs []byte, txData []byte, rootchainAddress common.Address, rootChainInstance *rootchain.Rootchain) error {
-	ret := _m.Called(voteSignBytes, sigs, txData, rootchainAddress, rootChainInstance)
+// SendCheckpoint provides a mock function with given fields: sigedData, sigs, rootchainAddress, rootChainInstance
+func (_m *IContractCaller) SendCheckpoint(sigedData []byte, sigs []byte, rootchainAddress common.Address, rootChainInstance *rootchain.Rootchain) error {
+	ret := _m.Called(sigedData, sigs, rootchainAddress, rootChainInstance)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func([]byte, []byte, []byte, common.Address, *rootchain.Rootchain) error); ok {
-		r0 = rf(voteSignBytes, sigs, txData, rootchainAddress, rootChainInstance)
+	if rf, ok := ret.Get(0).(func([]byte, []byte, common.Address, *rootchain.Rootchain) error); ok {
+		r0 = rf(sigedData, sigs, rootchainAddress, rootChainInstance)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/staking/client/cli/tx.go
+++ b/staking/client/cli/tx.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -93,7 +92,7 @@ func SendValidatorJoinTx(cdc *codec.Codec) *cobra.Command {
 			}
 
 			// get main tx receipt
-			receipt, err := contractCallerObj.GetConfirmedTxReceipt(time.Now().UTC(), hmTypes.HexToHeimdallHash(txhash).EthHash(), chainmanagerParams.TxConfirmationTime)
+			receipt, err := contractCallerObj.GetConfirmedTxReceipt(hmTypes.HexToHeimdallHash(txhash).EthHash(), chainmanagerParams.MainchainTxConfirmations)
 			if err != nil || receipt == nil {
 				return errors.New("Transaction is not confirmed yet. Please wait for sometime and try again")
 			}

--- a/staking/handler_test.go
+++ b/staking/handler_test.go
@@ -91,7 +91,7 @@ func (suite *HandlerTestSuite) TestHandleMsgValidatorJoin() {
 		SignerPubkey:    pubkey.Bytes()[1:],
 	}
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	suite.contractCaller.On("DecodeValidatorJoinEvent", chainParams.ChainParams.StakingInfoAddress.EthAddress(), txreceipt, msgValJoin.LogIndex).Return(stakinginfoStaked, nil)
 
@@ -123,7 +123,7 @@ func (suite *HandlerTestSuite) TestHandleMsgValidatorUpdate() {
 	msg := types.NewMsgSignerUpdate(newSigner[0].Signer, uint64(newSigner[0].ID), newSigner[0].PubKey, msgTxHash, 0, 0)
 
 	txreceipt := &ethTypes.Receipt{BlockNumber: big.NewInt(10)}
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, msgTxHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, msgTxHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	signerUpdateEvent := &stakinginfo.StakinginfoSignerChange{
 		ValidatorId:  new(big.Int).SetUint64(oldSigner.ID.Uint64()),
@@ -168,7 +168,7 @@ func (suite *HandlerTestSuite) TestHandleMsgValidatorExit() {
 		BlockNumber: big.NewInt(10),
 	}
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, msgTxHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, msgTxHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	amount, _ := big.NewInt(0).SetString("10000000000000000000", 10)
 	stakinginfoUnstakeInit := &stakinginfo.StakinginfoUnstakeInit{
@@ -220,7 +220,7 @@ func (suite *HandlerTestSuite) TestHandleMsgStakeUpdate() {
 	msg := types.NewMsgStakeUpdate(oldVal.Signer, oldVal.ID.Uint64(), msgTxHash, 0, 0)
 
 	txreceipt := &ethTypes.Receipt{BlockNumber: big.NewInt(10)}
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, msgTxHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, msgTxHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	stakinginfoStakeUpdate := &stakinginfo.StakinginfoStakeUpdate{
 		ValidatorId: new(big.Int).SetUint64(oldVal.ID.Uint64()),
@@ -298,7 +298,7 @@ func (suite *HandlerTestSuite) TestExitedValidatorJoiningAgain() {
 		SignerPubkey:    pubKey.Bytes()[1:],
 	}
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	suite.contractCaller.On("DecodeValidatorJoinEvent", chainParams.ChainParams.StakingInfoAddress.EthAddress(), txreceipt, msgValJoin.LogIndex).Return(stakinginfoStaked, nil)
 
@@ -350,7 +350,7 @@ func (suite *HandlerTestSuite) TestTopupSuccessBeforeValidatorJoin() {
 		0,
 	)
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	suite.contractCaller.On("DecodeValidatorJoinEvent", chainParams.ChainParams.StakingInfoAddress.EthAddress(), txreceipt, msgValJoin.LogIndex).Return(stakinginfoStaked, nil)
 

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -261,7 +260,7 @@ func handleQueryStakingSequence(ctx sdk.Context, req abci.RequestQuery, keeper K
 	chainParams := keeper.chainKeeper.GetParams(ctx)
 
 	// get main tx receipt
-	receipt, err := contractCallerObj.GetConfirmedTxReceipt(time.Now().UTC(), hmTypes.HexToHeimdallHash(params.TxHash).EthHash(), chainParams.TxConfirmationTime)
+	receipt, err := contractCallerObj.GetConfirmedTxReceipt(hmTypes.HexToHeimdallHash(params.TxHash).EthHash(), chainParams.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("Transaction is not confirmed yet. Please wait for sometime and try again"))
 	}

--- a/staking/querier_test.go
+++ b/staking/querier_test.go
@@ -330,7 +330,7 @@ func (suite *QuerierTestSuite) TestHandleQueryStakingSequence() {
 
 	app.StakingKeeper.SetStakingSequence(ctx, sequence.String())
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	path := []string{types.QueryStakingSequence}
 

--- a/staking/side_handler.go
+++ b/staking/side_handler.go
@@ -75,7 +75,7 @@ func SideHandleMsgValidatorJoin(ctx sdk.Context, msg types.MsgValidatorJoin, k K
 	chainParams := params.ChainParams
 
 	// get main tx receipt
-	receipt, err := contractCaller.GetConfirmedTxReceipt(ctx.BlockTime(), msg.TxHash.EthHash(), params.TxConfirmationTime)
+	receipt, err := contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), params.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWaitFrConfirmation)
 	}
@@ -158,7 +158,7 @@ func SideHandleMsgStakeUpdate(ctx sdk.Context, msg types.MsgStakeUpdate, k Keepe
 	chainParams := params.ChainParams
 
 	// get main tx receipt
-	receipt, err := contractCaller.GetConfirmedTxReceipt(ctx.BlockTime(), msg.TxHash.EthHash(), params.TxConfirmationTime)
+	receipt, err := contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), params.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return hmCommon.ErrorSideTx(k.Codespace(), common.CodeErrDecodeEvent)
 	}
@@ -209,7 +209,7 @@ func SideHandleMsgSignerUpdate(ctx sdk.Context, msg types.MsgSignerUpdate, k Kee
 	chainParams := params.ChainParams
 
 	// get main tx receipt
-	receipt, err := contractCaller.GetConfirmedTxReceipt(ctx.BlockTime(), msg.TxHash.EthHash(), params.TxConfirmationTime)
+	receipt, err := contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), params.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWaitFrConfirmation)
 	}
@@ -268,7 +268,7 @@ func SideHandleMsgValidatorExit(ctx sdk.Context, msg types.MsgValidatorExit, k K
 	chainParams := params.ChainParams
 
 	// get main tx receipt
-	receipt, err := contractCaller.GetConfirmedTxReceipt(ctx.BlockTime(), msg.TxHash.EthHash(), params.TxConfirmationTime)
+	receipt, err := contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), params.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWaitFrConfirmation)
 	}

--- a/topup/handler_test.go
+++ b/topup/handler_test.go
@@ -72,7 +72,7 @@ func (suite *HandlerTestSuite) TestHandleMsgTopup() {
 		Fee:         big.NewInt(100000000000000000),
 	}
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	suite.contractCaller.On("DecodeValidatorTopupFeesEvent", chainParams.ChainParams.StakingInfoAddress.EthAddress(), mock.Anything, msgTopup.LogIndex).Return(stakinginfoTopUpFee, nil)
 	result := suite.handler(ctx, msgTopup)
@@ -108,7 +108,7 @@ func (suite *HandlerTestSuite) TestHandleMsgWithdrawFee() {
 		Fee:         big.NewInt(100000000000000000),
 	}
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	suite.contractCaller.On("DecodeValidatorTopupFeesEvent", chainParams.ChainParams.StakingInfoAddress.EthAddress(), mock.Anything, msgTopup.LogIndex).Return(stakinginfoTopUpFee, nil)
 	topupResult := suite.handler(ctx, msgTopup)

--- a/topup/querier.go
+++ b/topup/querier.go
@@ -3,7 +3,6 @@ package topup
 import (
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -35,7 +34,7 @@ func querySequence(ctx sdk.Context, req abci.RequestQuery, k Keeper, contractCal
 	chainParams := k.chainKeeper.GetParams(ctx)
 
 	// get main tx receipt
-	receipt, err := contractCallerObj.GetConfirmedTxReceipt(time.Now().UTC(), hmTypes.HexToHeimdallHash(params.TxHash).EthHash(), chainParams.TxConfirmationTime)
+	receipt, err := contractCallerObj.GetConfirmedTxReceipt(hmTypes.HexToHeimdallHash(params.TxHash).EthHash(), chainParams.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("Transaction is not confirmed yet. Please wait for sometime and try again"))
 	}

--- a/topup/querier_test.go
+++ b/topup/querier_test.go
@@ -82,7 +82,7 @@ func (suite *QuerierTestSuite) TestQuerySequence() {
 	sequence.Add(sequence, new(big.Int).SetUint64(logIndex))
 	app.TopupKeeper.SetTopupSequence(ctx, sequence.String())
 
-	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.TxConfirmationTime).Return(txreceipt, nil)
+	suite.contractCaller.On("GetConfirmedTxReceipt", mock.Anything, txHash.EthHash(), chainParams.MainchainTxConfirmations).Return(txreceipt, nil)
 
 	path := []string{types.QuerySequence}
 

--- a/topup/side_handler.go
+++ b/topup/side_handler.go
@@ -60,7 +60,7 @@ func SideHandleMsgTopup(ctx sdk.Context, k Keeper, msg types.MsgTopup, contractC
 	chainParams := params.ChainParams
 
 	// get main tx receipt
-	receipt, err := contractCaller.GetConfirmedTxReceipt(ctx.BlockTime(), msg.TxHash.EthHash(), params.TxConfirmationTime)
+	receipt, err := contractCaller.GetConfirmedTxReceipt(msg.TxHash.EthHash(), params.MainchainTxConfirmations)
 	if err != nil || receipt == nil {
 		return hmCommon.ErrorSideTx(k.Codespace(), common.CodeWaitFrConfirmation)
 	}


### PR DESCRIPTION
Use confirmation blocks instead of confirmation time

This PR has fixes for
- https://linear.app/issue/MAT-1132/use-confirmation-blocks-instead-of-confirmation-time
- https://linear.app/issue/MAT-1305/10-bor-blocks-as-confirmation-for-checkpoint