### PR TITLE
MAT-1477 - Bridge optimizations

### DIFF
--- a/bridge/cmd/start.go
+++ b/bridge/cmd/start.go
@@ -47,11 +47,19 @@ func GetStartCmd() *cobra.Command {
 			_txBroadcaster := broadcaster.NewTxBroadcaster(cdc)
 			_httpClient := httpClient.NewHTTP(helper.GetConfig().TendermintRPCUrl, "/websocket")
 
+			// cli context
+			cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
+			cliCtx.BroadcastMode = client.BroadcastAsync
+			cliCtx.TrustNode = true
+
+			// params context
+			_paramsContext := util.NewParamsContext(cliCtx)
+
 			// selected services to start
 			services := []common.Service{}
 			services = append(services,
 				listener.NewListenerService(cdc, _queueConnector, _httpClient),
-				processor.NewProcessorService(cdc, _queueConnector, _httpClient, _txBroadcaster),
+				processor.NewProcessorService(cdc, _queueConnector, _httpClient, _txBroadcaster, _paramsContext),
 			)
 
 			// sync group
@@ -89,11 +97,6 @@ func GetStartCmd() *cobra.Command {
 			if err != nil {
 				panic(fmt.Sprintf("Error connecting to server %v", err))
 			}
-
-			// cli context
-			cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
-			cliCtx.BroadcastMode = client.BroadcastAsync
-			cliCtx.TrustNode = true
 
 			// start bridge services only when node fully synced
 			for {

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -37,6 +37,9 @@ type BaseProcessor struct {
 	// tx broadcaster
 	txBroadcaster *broadcaster.TxBroadcaster
 
+	// params context
+	paramsContext *util.ParamsContext
+
 	// The "subclass" of BaseProcessor
 	impl Processor
 
@@ -54,7 +57,7 @@ type BaseProcessor struct {
 }
 
 // NewBaseProcessor creates a new BaseProcessor.
-func NewBaseProcessor(cdc *codec.Codec, queueConnector *queue.QueueConnector, httpClient *httpClient.HTTP, txBroadcaster *broadcaster.TxBroadcaster, name string, impl Processor) *BaseProcessor {
+func NewBaseProcessor(cdc *codec.Codec, queueConnector *queue.QueueConnector, httpClient *httpClient.HTTP, txBroadcaster *broadcaster.TxBroadcaster, paramsContext *util.ParamsContext, name string, impl Processor) *BaseProcessor {
 	logger := util.Logger().With("service", "processor", "module", name)
 
 	cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
@@ -82,6 +85,7 @@ func NewBaseProcessor(cdc *codec.Codec, queueConnector *queue.QueueConnector, ht
 		queueConnector:    queueConnector,
 		contractConnector: contractCaller,
 		txBroadcaster:     txBroadcaster,
+		paramsContext:     paramsContext,
 		httpClient:        httpClient,
 		storageClient:     util.GetBridgeDBInstance(viper.GetString(util.BridgeDBFlag)),
 	}

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -18,7 +18,6 @@ import (
 	"github.com/maticnetwork/bor/core/types"
 	authTypes "github.com/maticnetwork/heimdall/auth/types"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
-	chainmanagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 	checkpointTypes "github.com/maticnetwork/heimdall/checkpoint/types"
 	"github.com/maticnetwork/heimdall/contracts/rootchain"
 	"github.com/maticnetwork/heimdall/helper"
@@ -41,12 +40,6 @@ type CheckpointProcessor struct {
 // Result represents single req result
 type Result struct {
 	Result uint64 `json:"result"`
-}
-
-// CheckpointContext represents checkpoint context
-type CheckpointContext struct {
-	ChainmanagerParams *chainmanagerTypes.Params
-	CheckpointParams   *checkpointTypes.Params
 }
 
 // NewCheckpointProcessor - add rootchain abi to checkpoint processor
@@ -118,21 +111,21 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 
 	if isProposer {
 		// fetch checkpoint context
-		checkpointContext, err := cp.getCheckpointContext()
+		params, err := cp.paramsContext.GetParams()
 		if err != nil {
 			return err
 		}
 
 		// process latest confirmed child block only
-		chainmanagerParams := checkpointContext.ChainmanagerParams
-		cp.Logger.Debug("no of checkpoint confirmations required", "maticchainTxConfirmations", chainmanagerParams.MaticchainTxConfirmations)
-		latestConfirmedChildBlock := header.Number.Uint64() - chainmanagerParams.MaticchainTxConfirmations
+
+		cp.Logger.Debug("no of checkpoint confirmations required", "maticchainTxConfirmations", params.ChainmanagerParams.MaticchainTxConfirmations)
+		latestConfirmedChildBlock := header.Number.Uint64() - params.ChainmanagerParams.MaticchainTxConfirmations
 		if latestConfirmedChildBlock <= 0 {
-			cp.Logger.Error("no of blocks on childchain is less than confirmations required", "childChainBlocks", header.Number.Uint64(), "confirmationsRequired", chainmanagerParams.MaticchainTxConfirmations)
+			cp.Logger.Error("no of blocks on childchain is less than confirmations required", "childChainBlocks", header.Number.Uint64(), "confirmationsRequired", params.ChainmanagerParams.MaticchainTxConfirmations)
 			return errors.New("no of blocks on childchain is less than confirmations required")
 		}
 
-		expectedCheckpointState, err := cp.nextExpectedCheckpoint(checkpointContext, latestConfirmedChildBlock)
+		expectedCheckpointState, err := cp.nextExpectedCheckpoint(params, latestConfirmedChildBlock)
 		if err != nil {
 			cp.Logger.Error("Error while calculate next expected checkpoint", "error", err)
 			return err
@@ -144,7 +137,7 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 		// Check checkpoint buffer
 		//
 		timeStamp := uint64(time.Now().Unix())
-		checkpointBufferTime := uint64(checkpointContext.CheckpointParams.CheckpointBufferTime.Seconds())
+		checkpointBufferTime := uint64(params.CheckpointParams.CheckpointBufferTime.Seconds())
 
 		bufferedCheckpoint, err := util.GetBufferedCheckpoint(cp.cliCtx)
 		if err != nil {
@@ -156,7 +149,7 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 			return nil
 		}
 
-		if err := cp.createAndSendCheckpointToHeimdall(checkpointContext, start, end); err != nil {
+		if err := cp.createAndSendCheckpointToHeimdall(params, start, end); err != nil {
 			cp.Logger.Error("Error sending checkpoint to heimdall", "error", err)
 			return err
 		}
@@ -210,19 +203,19 @@ func (cp *CheckpointProcessor) sendCheckpointToRootchain(eventBytes string, bloc
 		}
 	}
 
-	checkpointContext, err := cp.getCheckpointContext()
+	params, err := cp.paramsContext.GetParams()
 	if err != nil {
 		return err
 	}
 
-	shouldSend, err := cp.shouldSendCheckpoint(checkpointContext, startBlock, endBlock)
+	shouldSend, err := cp.shouldSendCheckpoint(params, startBlock, endBlock)
 	if err != nil {
 		return err
 	}
 
 	if shouldSend && isCurrentProposer {
 		txHash := common.FromHex(txHash)
-		if err := cp.createAndSendCheckpointToRootchain(checkpointContext, startBlock, endBlock, blockHeight, txHash); err != nil {
+		if err := cp.createAndSendCheckpointToRootchain(params, startBlock, endBlock, blockHeight, txHash); err != nil {
 			cp.Logger.Error("Error sending checkpoint to rootchain", "error", err)
 			return err
 		}
@@ -237,7 +230,7 @@ func (cp *CheckpointProcessor) sendCheckpointToRootchain(eventBytes string, bloc
 // 1. create and broadcast checkpointAck msg to heimdall.
 func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, checkpointAckStr string) error {
 	// fetch checkpoint context
-	checkpointContext, err := cp.getCheckpointContext()
+	params, err := cp.paramsContext.GetParams()
 	if err != nil {
 		return err
 	}
@@ -252,7 +245,7 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 	if err := helper.UnpackLog(cp.rootchainAbi, event, eventName, &log); err != nil {
 		cp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		checkpointNumber := big.NewInt(0).Div(event.HeaderBlockId, big.NewInt(0).SetUint64(checkpointContext.CheckpointParams.ChildBlockInterval))
+		checkpointNumber := big.NewInt(0).Div(event.HeaderBlockId, big.NewInt(0).SetUint64(params.CheckpointParams.ChildBlockInterval))
 
 		cp.Logger.Info(
 			"✅ Received task to send checkpoint-ack to heimdall",
@@ -305,18 +298,18 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 // 3. Send NoAck to heimdall if required.
 func (cp *CheckpointProcessor) handleCheckpointNoAck() {
 	// fetch fresh checkpoint context
-	checkpointContext, err := cp.getCheckpointContext()
+	params, err := cp.paramsContext.GetParams()
 	if err != nil {
 		return
 	}
 
-	lastCreatedAt, err := cp.getLatestCheckpointTime(checkpointContext)
+	lastCreatedAt, err := cp.getLatestCheckpointTime(params)
 	if err != nil {
 		cp.Logger.Error("Error fetching latest checkpoint time from rootchain", "error", err)
 		return
 	}
 
-	isNoAckRequired, count := cp.checkIfNoAckIsRequired(checkpointContext, lastCreatedAt)
+	isNoAckRequired, count := cp.checkIfNoAckIsRequired(params, lastCreatedAt)
 	if isNoAckRequired {
 		var isProposer bool
 
@@ -337,9 +330,9 @@ func (cp *CheckpointProcessor) handleCheckpointNoAck() {
 }
 
 // nextExpectedCheckpoint - fetched contract checkpoint state and returns the next probable checkpoint that needs to be sent
-func (cp *CheckpointProcessor) nextExpectedCheckpoint(checkpointContext *CheckpointContext, latestChildBlock uint64) (*ContractCheckpoint, error) {
-	chainmanagerParams := checkpointContext.ChainmanagerParams
-	checkpointParams := checkpointContext.CheckpointParams
+func (cp *CheckpointProcessor) nextExpectedCheckpoint(params util.Params, latestChildBlock uint64) (*ContractCheckpoint, error) {
+	chainmanagerParams := params.ChainmanagerParams
+	checkpointParams := params.CheckpointParams
 
 	rootChainInstance, err := cp.contractConnector.GetRootChainInstance(chainmanagerParams.ChainParams.RootChainAddress.EthAddress())
 	if err != nil {
@@ -422,7 +415,7 @@ func (cp *CheckpointProcessor) nextExpectedCheckpoint(checkpointContext *Checkpo
 }
 
 // sendCheckpointToHeimdall - creates checkpoint msg and broadcasts to heimdall
-func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(checkpointContext *CheckpointContext, start uint64, end uint64) error {
+func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(params util.Params, start uint64, end uint64) error {
 	cp.Logger.Debug("Initiating checkpoint to Heimdall", "start", start, "end", end)
 
 	if end == 0 || start >= end {
@@ -431,7 +424,7 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(checkpointConte
 	}
 
 	// get checkpoint params
-	checkpointParams := checkpointContext.CheckpointParams
+	checkpointParams := params.CheckpointParams
 
 	// Get root hash
 	root, err := cp.contractConnector.GetRootHash(start, end, checkpointParams.MaxCheckpointLength)
@@ -453,7 +446,7 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(checkpointConte
 		"accountRoot", accountRootHash,
 	)
 
-	chainParams := checkpointContext.ChainmanagerParams.ChainParams
+	chainParams := params.ChainmanagerParams.ChainParams
 
 	// create and send checkpoint message
 	msg := checkpointTypes.NewMsgCheckpointBlock(
@@ -476,7 +469,7 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(checkpointConte
 
 // createAndSendCheckpointToRootchain prepares the data required for rootchain checkpoint submission
 // and sends a transaction to rootchain
-func (cp *CheckpointProcessor) createAndSendCheckpointToRootchain(checkpointContext *CheckpointContext, start uint64, end uint64, height int64, txHash []byte) error {
+func (cp *CheckpointProcessor) createAndSendCheckpointToRootchain(params util.Params, start uint64, end uint64, height int64, txHash []byte) error {
 	cp.Logger.Info("Preparing checkpoint to be pushed on chain", "height", height, "txHash", hmTypes.BytesToHeimdallHash(txHash), "start", start, "end", end)
 	// proof
 	tx, err := helper.QueryTxWithProof(cp.cliCtx, txHash)
@@ -510,14 +503,14 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToRootchain(checkpointCont
 		return err
 	}
 
-	shouldSend, err := cp.shouldSendCheckpoint(checkpointContext, start, end)
+	shouldSend, err := cp.shouldSendCheckpoint(params, start, end)
 	if err != nil {
 		return err
 	}
 
 	if shouldSend {
 		// chain manager params
-		chainParams := checkpointContext.ChainmanagerParams.ChainParams
+		chainParams := params.ChainmanagerParams.ChainParams
 		// root chain address
 		rootChainAddress := chainParams.RootChainAddress.EthAddress()
 		// root chain instance
@@ -553,10 +546,10 @@ func (cp *CheckpointProcessor) fetchDividendAccountRoot() (accountroothash hmTyp
 }
 
 // fetchLatestCheckpointTime - get latest checkpoint time from rootchain
-func (cp *CheckpointProcessor) getLatestCheckpointTime(checkpointContext *CheckpointContext) (int64, error) {
+func (cp *CheckpointProcessor) getLatestCheckpointTime(params util.Params) (int64, error) {
 	// get chain params
-	chainParams := checkpointContext.ChainmanagerParams.ChainParams
-	checkpointParams := checkpointContext.CheckpointParams
+	chainParams := params.ChainmanagerParams.ChainParams
+	checkpointParams := params.CheckpointParams
 
 	rootChainInstance, err := cp.contractConnector.GetRootChainInstance(chainParams.RootChainAddress.EthAddress())
 	if err != nil {
@@ -596,7 +589,7 @@ func (cp *CheckpointProcessor) getLastNoAckTime() uint64 {
 }
 
 // checkIfNoAckIsRequired - check if NoAck has to be sent or not
-func (cp *CheckpointProcessor) checkIfNoAckIsRequired(checkpointContext *CheckpointContext, lastCreatedAt int64) (bool, uint64) {
+func (cp *CheckpointProcessor) checkIfNoAckIsRequired(params util.Params, lastCreatedAt int64) (bool, uint64) {
 	var index float64
 	// if last created at ==0 , no checkpoint yet
 	if lastCreatedAt == 0 {
@@ -616,7 +609,7 @@ func (cp *CheckpointProcessor) checkIfNoAckIsRequired(checkpointContext *Checkpo
 	}
 
 	// checkpoint params
-	checkpointParams := checkpointContext.CheckpointParams
+	checkpointParams := params.CheckpointParams
 
 	// check if difference between no-ack time and current time
 	lastNoAck := cp.getLastNoAckTime()
@@ -648,8 +641,8 @@ func (cp *CheckpointProcessor) proposeCheckpointNoAck() (err error) {
 }
 
 // shouldSendCheckpoint checks if checkpoint with given start,end should be sent to rootchain or not.
-func (cp *CheckpointProcessor) shouldSendCheckpoint(checkpointContext *CheckpointContext, start uint64, end uint64) (bool, error) {
-	chainmanagerParams := checkpointContext.ChainmanagerParams
+func (cp *CheckpointProcessor) shouldSendCheckpoint(params util.Params, start uint64, end uint64) (bool, error) {
+	chainmanagerParams := params.ChainmanagerParams
 
 	rootChainInstance, err := cp.contractConnector.GetRootChainInstance(chainmanagerParams.ChainParams.RootChainAddress.EthAddress())
 	if err != nil {
@@ -688,27 +681,4 @@ func (cp *CheckpointProcessor) shouldSendCheckpoint(checkpointContext *Checkpoin
 func (cp *CheckpointProcessor) Stop() {
 	// cancel No-Ack polling
 	cp.cancelNoACKPolling()
-}
-
-//
-// utils
-//
-
-func (cp *CheckpointProcessor) getCheckpointContext() (*CheckpointContext, error) {
-	chainmanagerParams, err := util.GetChainmanagerParams(cp.cliCtx)
-	if err != nil {
-		cp.Logger.Error("Error while fetching chain manager params", "error", err)
-		return nil, err
-	}
-
-	checkpointParams, err := util.GetCheckpointParams(cp.cliCtx)
-	if err != nil {
-		cp.Logger.Error("Error while fetching checkpoint params", "error", err)
-		return nil, err
-	}
-
-	return &CheckpointContext{
-		ChainmanagerParams: chainmanagerParams,
-		CheckpointParams:   checkpointParams,
-	}, nil
 }

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -295,10 +295,8 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 	}
 	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
 	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
-	// estimatedNextBlockTime is in milliseconds
-	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
-	cp.Logger.Debug("Retrying checkpoint-ack to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
-	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	cp.Logger.Debug("Retrying checkpoint-ack to check if side-tx is successful or not", "after", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
 }
 
 // handleCheckpointNoAck - Checkpoint No-Ack handler

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/RichardKnop/machinery/v1/tasks"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/maticnetwork/bor/accounts/abi"
@@ -292,7 +293,12 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 			return err
 		}
 	}
-	return nil
+	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
+	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
+	// estimatedNextBlockTime is in milliseconds
+	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
+	cp.Logger.Debug("Retrying checkpoint-ack to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
 }
 
 // handleCheckpointNoAck - Checkpoint No-Ack handler

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"encoding/hex"
 	"encoding/json"
-	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
@@ -117,10 +116,8 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 
 	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
 	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
-	// estimatedNextBlockTime is in milliseconds
-	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
-	cp.Logger.Debug("Retrying deposit to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
-	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	cp.Logger.Debug("Retrying deposit to check if side-tx is successful or not", "after", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
 }
 
 // isOldTx  checks if tx is already processed or not

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -9,17 +9,11 @@ import (
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
-	chainmanagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 	clerkTypes "github.com/maticnetwork/heimdall/clerk/types"
 	"github.com/maticnetwork/heimdall/contracts/statesender"
 	"github.com/maticnetwork/heimdall/helper"
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
-
-// ClerkContext for bridge
-type ClerkContext struct {
-	ChainmanagerParams *chainmanagerTypes.Params
-}
 
 // ClerkProcessor - sync state/deposit events
 type ClerkProcessor struct {
@@ -59,12 +53,12 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 		return err
 	}
 
-	clerkContext, err := cp.getClerkContext()
+	params, err := cp.paramsContext.GetParams()
 	if err != nil {
 		return err
 	}
 
-	chainParams := clerkContext.ChainmanagerParams.ChainParams
+	chainParams := params.ChainmanagerParams.ChainParams
 
 	event := new(statesender.StatesenderStateSynced)
 	if err := helper.UnpackLog(cp.stateSenderAbi, event, eventName, &vLog); err != nil {
@@ -147,20 +141,4 @@ func (cp *ClerkProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, l
 	}
 
 	return status, nil
-}
-
-//
-// utils
-//
-
-func (cp *ClerkProcessor) getClerkContext() (*ClerkContext, error) {
-	chainmanagerParams, err := util.GetChainmanagerParams(cp.cliCtx)
-	if err != nil {
-		cp.Logger.Error("Error while fetching chain manager params", "error", err)
-		return nil, err
-	}
-
-	return &ClerkContext{
-		ChainmanagerParams: chainmanagerParams,
-	}, nil
 }

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
@@ -90,10 +89,8 @@ func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string
 
 	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
 	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
-	// estimatedNextBlockTime is in milliseconds
-	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
-	fp.Logger.Debug("Retrying topup to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
-	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	fp.Logger.Debug("Retrying topup to check if side-tx is successful or not", "after", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
 }
 
 // isOldTx  checks if tx is already processed or not

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -2,7 +2,9 @@ package processor
 
 import (
 	"encoding/json"
+	"time"
 
+	"github.com/RichardKnop/machinery/v1/tasks"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
@@ -85,7 +87,13 @@ func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string
 			return err
 		}
 	}
-	return nil
+
+	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
+	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
+	// estimatedNextBlockTime is in milliseconds
+	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
+	fp.Logger.Debug("Retrying topup to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
 }
 
 // isOldTx  checks if tx is already processed or not

--- a/bridge/setu/processor/service.go
+++ b/bridge/setu/processor/service.go
@@ -33,6 +33,7 @@ func NewProcessorService(
 	queueConnector *queue.QueueConnector,
 	httpClient *httpClient.HTTP,
 	txBroadcaster *broadcaster.TxBroadcaster,
+	paramsContext *util.ParamsContext,
 ) *ProcessorService {
 	var logger = util.Logger().With("module", processorServiceStr)
 	// creating processor object
@@ -53,27 +54,27 @@ func NewProcessorService(
 
 	// initialize checkpoint processor
 	checkpointProcessor := NewCheckpointProcessor(&contractCaller.RootChainABI)
-	checkpointProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, "checkpoint", checkpointProcessor)
+	checkpointProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, paramsContext, "checkpoint", checkpointProcessor)
 
 	// initialize fee processor
 	feeProcessor := NewFeeProcessor(&contractCaller.StakingInfoABI)
-	feeProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, "fee", feeProcessor)
+	feeProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, paramsContext, "fee", feeProcessor)
 
 	// initialize staking processor
 	stakingProcessor := NewStakingProcessor(&contractCaller.StakingInfoABI)
-	stakingProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, "staking", stakingProcessor)
+	stakingProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, paramsContext, "staking", stakingProcessor)
 
 	// initialize clerk processor
 	clerkProcessor := NewClerkProcessor(&contractCaller.StateSenderABI)
-	clerkProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, "clerk", clerkProcessor)
+	clerkProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, paramsContext, "clerk", clerkProcessor)
 
 	// initialize span processor
 	spanProcessor := &SpanProcessor{}
-	spanProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, "span", spanProcessor)
+	spanProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, paramsContext, "span", spanProcessor)
 
 	// initialize slashing processor
 	slashingProcessor := NewSlashingProcessor(&contractCaller.StakingInfoABI)
-	slashingProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, "slashing", slashingProcessor)
+	slashingProcessor.BaseProcessor = *NewBaseProcessor(cdc, queueConnector, httpClient, txBroadcaster, paramsContext, "slashing", slashingProcessor)
 
 	//
 	// Select processors

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -1,109 +1,77 @@
 package processor
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"net/http"
-	"strconv"
-	"time"
 
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/helper"
+	hmTypes "github.com/maticnetwork/heimdall/types"
 
+	"github.com/maticnetwork/bor/core/types"
 	borTypes "github.com/maticnetwork/heimdall/bor/types"
-
-	"github.com/maticnetwork/heimdall/types"
 )
 
 // SpanProcessor - process span related events
 type SpanProcessor struct {
 	BaseProcessor
-
-	// header listener subscription
-	cancelSpanService context.CancelFunc
 }
 
 // Start starts new block subscription
 func (sp *SpanProcessor) Start() error {
 	sp.Logger.Info("Starting")
-
-	// create cancellable context
-	spanCtx, cancelSpanService := context.WithCancel(context.Background())
-
-	sp.cancelSpanService = cancelSpanService
-
-	// start polling for span
-	sp.Logger.Info("Start polling for span", "pollInterval", helper.GetConfig().SpanPollInterval)
-	go sp.startPolling(spanCtx, helper.GetConfig().SpanPollInterval)
 	return nil
 }
 
-// RegisterTasks - nil
+// RegisterTasks
 func (sp *SpanProcessor) RegisterTasks() {
-
-}
-
-// startPolling - polls heimdall and checks if new span needs to be proposed
-func (sp *SpanProcessor) startPolling(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	// stop ticker when everything done
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			sp.checkAndPropose()
-		case <-ctx.Done():
-			sp.Logger.Info("Polling stopped")
-			ticker.Stop()
-			return
-		}
+	sp.Logger.Info("Registering span tasks")
+	if err := sp.queueConnector.Server.RegisterTask("sendSpanToHeimdall", sp.sendSpanToHeimdall); err != nil {
+		sp.Logger.Error("RegisterTasks | sendSpanToHeimdall", "error", err)
 	}
 }
 
-// checkAndPropose - will check if current user is span proposer and proposes the span
-func (sp *SpanProcessor) checkAndPropose() {
-	lastSpan, err := sp.getLastSpan()
+// HandleSendSpanTask - handle send span task
+// 1. check if this span has to be broadcasted to heimdall
+// 2. create and broadcast  span transaction to heimdall
+func (sp *SpanProcessor) sendSpanToHeimdall(headerBlockStr string) error {
+	var header = types.Header{}
+	if err := header.UnmarshalJSON([]byte(headerBlockStr)); err != nil {
+		sp.Logger.Error("Error while unmarshalling the header block", "error", err)
+		return err
+	}
+
+	// Fetch last span
+	lastSpan, err := util.GetLastSpan(sp.cliCtx)
 	if err == nil && lastSpan != nil {
 		sp.Logger.Debug("Found last span", "lastSpan", lastSpan.ID, "startBlock", lastSpan.StartBlock, "endBlock", lastSpan.EndBlock)
-		nextSpanMsg, err := sp.fetchNextSpanDetails(lastSpan.ID+1, lastSpan.EndBlock+1)
 
-		// check if current user is among next span producers
-		if err == nil && sp.isSpanProposer(nextSpanMsg.SelectedProducers) {
-			go sp.propose(lastSpan, nextSpanMsg)
-		} else {
-			sp.Logger.Error("Unable to fetch next span details", "lastSpanId", lastSpan.ID)
-			return
+	}
+
+	// check and propose span
+	if lastSpan.StartBlock <= header.Number.Uint64() && header.Number.Uint64() <= lastSpan.EndBlock {
+
+		// Fetch next span to be proposed
+		nextSpanMsg, err := util.FetchNextSpanDetails(sp.cliCtx, lastSpan.ID+1, lastSpan.EndBlock+1)
+		if err != nil {
+			sp.Logger.Error("Error while fetching next span details", "error", err)
+			return err
 		}
-	}
-}
 
-// propose producers for next span if needed
-func (sp *SpanProcessor) propose(lastSpan *types.Span, nextSpanMsg *types.Span) {
-	// call with last span on record + new span duration and see if it has been proposed
-	currentBlock, err := sp.getCurrentChildBlock()
-	if err != nil {
-		sp.Logger.Error("Unable to fetch current block", "error", err)
-		return
-	}
-
-	if lastSpan.StartBlock <= currentBlock && currentBlock <= lastSpan.EndBlock {
-		// log new span
-		sp.Logger.Info("✅ Proposing new span", "spanId", nextSpanMsg.ID, "startBlock", nextSpanMsg.StartBlock, "endBlock", nextSpanMsg.EndBlock)
-
-		//Get NextSpanSeed from HeimdallServer
+		// Get NextSpanSeed from HeimdallServer
 		var seed common.Hash
 		if seed, err = sp.fetchNextSpanSeed(); err != nil {
 			sp.Logger.Info("Error while fetching next span seed from HeimdallServer", "err", err)
-			return
+			return err
 		}
+
+		// log new span
+		sp.Logger.Info("✅ Proposing new span", "spanId", nextSpanMsg.ID, "startBlock", nextSpanMsg.StartBlock, "endBlock", nextSpanMsg.EndBlock, "seed", seed)
 
 		// broadcast to heimdall
 		msg := borTypes.MsgProposeSpan{
 			ID:         nextSpanMsg.ID,
-			Proposer:   types.BytesToHeimdallAddress(helper.GetAddress()),
+			Proposer:   hmTypes.BytesToHeimdallAddress(helper.GetAddress()),
 			StartBlock: nextSpanMsg.StartBlock,
 			EndBlock:   nextSpanMsg.EndBlock,
 			ChainID:    nextSpanMsg.ChainID,
@@ -113,105 +81,25 @@ func (sp *SpanProcessor) propose(lastSpan *types.Span, nextSpanMsg *types.Span) 
 		// return broadcast to heimdall
 		if err := sp.txBroadcaster.BroadcastToHeimdall(msg); err != nil {
 			sp.Logger.Error("Error while broadcasting span to heimdall", "spanId", nextSpanMsg.ID, "startBlock", nextSpanMsg.StartBlock, "endBlock", nextSpanMsg.EndBlock, "error", err)
-			return
+			return err
 		}
 	}
-}
 
-// checks span status
-func (sp *SpanProcessor) getLastSpan() (*types.Span, error) {
-	// fetch latest start block from heimdall via rest query
-	result, err := helper.FetchFromAPI(sp.cliCtx, helper.GetHeimdallServerEndpoint(util.LatestSpanURL))
-	if err != nil {
-		sp.Logger.Error("Error while fetching latest span")
-		return nil, err
-	}
-	var lastSpan types.Span
-	err = json.Unmarshal(result.Result, &lastSpan)
-	if err != nil {
-		sp.Logger.Error("Error unmarshalling span", "error", err)
-		return nil, err
-	}
-	return &lastSpan, nil
-}
-
-// getCurrentChildBlock gets the current child block
-func (sp *SpanProcessor) getCurrentChildBlock() (uint64, error) {
-	childBlock, err := sp.contractConnector.GetMaticChainBlock(nil)
-	if err != nil {
-		return 0, err
-	}
-	return childBlock.Number.Uint64(), nil
-}
-
-// isSpanProposer checks if current user is span proposer
-func (sp *SpanProcessor) isSpanProposer(nextSpanProducers []types.Validator) bool {
-	// anyone among next span producers can become next span proposer
-	for _, val := range nextSpanProducers {
-		if bytes.Equal(val.Signer.Bytes(), helper.GetAddress()) {
-			return true
-		}
-	}
-	return false
-}
-
-// fetch next span details from heimdall.
-func (sp *SpanProcessor) fetchNextSpanDetails(id uint64, start uint64) (*types.Span, error) {
-	req, err := http.NewRequest("GET", helper.GetHeimdallServerEndpoint(util.NextSpanInfoURL), nil)
-	if err != nil {
-		sp.Logger.Error("Error creating a new request", "error", err)
-		return nil, err
-	}
-	configParams, err := util.GetChainmanagerParams(sp.cliCtx)
-	if err != nil {
-		sp.Logger.Error("Error while fetching chainmanager params", "error", err)
-		return nil, err
-	}
-
-	q := req.URL.Query()
-	q.Add("span_id", strconv.FormatUint(id, 10))
-	q.Add("start_block", strconv.FormatUint(start, 10))
-	q.Add("chain_id", configParams.ChainParams.BorChainID)
-	q.Add("proposer", helper.GetFromAddress(sp.cliCtx).String())
-	req.URL.RawQuery = q.Encode()
-
-	// fetch next span details
-	result, err := helper.FetchFromAPI(sp.cliCtx, req.URL.String())
-	if err != nil {
-		sp.Logger.Error("Error fetching proposers", "error", err)
-		return nil, err
-	}
-
-	var msg types.Span
-	if err = json.Unmarshal(result.Result, &msg); err != nil {
-		sp.Logger.Error("Error unmarshalling propose tx msg ", "error", err)
-		return nil, err
-	}
-
-	sp.Logger.Debug("◽ Generated proposer span msg", "msg", msg.String())
-	return &msg, nil
+	return nil
 }
 
 // fetchNextSpanSeed - fetches seed for next span
 func (sp *SpanProcessor) fetchNextSpanSeed() (nextSpanSeed common.Hash, err error) {
-	sp.Logger.Info("Sending Rest call to Get Seed for next span")
+	sp.Logger.Debug("Sending Rest call to Get Seed for next span")
 	response, err := helper.FetchFromAPI(sp.cliCtx, helper.GetHeimdallServerEndpoint(util.NextSpanSeedURL))
 	if err != nil {
 		sp.Logger.Error("Error Fetching nextspanseed from HeimdallServer ", "error", err)
 		return nextSpanSeed, err
 	}
-	sp.Logger.Info("Next span seed fetched")
+	sp.Logger.Debug("Next span seed fetched")
 	if err := json.Unmarshal(response.Result, &nextSpanSeed); err != nil {
 		sp.Logger.Error("Error unmarshalling nextSpanSeed received from Heimdall Server", "error", err)
 		return nextSpanSeed, err
 	}
 	return nextSpanSeed, nil
-}
-
-// OnStop stops all necessary go routines
-func (sp *SpanProcessor) Stop() {
-
-	// cancel span polling
-	sp.cancelSpanService()
-
 }

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
@@ -126,7 +127,12 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 			return err
 		}
 	}
-	return nil
+	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
+	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
+	// estimatedNextBlockTime is in milliseconds
+	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
+	sp.Logger.Debug("Retrying validatorjoin to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
 }
 
 func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes string) error {
@@ -185,7 +191,13 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 			return err
 		}
 	}
-	return nil
+
+	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
+	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
+	// estimatedNextBlockTime is in milliseconds
+	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
+	sp.Logger.Debug("Retrying unstake-init to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
 }
 
 func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes string) error {
@@ -200,7 +212,7 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
 		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
-			sp.Logger.Info("Ignoring task to send unstakeinit to heimdall as already processed",
+			sp.Logger.Info("Ignoring task to send stake-update to heimdall as already processed",
 				"event", eventName,
 				"validatorID", event.ValidatorId,
 				"nonce", event.Nonce,
@@ -239,7 +251,12 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 			return err
 		}
 	}
-	return nil
+	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
+	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
+	// estimatedNextBlockTime is in milliseconds
+	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
+	sp.Logger.Debug("Retrying stake-update to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
 }
 
 func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logBytes string) error {
@@ -302,7 +319,13 @@ func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logByte
 			return err
 		}
 	}
-	return nil
+
+	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
+	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
+	// estimatedNextBlockTime is in milliseconds
+	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
+	sp.Logger.Debug("Retrying signer-change to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
 }
 
 // isOldTx  checks if tx is already processed or not

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
@@ -91,7 +90,7 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 				"event", eventName,
 				"signer", event.Signer,
 			)
-			return tasks.NewErrRetryTaskLater("account doesn't exist", util.RetryTaskDelay)
+			return tasks.NewErrRetryTaskLater("account doesn't exist", util.ValidatorJoinRetryDelay)
 		}
 
 		sp.Logger.Info(
@@ -129,10 +128,8 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 	}
 	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
 	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
-	// estimatedNextBlockTime is in milliseconds
-	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
-	sp.Logger.Debug("Retrying validatorjoin to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
-	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	sp.Logger.Debug("Retrying validatorjoin to check if side-tx is successful or not", "after", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
 }
 
 func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes string) error {
@@ -194,10 +191,8 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 
 	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
 	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
-	// estimatedNextBlockTime is in milliseconds
-	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
-	sp.Logger.Debug("Retrying unstake-init to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
-	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	sp.Logger.Debug("Retrying unstake-init to check if side-tx is successful or not", "after", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
 }
 
 func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes string) error {
@@ -251,12 +246,11 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 			return err
 		}
 	}
+
 	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
 	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
-	// estimatedNextBlockTime is in milliseconds
-	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
-	sp.Logger.Debug("Retrying stake-update to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
-	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	sp.Logger.Debug("Retrying stake-update to check if side-tx is successful or not", "after", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
 }
 
 func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logBytes string) error {
@@ -322,10 +316,8 @@ func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logByte
 
 	// After broadcasting transaction from bridge, add back the msg to queue with retry delay.
 	// This is to retry side-tx msg incase if it was failed earlier during side-tx processing on heimdall.
-	// estimatedNextBlockTime is in milliseconds
-	estimatedNextBlockTime := helper.GetGenesisDoc().ConsensusParams.Block.TimeIotaMs
-	sp.Logger.Debug("Retrying signer-change to check if side-tx is successful or not", "after", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
-	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", 6*time.Duration(estimatedNextBlockTime)*time.Millisecond)
+	sp.Logger.Debug("Retrying signer-change to check if side-tx is successful or not", "after", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
+	return tasks.NewErrRetryTaskLater("retry to check if side-tx is successful or not", util.BlocksToDelayBeforeRetry*util.TimeBetweenTwoBlocks)
 }
 
 // isOldTx  checks if tx is already processed or not

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -55,7 +55,10 @@ const (
 	TransactionTimeout      = 1 * time.Minute
 	CommitTimeout           = 2 * time.Minute
 	TaskDelayBetweenEachVal = 6 * time.Second
-	RetryTaskDelay          = 12 * time.Second
+	ValidatorJoinRetryDelay = 12 * time.Second
+
+	TimeBetweenTwoBlocks     = 6 * time.Second
+	BlocksToDelayBeforeRetry = 6
 
 	BridgeDBFlag = "bridge-db"
 )

--- a/bridge/setu/util/paramscontext.go
+++ b/bridge/setu/util/paramscontext.go
@@ -33,16 +33,15 @@ func NewParamsContext(cliCtx cliContext.CLIContext) *ParamsContext {
 	return &paramsContext
 }
 
-// GetParamsContext gets ParamsContext
+// GetParams updates cache if required and returns params
 func (paramsContext *ParamsContext) GetParams() (params Params, err error) {
 	var found bool
-
 	data, found := paramsContext.paramsCache.Get(paramsContext.key)
 	if found {
 		params = data.(Params)
 	} else {
 		// Fetch params and add to cache
-		params, err := fetchLatestParams(paramsContext.cliCtx)
+		params, err = fetchLatestParams(paramsContext.cliCtx)
 		if err == nil {
 			paramsContext.paramsCache.Set(paramsContext.key, params, 1*time.Hour)
 		}

--- a/bridge/setu/util/paramscontext.go
+++ b/bridge/setu/util/paramscontext.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"time"
+
+	"github.com/patrickmn/go-cache"
+
+	cliContext "github.com/cosmos/cosmos-sdk/client/context"
+	chainmanagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
+	checkpointTypes "github.com/maticnetwork/heimdall/checkpoint/types"
+)
+
+type ParamsContext struct {
+	cliCtx      cliContext.CLIContext
+	paramsCache *cache.Cache
+	key         string
+}
+
+type Params struct {
+	ChainmanagerParams *chainmanagerTypes.Params
+	CheckpointParams   *checkpointTypes.Params
+}
+
+// NewParamsContext creates new params context
+func NewParamsContext(cliCtx cliContext.CLIContext) *ParamsContext {
+
+	paramsContext := ParamsContext{
+		key:         "params",
+		cliCtx:      cliCtx,
+		paramsCache: cache.New(1*time.Hour, 1*time.Hour),
+	}
+
+	return &paramsContext
+}
+
+// GetParamsContext gets ParamsContext
+func (paramsContext *ParamsContext) GetParams() (params Params, err error) {
+	var found bool
+
+	data, found := paramsContext.paramsCache.Get(paramsContext.key)
+	if found {
+		params = data.(Params)
+	} else {
+		// Fetch params and add to cache
+		params, err := paramsContext.fetchLatestParams(paramsContext.cliCtx)
+		if err != nil {
+			paramsContext.paramsCache.Set(paramsContext.key, params, 1*time.Hour)
+		}
+	}
+	return
+}
+
+func (paramsContext *ParamsContext) fetchLatestParams(cliContext cliContext.CLIContext) (params Params, err error) {
+	chainmanagerParams, err := GetChainmanagerParams(cliContext)
+	if err != nil {
+		return
+	}
+
+	checkpointParams, err := GetCheckpointParams(cliContext)
+	if err != nil {
+		return
+	}
+
+	params = Params{
+		ChainmanagerParams: chainmanagerParams,
+		CheckpointParams:   checkpointParams,
+	}
+	return
+}

--- a/bridge/setu/util/paramscontext.go
+++ b/bridge/setu/util/paramscontext.go
@@ -43,7 +43,7 @@ func (paramsContext *ParamsContext) GetParams() (params Params, err error) {
 	} else {
 		// Fetch params and add to cache
 		params, err := fetchLatestParams(paramsContext.cliCtx)
-		if err != nil {
+		if err == nil {
 			paramsContext.paramsCache.Set(paramsContext.key, params, 1*time.Hour)
 		}
 	}

--- a/bridge/setu/util/paramscontext.go
+++ b/bridge/setu/util/paramscontext.go
@@ -42,7 +42,7 @@ func (paramsContext *ParamsContext) GetParams() (params Params, err error) {
 		params = data.(Params)
 	} else {
 		// Fetch params and add to cache
-		params, err := paramsContext.fetchLatestParams(paramsContext.cliCtx)
+		params, err := fetchLatestParams(paramsContext.cliCtx)
 		if err != nil {
 			paramsContext.paramsCache.Set(paramsContext.key, params, 1*time.Hour)
 		}
@@ -50,7 +50,7 @@ func (paramsContext *ParamsContext) GetParams() (params Params, err error) {
 	return
 }
 
-func (paramsContext *ParamsContext) fetchLatestParams(cliContext cliContext.CLIContext) (params Params, err error) {
+func fetchLatestParams(cliContext cliContext.CLIContext) (params Params, err error) {
 	chainmanagerParams, err := GetChainmanagerParams(cliContext)
 	if err != nil {
 		return


### PR DESCRIPTION
This PR contains following bridge optimisations
```
MAT-1696 - Multiple span transactions for same spanID

Solution
- Add delay between each proposer.
```

```
MAT-1673 - Retry `tx` from bridge if failed during side-tx-processing

Solution
- After broadcasting transaction from bridge, add back the msg to queue with retry delay.
`return tasks.NewErrRetryTaskLater("some error", 6 * estimatedNextBlockTime)`

- After `6 blocks` produced on heimdall, same msg will be retried by bridge.
- As we validate and check if msg has been already processed or not on heimdall using `sequenceNo`,
    - if already processed, bridge will ignore
    - else, bridge will send the msg again repeating the process.
```

```
MAT-1228 - Add context params to cache to reduce params api call
Solution
- Cache the params and  reload at frequent intervals. (1hr)
```