### PR TITLE
Fix checkpoint issue when bor is in 0 block issue

### DIFF
--- a/helper/call.go
+++ b/helper/call.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -705,21 +706,17 @@ func (c *ContractCaller) CurrentStateCounter(stateSenderInstance *statesender.St
 	return result
 }
 
-// CheckIfBlocksExist - check if latest block number is greater than end block
+// CheckIfBlocksExist - check if the given block exists on local chain
 func (c *ContractCaller) CheckIfBlocksExist(end uint64) bool {
-	// Get Latest block number.
-	var latestBlock *ethTypes.Header
+	// Get block by number.
+	var block *ethTypes.Header
 
-	err := c.MaticChainRPC.Call(&latestBlock, "eth_getBlockByNumber", "latest", false)
+	err := c.MaticChainRPC.Call(&block, "eth_getBlockByNumber", fmt.Sprintf("0x%x", end), false)
 	if err != nil {
 		return false
 	}
 
-	if end > latestBlock.Number.Uint64() {
-		return false
-	}
-
-	return true
+	return end == block.Number.Uint64()
 }
 
 //


### PR DESCRIPTION
- Earlier while validating checkpoint the heimdall used to check for latest block and compare if the end block for a checkpoint is lower than the latest number.
- In case of 0 block issue the latest number comes out to be 0 and hence the block check used to fail and checkpoint doesn't pass
- Now it will check if the end block is present or not instead of latest which used to give 0 block in case of 0 block issue.