### PR TITLE
POS-24 Embed Heimdall bridge in the Daemon binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ $ heimdalld start --chain=local         Will start for local with NewSelectionAl
 $ heimdalld rest-server 
 ```
 
+### Run bridge
+```bash 
+$ heimdalld bridge 
+```
 
 ### Documentation 
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,7 +1,16 @@
 package main
 
-import "github.com/maticnetwork/heimdall/bridge/cmd"
+import (
+	"fmt"
+	"os"
+
+	"github.com/maticnetwork/heimdall/bridge/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	rootCmd := cmd.BridgeCommands()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/bridge/cmd/root.go
+++ b/bridge/cmd/root.go
@@ -32,7 +32,7 @@ func BridgeCommands() *cobra.Command {
 
 // initTendermintViperConfig sets global viper configuration needed to heimdall
 func initTendermintViperConfig(cmd *cobra.Command) {
-	tendermintNode, _ := cmd.Flags().GetString(helper.NodeFlag)
+	heimdallNode, _ := cmd.Flags().GetString(helper.HeimdallNodeFlag)
 	homeValue, _ := cmd.Flags().GetString(helper.HomeFlag)
 	withHeimdallConfigValue, _ := cmd.Flags().GetString(helper.WithHeimdallConfigFlag)
 	bridgeDBValue, _ := cmd.Flags().GetString(bridgeDBFlag)
@@ -44,7 +44,7 @@ func initTendermintViperConfig(cmd *cobra.Command) {
 	}
 
 	// set to viper
-	viper.Set(helper.NodeFlag, tendermintNode)
+	viper.Set(helper.HeimdallNodeFlag, heimdallNode)
 	viper.Set(helper.HomeFlag, homeValue)
 	viper.Set(helper.WithHeimdallConfigFlag, withHeimdallConfigValue)
 	viper.Set(bridgeDBFlag, bridgeDBValue)
@@ -56,7 +56,7 @@ func initTendermintViperConfig(cmd *cobra.Command) {
 
 func init() {
 	var logger = helper.Logger.With("module", "bridge/cmd/")
-	rootCmd.PersistentFlags().StringP(helper.NodeFlag, "n", helper.DefaultNode, "Node to connect to")
+	rootCmd.PersistentFlags().StringP(helper.HeimdallNodeFlag, "n", helper.DefaultHeimdallNode, "Node to connect to")
 	rootCmd.PersistentFlags().String(helper.HomeFlag, helper.DefaultNodeHome, "directory for config and data")
 	rootCmd.PersistentFlags().String(
 		helper.WithHeimdallConfigFlag,

--- a/bridge/cmd/root.go
+++ b/bridge/cmd/root.go
@@ -32,7 +32,7 @@ func BridgeCommands() *cobra.Command {
 
 // initTendermintViperConfig sets global viper configuration needed to heimdall
 func initTendermintViperConfig(cmd *cobra.Command) {
-	heimdallNode, _ := cmd.Flags().GetString(helper.HeimdallNodeFlag)
+	tendermintNode, _ := cmd.Flags().GetString(helper.TendermintNodeFlag)
 	homeValue, _ := cmd.Flags().GetString(helper.HomeFlag)
 	withHeimdallConfigValue, _ := cmd.Flags().GetString(helper.WithHeimdallConfigFlag)
 	bridgeDBValue, _ := cmd.Flags().GetString(bridgeDBFlag)
@@ -44,7 +44,7 @@ func initTendermintViperConfig(cmd *cobra.Command) {
 	}
 
 	// set to viper
-	viper.Set(helper.HeimdallNodeFlag, heimdallNode)
+	viper.Set(helper.TendermintNodeFlag, tendermintNode)
 	viper.Set(helper.HomeFlag, homeValue)
 	viper.Set(helper.WithHeimdallConfigFlag, withHeimdallConfigValue)
 	viper.Set(bridgeDBFlag, bridgeDBValue)
@@ -56,7 +56,7 @@ func initTendermintViperConfig(cmd *cobra.Command) {
 
 func init() {
 	var logger = helper.Logger.With("module", "bridge/cmd/")
-	rootCmd.PersistentFlags().StringP(helper.HeimdallNodeFlag, "n", helper.DefaultHeimdallNode, "Node to connect to")
+	rootCmd.PersistentFlags().StringP(helper.TendermintNodeFlag, "n", helper.DefaultTendermintNode, "Node to connect to")
 	rootCmd.PersistentFlags().String(helper.HomeFlag, helper.DefaultNodeHome, "directory for config and data")
 	rootCmd.PersistentFlags().String(
 		helper.WithHeimdallConfigFlag,

--- a/bridge/cmd/root.go
+++ b/bridge/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -18,16 +16,22 @@ const (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "heimdall-bridge",
-	Short: "Heimdall bridge deamon",
+	Use:     "heimdall-bridge",
+	Aliases: []string{"bridge"},
+	Short:   "Heimdall bridge deamon",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// initialize tendermint viper config
-		InitTendermintViperConfig(cmd)
+		initTendermintViperConfig(cmd)
 	},
 }
 
-// InitTendermintViperConfig sets global viper configuration needed to heimdall
-func InitTendermintViperConfig(cmd *cobra.Command) {
+// BridgeCommands returns command for bridge service
+func BridgeCommands() *cobra.Command {
+	return rootCmd
+}
+
+// initTendermintViperConfig sets global viper configuration needed to heimdall
+func initTendermintViperConfig(cmd *cobra.Command) {
 	tendermintNode, _ := cmd.Flags().GetString(helper.NodeFlag)
 	homeValue, _ := cmd.Flags().GetString(helper.HomeFlag)
 	withHeimdallConfigValue, _ := cmd.Flags().GetString(helper.WithHeimdallConfigFlag)
@@ -50,19 +54,10 @@ func InitTendermintViperConfig(cmd *cobra.Command) {
 	helper.InitHeimdallConfig("")
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
 func init() {
 	var logger = helper.Logger.With("module", "bridge/cmd/")
-	rootCmd.PersistentFlags().StringP(helper.NodeFlag, "n", "tcp://localhost:26657", "Node to connect to")
-	rootCmd.PersistentFlags().String(helper.HomeFlag, os.ExpandEnv("$HOME/.heimdalld"), "directory for config and data")
+	rootCmd.PersistentFlags().StringP(helper.NodeFlag, "n", helper.DefaultNode, "Node to connect to")
+	rootCmd.PersistentFlags().String(helper.HomeFlag, helper.DefaultNodeHome, "directory for config and data")
 	rootCmd.PersistentFlags().String(
 		helper.WithHeimdallConfigFlag,
 		"",

--- a/bridge/setu/broadcaster/broadcaster_test.go
+++ b/bridge/setu/broadcaster/broadcaster_test.go
@@ -2,6 +2,7 @@ package broadcaster
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/maticnetwork/heimdall/app"
@@ -18,7 +19,7 @@ func TestBroadcastToHeimdall(t *testing.T) {
 	cdc := app.MakeCodec()
 	// cli context
 	tendermintNode := "tcp://localhost:26657"
-	viper.Set(helper.NodeFlag, tendermintNode)
+	viper.Set(helper.HeimdallNodeFlag, tendermintNode)
 	viper.Set("log_level", "info")
 	// cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
 	// cliCtx.BroadcastMode = client.BroadcastSync
@@ -35,7 +36,7 @@ func TestBroadcastToHeimdall(t *testing.T) {
 	}
 
 	for index, test := range testData {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
 			// create and send checkpoint message
 			msg := checkpointTypes.NewMsgCheckpointBlock(
 				test.Proposer,
@@ -43,6 +44,7 @@ func TestBroadcastToHeimdall(t *testing.T) {
 				test.EndBlock,
 				test.RootHash,
 				test.AccountRootHash,
+				test.BorChainID,
 			)
 
 			err := _txBroadcaster.BroadcastToHeimdall(msg)

--- a/bridge/setu/broadcaster/broadcaster_test.go
+++ b/bridge/setu/broadcaster/broadcaster_test.go
@@ -19,7 +19,7 @@ func TestBroadcastToHeimdall(t *testing.T) {
 	cdc := app.MakeCodec()
 	// cli context
 	tendermintNode := "tcp://localhost:26657"
-	viper.Set(helper.HeimdallNodeFlag, tendermintNode)
+	viper.Set(helper.TendermintNodeFlag, tendermintNode)
 	viper.Set("log_level", "info")
 	// cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
 	// cliCtx.BroadcastMode = client.BroadcastSync

--- a/cmd/heimdallcli/main.go
+++ b/cmd/heimdallcli/main.go
@@ -57,12 +57,12 @@ var (
 )
 
 func initTendermintViperConfig(cmd *cobra.Command) {
-	tendermintNode, _ := cmd.Flags().GetString(helper.NodeFlag)
+	heimdallNode, _ := cmd.Flags().GetString(helper.HeimdallNodeFlag)
 	homeValue, _ := cmd.Flags().GetString(helper.HomeFlag)
 	withHeimdallConfigValue, _ := cmd.Flags().GetString(helper.WithHeimdallConfigFlag)
 
 	// set to viper
-	viper.Set(helper.NodeFlag, tendermintNode)
+	viper.Set(helper.HeimdallNodeFlag, heimdallNode)
 	viper.Set(helper.HomeFlag, homeValue)
 	viper.Set(helper.WithHeimdallConfigFlag, withHeimdallConfigValue)
 

--- a/cmd/heimdallcli/main.go
+++ b/cmd/heimdallcli/main.go
@@ -57,12 +57,12 @@ var (
 )
 
 func initTendermintViperConfig(cmd *cobra.Command) {
-	heimdallNode, _ := cmd.Flags().GetString(helper.HeimdallNodeFlag)
+	tendermintNode, _ := cmd.Flags().GetString(helper.TendermintNodeFlag)
 	homeValue, _ := cmd.Flags().GetString(helper.HomeFlag)
 	withHeimdallConfigValue, _ := cmd.Flags().GetString(helper.WithHeimdallConfigFlag)
 
 	// set to viper
-	viper.Set(helper.HeimdallNodeFlag, heimdallNode)
+	viper.Set(helper.TendermintNodeFlag, tendermintNode)
 	viper.Set(helper.HomeFlag, homeValue)
 	viper.Set(helper.WithHeimdallConfigFlag, withHeimdallConfigValue)
 

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ethCommon "github.com/maticnetwork/bor/common"
+	hmbridge "github.com/maticnetwork/heimdall/bridge/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -111,6 +112,7 @@ func main() {
 	rootCmd.AddCommand(showAccountCmd())
 	rootCmd.AddCommand(showPrivateKeyCmd())
 	rootCmd.AddCommand(hmserver.ServeCommands(cdc, hmserver.RegisterRoutes))
+	rootCmd.AddCommand(hmbridge.BridgeCommands())
 	rootCmd.AddCommand(VerifyGenesis(ctx, cdc))
 	rootCmd.AddCommand(initCmd(ctx, cdc))
 	rootCmd.AddCommand(testnetCmd(ctx, cdc))

--- a/helper/call_test.go
+++ b/helper/call_test.go
@@ -14,8 +14,8 @@ import (
 
 //  Test - to decode signers from checkpoint sigs data
 func TestCheckpointsigs(t *testing.T) {
-	tendermintNode := "tcp://localhost:26657"
-	viper.Set(NodeFlag, tendermintNode)
+	heimdallNode := "tcp://localhost:26657"
+	viper.Set(HeimdallNodeFlag, heimdallNode)
 	viper.Set("log_level", "info")
 	InitHeimdallConfig(os.ExpandEnv("$HOME/.heimdalld"))
 

--- a/helper/call_test.go
+++ b/helper/call_test.go
@@ -14,8 +14,8 @@ import (
 
 //  Test - to decode signers from checkpoint sigs data
 func TestCheckpointsigs(t *testing.T) {
-	heimdallNode := "tcp://localhost:26657"
-	viper.Set(HeimdallNodeFlag, heimdallNode)
+	tendermintNode := "tcp://localhost:26657"
+	viper.Set(TendermintNodeFlag, tendermintNode)
 	viper.Set("log_level", "info")
 	InitHeimdallConfig(os.ExpandEnv("$HOME/.heimdalld"))
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	NodeFlag               = "node"
+	HeimdallNodeFlag       = "node"
 	WithHeimdallConfigFlag = "with-heimdall-config"
 	HomeFlag               = "home"
 	FlagClientHome         = "home-client"
@@ -71,7 +71,7 @@ const (
 
 	DefaultChain string = "mainnet"
 
-	DefaultNode = "tcp://localhost:26657"
+	DefaultHeimdallNode = "tcp://localhost:26657"
 
 	secretFilePerm = 0600
 )

--- a/helper/config.go
+++ b/helper/config.go
@@ -71,6 +71,8 @@ const (
 
 	DefaultChain string = "mainnet"
 
+	DefaultNode = "tcp://localhost:26657"
+
 	secretFilePerm = 0600
 )
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	HeimdallNodeFlag       = "node"
+	TendermintNodeFlag     = "node"
 	WithHeimdallConfigFlag = "with-heimdall-config"
 	HomeFlag               = "home"
 	FlagClientHome         = "home-client"
@@ -71,7 +71,7 @@ const (
 
 	DefaultChain string = "mainnet"
 
-	DefaultHeimdallNode = "tcp://localhost:26657"
+	DefaultTendermintNode = "tcp://localhost:26657"
 
 	secretFilePerm = 0600
 )

--- a/helper/config_test.go
+++ b/helper/config_test.go
@@ -11,8 +11,8 @@ import (
 //  Test - to check heimdall config
 func TestHeimdallConfig(t *testing.T) {
 	// cli context
-	tendermintNode := "tcp://localhost:26657"
-	viper.Set(NodeFlag, tendermintNode)
+	heimdallNode := "tcp://localhost:26657"
+	viper.Set(HeimdallNodeFlag, heimdallNode)
 	viper.Set("log_level", "info")
 	// cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
 	// cliCtx.BroadcastMode = client.BroadcastSync

--- a/helper/config_test.go
+++ b/helper/config_test.go
@@ -11,8 +11,8 @@ import (
 //  Test - to check heimdall config
 func TestHeimdallConfig(t *testing.T) {
 	// cli context
-	heimdallNode := "tcp://localhost:26657"
-	viper.Set(HeimdallNodeFlag, heimdallNode)
+	tendermintNode := "tcp://localhost:26657"
+	viper.Set(TendermintNodeFlag, tendermintNode)
 	viper.Set("log_level", "info")
 	// cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
 	// cliCtx.BroadcastMode = client.BroadcastSync

--- a/server/root.go
+++ b/server/root.go
@@ -49,7 +49,7 @@ func ServeCommands(cdc *codec.Codec, registerRoutesFn func(*lcd.RestServer)) *co
 	cmd.Flags().String(client.FlagListenAddr, "tcp://0.0.0.0:1317", "The address for the server to listen on")
 	cmd.Flags().Bool(client.FlagTrustNode, true, "Trust connected full node (don't verify proofs for responses)")
 	cmd.Flags().String(client.FlagChainID, "", "The chain ID to connect to")
-	cmd.Flags().String(client.FlagNode, "tcp://localhost:26657", "Address of the node to connect to")
+	cmd.Flags().String(client.FlagNode, helper.DefaultNode, "Address of the node to connect to")
 	cmd.Flags().Int(client.FlagMaxOpenConnections, 1000, "The number of maximum open connections")
 
 	return cmd

--- a/server/root.go
+++ b/server/root.go
@@ -49,7 +49,7 @@ func ServeCommands(cdc *codec.Codec, registerRoutesFn func(*lcd.RestServer)) *co
 	cmd.Flags().String(client.FlagListenAddr, "tcp://0.0.0.0:1317", "The address for the server to listen on")
 	cmd.Flags().Bool(client.FlagTrustNode, true, "Trust connected full node (don't verify proofs for responses)")
 	cmd.Flags().String(client.FlagChainID, "", "The chain ID to connect to")
-	cmd.Flags().String(client.FlagNode, helper.DefaultNode, "Address of the node to connect to")
+	cmd.Flags().String(client.FlagNode, helper.DefaultHeimdallNode, "Address of the node to connect to")
 	cmd.Flags().Int(client.FlagMaxOpenConnections, 1000, "The number of maximum open connections")
 
 	return cmd

--- a/server/root.go
+++ b/server/root.go
@@ -49,7 +49,7 @@ func ServeCommands(cdc *codec.Codec, registerRoutesFn func(*lcd.RestServer)) *co
 	cmd.Flags().String(client.FlagListenAddr, "tcp://0.0.0.0:1317", "The address for the server to listen on")
 	cmd.Flags().Bool(client.FlagTrustNode, true, "Trust connected full node (don't verify proofs for responses)")
 	cmd.Flags().String(client.FlagChainID, "", "The chain ID to connect to")
-	cmd.Flags().String(client.FlagNode, helper.DefaultHeimdallNode, "Address of the node to connect to")
+	cmd.Flags().String(client.FlagNode, helper.DefaultTendermintNode, "Address of the node to connect to")
 	cmd.Flags().Int(client.FlagMaxOpenConnections, 1000, "The number of maximum open connections")
 
 	return cmd


### PR DESCRIPTION
Right now, there are three Heimdall services that we have to run in the network:
- Daemon
- Bridge
- Rest server 

Rest server is defined in the Daemon binary and runs as:
```bash
$ heimdalld rest-server
```
However, the Bridge is an independent binary.
This makes it complex to distribute the software (release binaries and docker images).

The goal of this issue is to integrate the bridge on the Daemon alongside the Rest server in a command like this:
```bash
$ heimdalld bridge
```