### PR TITLE
Adding missing cmd to heimdall 

### DIFF
--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -538,7 +538,9 @@ func generateValidatorKey() *cobra.Command {
 			}
 
 			jsonBytes, err := tmjson.MarshalIndent(nodeKey, "", "  ")
-
+			if err != nil {
+				return err
+			}
 			err = ioutil.WriteFile("priv_validator_key.json", jsonBytes, 0600)
 			if err != nil {
 				return err

--- a/cmd/heimdalld/cmd/root.go
+++ b/cmd/heimdalld/cmd/root.go
@@ -157,6 +157,8 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		showPrivateKeyCmd(),
 		generateKeystoreCmd(),
 		generateValidatorKey(),
+		convertAddressToHexCmd(),
+		convertHexToAddressCmd(),
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, createSimappAndExport, addModuleInitFlags)
@@ -544,6 +546,36 @@ func generateValidatorKey() *cobra.Command {
 				return err
 			}
 
+			return nil
+		},
+	}
+}
+
+func convertAddressToHexCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "address-to-hex [address]",
+		Short: "Convert address to hex",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Hex:", ethCommon.BytesToAddress(key).String())
+			return nil
+		},
+	}
+}
+
+func convertHexToAddressCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "hex-to-address [hex]",
+		Short: "Convert hex to address",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			address := ethCommon.HexToAddress(args[0])
+			fmt.Println("Address:", sdk.AccAddress(address.Bytes()).String())
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/jinzhu/copier v0.2.5
 	github.com/maticnetwork/bor v0.2.2-0.20200807103547-4d42b15906aa
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/regen-network/cosmos-proto v0.3.1


### PR DESCRIPTION
1. show-account
2. show-privatekey
3. export-heimdall
4. generate-keystore
5. generate-validatorkey
6. address-to-hex
7. hex-to-address
