### PR TITLE
Run with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG HEIMDALL_DIR=/heimdall
 ENV HEIMDALL_DIR=$HEIMDALL_DIR
 
 RUN apt-get update -y && apt-get upgrade -y \
-    && apt install build-essential git tini -y \
+    && apt install build-essential git -y \
     && mkdir -p /heimdall
 
 WORKDIR ${HEIMDALL_DIR}
@@ -17,5 +17,4 @@ COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENV SHELL /bin/bash
 EXPOSE 1317 26656 26657
 
-ENTRYPOINT ["tini", "--"]
-CMD ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+# This is an example compose file for starting up Heimdall required components
+# to run standalone without Bor for development and testing purposes.
+# Do not use this for production.
+version: "3"
+
+services:
+  rabbitmq:
+    container_name: rabbitmq
+    image: rabbitmq:3-alpine
+    ports:
+      - "5672:5672" # RabbitMQ
+    restart: unless-stopped
+
+  heimdalld:
+    container_name: heimdalld
+    image: 0xpolygon/heimdall:latest
+    build: .
+    restart: unless-stopped
+    environment:
+      - HEIMDALL_ETH_RPC_URL=https://goerli.infura.io/v3/[YOUR_INFURA_PROJECT_ID]
+    volumes:
+      - ./data:/heimdall
+    ports:
+      - "26656:26656" # P2P (TCP)
+      - "26657:26657" # RPC (TCP)
+    depends_on:
+      - rabbitmq
+    command:
+      - start
+      - --p2p.laddr=tcp://0.0.0.0:26656
+      - --rpc.laddr=tcp://0.0.0.0:26657
+
+  heimdallr:
+    container_name: heimdallr
+    image: 0xpolygon/heimdall:latest
+    build: .
+    restart: unless-stopped
+    environment:
+      - HEIMDALL_ETH_RPC_URL=https://goerli.infura.io/v3/[YOUR_INFURA_PROJECT_ID]
+    volumes:
+      - ./data:/heimdall
+    ports:
+      - "1317:1317" # Heimdall REST API
+    depends_on:
+      - heimdalld
+    command:
+      - rest-server
+      - --laddr=tcp://0.0.0.0:1317
+      - --node=tcp://heimdalld:26657
+
+  bridge:
+    container_name: bridge
+    image: 0xpolygon/heimdall:latest
+    build: .
+    restart: unless-stopped
+    environment:
+      - HEIMDALL_ETH_RPC_URL=https://goerli.infura.io/v3/[YOUR_INFURA_PROJECT_ID]
+      - HEIMDALL_AMQP_URL=amqp://guest:guest@rabbitmq:5672
+      - HEIMDALL_HEIMDALL_REST_SERVER=http://heimdallr:1317
+      - HEIMDALL_TENDERMINT_RPC_URL=http://heimdalld:26657
+    volumes:
+      - ./data:/heimdall
+    depends_on:
+      - heimdalld
+      - heimdallr
+      - rabbitmq
+    command:
+      - bridge
+      - start 
+      - --all

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,10 +4,9 @@ if [ ! -f $HEIMDALL_DIR/config/heimdall-config.toml ]; then
     heimdalld --home=$HEIMDALL_DIR init
 fi;
 
-# start processes
-heimdalld --home=$HEIMDALL_DIR start &
-heimdalld --home=$HEIMDALL_DIR rest-server &
-sleep 100
-bridge --home=$HEIMDALL_DIR start --all
+if [ "$1" = 'bridge' ]; then
+    shift
+    exec bridge --home=$HEIMDALL_DIR "$@"
+fi
 
-exit $?
+exec heimdalld --home=$HEIMDALL_DIR "$@"


### PR DESCRIPTION
With this PR we move towards the Docker philosophy of running just a single process. Running multiple processes without attending signals was not useful and dangerous for graceful stops.

- Refactor a bit the entrypoint so it responds to all binaries, heimdalld and bridge.
- Create a canonical docker-compose file to run all 3 components configuring them using env vars.
- heimdalcli could be run by overriding the entrypoint.
- Remove tini as now the main bin is heimdalld and it correctly handle signals.

Precede #748 