### PR TITLE
Allow Heimdall to be configured using env vars

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -163,6 +163,8 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFilePath string) {
 	configDir := filepath.Join(homeDir, "config")
 
 	heimdallViper := viper.New()
+	heimdallViper.SetEnvPrefix("HEIMDALL")
+	heimdallViper.AutomaticEnv()
 	if heimdallConfigFilePath == "" {
 		heimdallViper.SetConfigName("heimdall-config") // name of config file (without extension)
 		heimdallViper.AddConfigPath(configDir)         // call multiple times to add many search paths


### PR DESCRIPTION
Thanks to viper we can setup the automatic env configuration, this is very convenient for running in docker as we don't need to add explicit params to the CLI and we avoid having to sed on config files.