### PR TITLE
chg: remove hard coded consensus params

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -544,16 +544,6 @@ func (app *HeimdallApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) 
 	return abci.ResponseInitChain{
 		// validator updates
 		Validators: valUpdates,
-
-		// consensus params
-		ConsensusParams: &abci.ConsensusParams{
-			Block: &abci.BlockParams{
-				MaxBytes: maxBytesPerBlock,
-				MaxGas:   maxGasPerBlock,
-			},
-			Evidence:  &abci.EvidenceParams{},
-			Validator: &abci.ValidatorParams{PubKeyTypes: []string{ABCIPubKeyTypeSecp256k1}},
-		},
 	}
 }
 


### PR DESCRIPTION
These params can be configured from `genesis.json` at

```js
  "genesis_time": "2020-03-12T09:23:23.318713Z",
  "chain_id": "heimdall-P5rXwg",
  "consensus_params": {
    "block": {
      "max_bytes": "22020096",
      "max_gas": "50000000",
      "time_iota_ms": "1000"
    },
    "evidence": {
      "max_age": "100000"
    },
    "validator": {
      "pub_key_types": [
        "secp256k1"
      ]
    }
  }
```