### PR TITLE
POS-53 Remove setup script for Heimdall and embed genesis files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.16
       - name: "Build binaries"
         run: make build
       - name: "Run tests"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ $ make install
 ### Init-heimdall 
 ```bash 
 $ heimdalld init
+$ heimdalld init --chain=mainnet        Will init with genesis.json for mainnet
+$ heimdalld init --chain=mumbai         Will init with genesis.json for mumbai
 ```
 ### Run-heimdall 
 ```bash 

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/common"
 	tmtime "github.com/tendermint/tendermint/types/time"
@@ -26,6 +28,123 @@ import (
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
+type initHeimdallConfig struct {
+	clientHome  string
+	chainID     string
+	validatorID int64
+	chain       string
+	forceInit   bool
+}
+
+func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdallConfig, config *cfg.Config) error {
+	// do not execute init if forceInit is false and genesis.json already exists (or we do not have permission to write to file)
+	if !initConfig.forceInit {
+		_, err := os.Stat(config.GenesisFile())
+		if err == nil || !errors.Is(err, os.ErrNotExist) { // https://stackoverflow.com/questions/12518876/how-to-check-if-a-file-exists-in-go
+			return nil
+		}
+	}
+
+	WriteDefaultHeimdallConfig(filepath.Join(config.RootDir, "config/heimdall-config.toml"), helper.GetDefaultHeimdallConfig())
+
+	nodeID, valPubKey, _, err := InitializeNodeValidatorFiles(config)
+	if err != nil {
+		return err
+	}
+
+	genesisCreated, err := helper.WriteGenesisFile(initConfig.chain, config.GenesisFile())
+	if err != nil {
+		return err
+	} else if genesisCreated {
+		return nil
+	}
+
+	// create chain id
+	chainID := initConfig.chainID
+	if chainID == "" {
+		chainID = fmt.Sprintf("heimdall-%v", common.RandStr(6))
+	}
+
+	// get pubkey
+	newPubkey := CryptoKeyToPubkey(valPubKey)
+
+	// create validator account
+	validator := hmTypes.NewValidator(hmTypes.NewValidatorID(uint64(initConfig.validatorID)),
+		0, 0, 1, 1, newPubkey,
+		hmTypes.BytesToHeimdallAddress(valPubKey.Address().Bytes()))
+
+	// create dividend account for validator
+	dividendAccount := hmTypes.NewDividendAccount(validator.Signer, ZeroIntString)
+
+	vals := []*hmTypes.Validator{validator}
+	validatorSet := hmTypes.NewValidatorSet(vals)
+
+	dividendAccounts := []hmTypes.DividendAccount{dividendAccount}
+
+	// create validator signing info
+	valSigningInfo := hmTypes.NewValidatorSigningInfo(validator.ID, 0, 0, 0)
+	valSigningInfoMap := make(map[string]hmTypes.ValidatorSigningInfo)
+	valSigningInfoMap[valSigningInfo.ValID.String()] = valSigningInfo
+
+	// create genesis state
+	appStateBytes := app.NewDefaultGenesisState()
+
+	// auth state change
+	appStateBytes, err = authTypes.SetGenesisStateToAppState(
+		appStateBytes,
+		[]authTypes.GenesisAccount{getGenesisAccount(validator.Signer.Bytes())},
+	)
+	if err != nil {
+		return err
+	}
+
+	// staking state change
+	appStateBytes, err = stakingTypes.SetGenesisStateToAppState(appStateBytes, vals, *validatorSet)
+	if err != nil {
+		return err
+	}
+
+	// slashing state change
+	appStateBytes, err = slashingTypes.SetGenesisStateToAppState(appStateBytes, valSigningInfoMap)
+	if err != nil {
+		return err
+	}
+
+	// bor state change
+	appStateBytes, err = borTypes.SetGenesisStateToAppState(appStateBytes, *validatorSet)
+	if err != nil {
+		return err
+	}
+
+	// topup state change
+	appStateBytes, err = topupTypes.SetGenesisStateToAppState(appStateBytes, dividendAccounts)
+	if err != nil {
+		return err
+	}
+
+	// app state json
+	appStateJSON, err := json.Marshal(appStateBytes)
+	if err != nil {
+		return err
+	}
+
+	toPrint := struct {
+		ChainID string `json:"chain_id"`
+		NodeID  string `json:"node_id"`
+	}{
+		chainID,
+		nodeID,
+	}
+
+	out, err := codec.MarshalJSONIndent(cdc, toPrint)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "%s\n", string(out))
+	return writeGenesisFile(tmtime.Now(), config.GenesisFile(), chainID, appStateJSON)
+}
+
 // InitCmd initialises files required to start heimdall
 func initCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 	cmd := &cobra.Command{
@@ -33,101 +152,16 @@ func initCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 		Short: "Initialize genesis config, priv-validator file, and p2p-node file",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			initConfig := &initHeimdallConfig{
+				chainID:     viper.GetString(client.FlagChainID),
+				chain:       viper.GetString(helper.ChainFlag),
+				validatorID: viper.GetInt64(stakingcli.FlagValidatorID),
+				clientHome:  viper.GetString(helper.FlagClientHome),
+				forceInit:   true,
+			}
 			config := ctx.Config
 			config.SetRoot(viper.GetString(cli.HomeFlag))
-
-			// create chain id
-			chainID := viper.GetString(client.FlagChainID)
-			if chainID == "" {
-				chainID = fmt.Sprintf("heimdall-%v", common.RandStr(6))
-			}
-
-			validatorID := viper.GetInt64(stakingcli.FlagValidatorID)
-			nodeID, valPubKey, _, err := InitializeNodeValidatorFiles(config)
-			if err != nil {
-				return err
-			}
-
-			WriteDefaultHeimdallConfig(filepath.Join(config.RootDir, "config/heimdall-config.toml"), helper.GetDefaultHeimdallConfig())
-
-			// get pubkey
-			newPubkey := CryptoKeyToPubkey(valPubKey)
-
-			// create validator account
-			validator := hmTypes.NewValidator(hmTypes.NewValidatorID(uint64(validatorID)),
-				0, 0, 1, 1, newPubkey,
-				hmTypes.BytesToHeimdallAddress(valPubKey.Address().Bytes()))
-
-			// create dividend account for validator
-			dividendAccount := hmTypes.NewDividendAccount(validator.Signer, ZeroIntString)
-
-			vals := []*hmTypes.Validator{validator}
-			validatorSet := hmTypes.NewValidatorSet(vals)
-
-			dividendAccounts := []hmTypes.DividendAccount{dividendAccount}
-
-			// create validator signing info
-			valSigningInfo := hmTypes.NewValidatorSigningInfo(validator.ID, 0, 0, 0)
-			valSigningInfoMap := make(map[string]hmTypes.ValidatorSigningInfo)
-			valSigningInfoMap[valSigningInfo.ValID.String()] = valSigningInfo
-
-			// create genesis state
-			appStateBytes := app.NewDefaultGenesisState()
-
-			// auth state change
-			appStateBytes, err = authTypes.SetGenesisStateToAppState(
-				appStateBytes,
-				[]authTypes.GenesisAccount{getGenesisAccount(validator.Signer.Bytes())},
-			)
-			if err != nil {
-				return err
-			}
-
-			// staking state change
-			appStateBytes, err = stakingTypes.SetGenesisStateToAppState(appStateBytes, vals, *validatorSet)
-			if err != nil {
-				return err
-			}
-
-			// slashing state change
-			appStateBytes, err = slashingTypes.SetGenesisStateToAppState(appStateBytes, valSigningInfoMap)
-			if err != nil {
-				return err
-			}
-
-			// bor state change
-			appStateBytes, err = borTypes.SetGenesisStateToAppState(appStateBytes, *validatorSet)
-			if err != nil {
-				return err
-			}
-
-			// topup state change
-			appStateBytes, err = topupTypes.SetGenesisStateToAppState(appStateBytes, dividendAccounts)
-			if err != nil {
-				return err
-			}
-
-			// app state json
-			appStateJSON, err := json.Marshal(appStateBytes)
-			if err != nil {
-				return err
-			}
-
-			toPrint := struct {
-				ChainID string `json:"chain_id"`
-				NodeID  string `json:"node_id"`
-			}{
-				chainID,
-				nodeID,
-			}
-
-			out, err := codec.MarshalJSONIndent(cdc, toPrint)
-			if err != nil {
-				return err
-			}
-
-			fmt.Fprintf(os.Stderr, "%s\n", string(out))
-			return writeGenesisFile(tmtime.Now(), config.GenesisFile(), chainID, appStateJSON)
+			return heimdallInit(ctx, cdc, initConfig, config)
 		},
 	}
 

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -52,7 +52,7 @@ func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdal
 		return err
 	}
 
-	genesisCreated, err := helper.WriteGenesisFile(initConfig.chain, config.GenesisFile())
+	genesisCreated, err := helper.WriteGenesisFile(initConfig.chain, config.GenesisFile(), cdc)
 	if err != nil {
 		return err
 	} else if genesisCreated {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maticnetwork/heimdall
 
-go 1.12
+go 1.16
 
 require (
 	github.com/RichardKnop/machinery v1.7.4

--- a/helper/allocs/mainnet.json
+++ b/helper/allocs/mainnet.json
@@ -3,12 +3,12 @@
   "chain_id": "heimdall-137",
   "consensus_params": {
     "block": {
-      "max_bytes": 22020096,
-      "max_gas": 25000000,
-      "time_iota_ms": 1000
+      "max_bytes": "22020096",
+      "max_gas": "25000000",
+      "time_iota_ms": "1000"
     },
     "evidence": {
-      "max_age": 100000
+      "max_age": "100000"
     },
     "validator": {
       "pub_key_types": [

--- a/helper/allocs/mainnet.json
+++ b/helper/allocs/mainnet.json
@@ -1,0 +1,635 @@
+{
+  "genesis_time": "2020-05-30T04:28:03.177054Z",
+  "chain_id": "heimdall-137",
+  "consensus_params": {
+    "block": {
+      "max_bytes": 22020096,
+      "max_gas": 25000000,
+      "time_iota_ms": 1000
+    },
+    "evidence": {
+      "max_age": 100000
+    },
+    "validator": {
+      "pub_key_types": [
+        "secp256k1"
+      ]
+    }
+  },
+  "app_hash": "",
+  "app_state": {
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000",
+        "max_tx_gas": "1000000",
+        "tx_fees": "1000000000000000"
+      },
+      "accounts": [
+        {
+          "address": "0x5973918275c01f50555d44e92c9d9b353cadad54",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "10000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0xb8bb158b93c94ed35c1970d610d1e2b34e26652c",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "10000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0xf84c74dea96df0ec22e11e7c33996c73fcc2d822",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "10000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0xb702f1c9154ac9c08da247a8e30ee6f2f3373f41",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "10000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0x7fcd58c2d53d980b247f1612fdba93e9a76193e6",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "10000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "10000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0x42eefcda06ead475cde3731b8eb138e88cd0bac3",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "10000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        }
+      ]
+    },
+    "bank": {
+      "send_enabled": true
+    },
+    "bor": {
+      "params": {
+        "sprint_duration": "64",
+        "span_duration": "6400",
+        "producer_count": "11"
+      },
+      "spans": [
+        {
+          "span_id": "0",
+          "start_block": "0",
+          "end_block": "255",
+          "validator_set": {
+            "validators": [
+              {
+                "ID": "6",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x0447ed13442b485dd6990efc01d4297d798e90d3fa8467dd9c2f50ffe3238c8bf722f6c774f584b5fe91364b7b430c5a24fe57aca48665cf778030266f2c452bd9",
+                "signer": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "-60000"
+              },
+              {
+                "ID": "7",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x043522a004012c9740703f676b95b5121edd7237fb0f182c3c45e7c7a77eaa67a20e6d0ac025d5bd96295bf95e2e875ab2a9da5c0e547b7d00ca7ede33c1b03893",
+                "signer": "0x42eefcda06ead475cde3731b8eb138e88cd0bac3",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "1",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x043c53ea6e1964e0670dc9ac72b3224207885d4c5f08cabe1e1080c662fdec278e7e833798757cb5cf121447dcd02a15f010eb4aa87cceecb23daa4bf904112e77",
+                "signer": "0x5973918275c01f50555d44e92c9d9b353cadad54",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "5",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x0479efe8c50b1f9923f48a467ecac0a64c2d6bcaa9ae67e135df84cac5aed5321f9cbb29c115f26dc84f2ef0e5fea29615848c79d690cb205cc10d688324ae8bce",
+                "signer": "0x7fcd58c2d53d980b247f1612fdba93e9a76193e6",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "4",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x04b4e1d56b3429f7756452426be611e595debcb858d59f47d29ec9dd6e4b547dce1539f9b7144420bc309de496b70d6dc5f13345eee85e6b7fb332cd9f364ef12f",
+                "signer": "0xb702f1c9154ac9c08da247a8e30ee6f2f3373f41",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "2",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x04d6b06c725f5410e4ccbd65906ece180364ebea4902b21232c1fb5892a76be7eec22480397d6bf653e9abe7ac50435ee472b59364fe78b17acb2be2116f92a76f",
+                "signer": "0xb8bb158b93c94ed35c1970d610d1e2b34e26652c",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "3",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x040600efda73e1404b0c596e08c78c5ed51631fc173e5f39d21deeddd5712fcd7d6d440c53d211eb48b03063a05b2c0c0eb084053dfcf1c6540def705c8e028456",
+                "signer": "0xf84c74dea96df0ec22e11e7c33996c73fcc2d822",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              }
+            ],
+            "proposer": {
+              "ID": "6",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x0447ed13442b485dd6990efc01d4297d798e90d3fa8467dd9c2f50ffe3238c8bf722f6c774f584b5fe91364b7b430c5a24fe57aca48665cf778030266f2c452bd9",
+              "signer": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "-60000"
+            }
+          },
+          "selected_producers": [
+            {
+              "ID": "6",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x0447ed13442b485dd6990efc01d4297d798e90d3fa8467dd9c2f50ffe3238c8bf722f6c774f584b5fe91364b7b430c5a24fe57aca48665cf778030266f2c452bd9",
+              "signer": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "-60000"
+            },
+            {
+              "ID": "7",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x043522a004012c9740703f676b95b5121edd7237fb0f182c3c45e7c7a77eaa67a20e6d0ac025d5bd96295bf95e2e875ab2a9da5c0e547b7d00ca7ede33c1b03893",
+              "signer": "0x42eefcda06ead475cde3731b8eb138e88cd0bac3",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "10000"
+            },
+            {
+              "ID": "1",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x043c53ea6e1964e0670dc9ac72b3224207885d4c5f08cabe1e1080c662fdec278e7e833798757cb5cf121447dcd02a15f010eb4aa87cceecb23daa4bf904112e77",
+              "signer": "0x5973918275c01f50555d44e92c9d9b353cadad54",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "10000"
+            },
+            {
+              "ID": "5",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x0479efe8c50b1f9923f48a467ecac0a64c2d6bcaa9ae67e135df84cac5aed5321f9cbb29c115f26dc84f2ef0e5fea29615848c79d690cb205cc10d688324ae8bce",
+              "signer": "0x7fcd58c2d53d980b247f1612fdba93e9a76193e6",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "10000"
+            }
+          ],
+          "bor_chain_id": "137"
+        }
+      ]
+    },
+    "chainmanager": {
+      "params": {
+        "mainchain_tx_confirmations": "6",
+        "maticchain_tx_confirmations": "10",
+        "chain_params": {
+          "bor_chain_id": "137",
+          "matic_token_address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+          "staking_manager_address": "0x88F65097BA6E10F25E93bf41987f9416BBB303eB",
+          "slash_manager_address": "0xbfAEa5DCcbA49DB25A9F9DD0E4245Ba7b1858aB4",
+          "root_chain_address": "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287",
+          "staking_info_address": "0xCe911aE0ffe9F54F96AFE49FC9BcBA0658f5CD1F",
+          "state_sender_address": "0x28e4F3a7f651294B9564800b2D01f35189A5bFbE",
+          "state_receiver_address": "0x0000000000000000000000000000000000001001",
+          "validator_set_address": "0x0000000000000000000000000000000000001000"
+        }
+      }
+    },
+    "checkpoint": {
+      "params": {
+        "checkpoint_buffer_time": "1000000000000",
+        "avg_checkpoint_length": "256",
+        "max_checkpoint_length": "1024",
+        "child_chain_block_interval": "10000"
+      },
+      "buffered_checkpoint": null,
+      "last_no_ack": "0",
+      "ack_count": "0",
+      "checkpoints": null
+    },
+    "clerk": {
+      "event_records": [],
+      "record_sequences": null
+    },
+    "gov": {
+      "starting_proposal_id": "1",
+      "deposits": null,
+      "votes": null,
+      "proposals": null,
+      "deposit_params": {
+        "min_deposit": [
+          {
+            "denom": "matic",
+            "amount": "100000000000000000000"
+          }
+        ],
+        "max_deposit_period": "3600000000000"
+      },
+      "voting_params": {
+        "voting_period": "3600000000000"
+      },
+      "tally_params": {
+        "quorum": "0.334000000000000000",
+        "threshold": "0.500000000000000000",
+        "veto": "0.334000000000000000"
+      }
+    },
+    "params": null,
+    "sidechannel": {
+      "past_commits": []
+    },
+    "slashing": {
+      "params": {
+        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.500000000000000000",
+        "downtime_jail_duration": "600000000000",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.010000000000000000",
+        "slash_fraction_limit": "0.333333333333333333",
+        "jail_fraction_limit": "0.333333333333333333",
+        "max_evidence_age": "120000000000",
+        "enable_slashing": false
+      },
+      "signing_infos": {
+        "1": {
+          "valID": "1",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "2": {
+          "valID": "2",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "3": {
+          "valID": "3",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "4": {
+          "valID": "4",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "5": {
+          "valID": "5",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "6": {
+          "valID": "6",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "7": {
+          "valID": "7",
+          "startHeight": "0",
+          "indexOffset": "0"
+        }
+      },
+      "missed_blocks": {},
+      "buffer_val_slash_info": null,
+      "tick_val_slash_info": null,
+      "tick_count": "0"
+    },
+    "staking": {
+      "validators": [
+        {
+          "ID": "1",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x043c53ea6e1964e0670dc9ac72b3224207885d4c5f08cabe1e1080c662fdec278e7e833798757cb5cf121447dcd02a15f010eb4aa87cceecb23daa4bf904112e77",
+          "signer": "0x5973918275c01f50555d44e92c9d9b353cadad54",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "2",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x04d6b06c725f5410e4ccbd65906ece180364ebea4902b21232c1fb5892a76be7eec22480397d6bf653e9abe7ac50435ee472b59364fe78b17acb2be2116f92a76f",
+          "signer": "0xb8bb158b93c94ed35c1970d610d1e2b34e26652c",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "3",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x040600efda73e1404b0c596e08c78c5ed51631fc173e5f39d21deeddd5712fcd7d6d440c53d211eb48b03063a05b2c0c0eb084053dfcf1c6540def705c8e028456",
+          "signer": "0xf84c74dea96df0ec22e11e7c33996c73fcc2d822",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "4",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x04b4e1d56b3429f7756452426be611e595debcb858d59f47d29ec9dd6e4b547dce1539f9b7144420bc309de496b70d6dc5f13345eee85e6b7fb332cd9f364ef12f",
+          "signer": "0xb702f1c9154ac9c08da247a8e30ee6f2f3373f41",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "5",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x0479efe8c50b1f9923f48a467ecac0a64c2d6bcaa9ae67e135df84cac5aed5321f9cbb29c115f26dc84f2ef0e5fea29615848c79d690cb205cc10d688324ae8bce",
+          "signer": "0x7fcd58c2d53d980b247f1612fdba93e9a76193e6",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "6",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x0447ed13442b485dd6990efc01d4297d798e90d3fa8467dd9c2f50ffe3238c8bf722f6c774f584b5fe91364b7b430c5a24fe57aca48665cf778030266f2c452bd9",
+          "signer": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "7",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x043522a004012c9740703f676b95b5121edd7237fb0f182c3c45e7c7a77eaa67a20e6d0ac025d5bd96295bf95e2e875ab2a9da5c0e547b7d00ca7ede33c1b03893",
+          "signer": "0x42eefcda06ead475cde3731b8eb138e88cd0bac3",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        }
+      ],
+      "current_val_set": {
+        "validators": [
+          {
+            "ID": "6",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x0447ed13442b485dd6990efc01d4297d798e90d3fa8467dd9c2f50ffe3238c8bf722f6c774f584b5fe91364b7b430c5a24fe57aca48665cf778030266f2c452bd9",
+            "signer": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "-60000"
+          },
+          {
+            "ID": "7",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x043522a004012c9740703f676b95b5121edd7237fb0f182c3c45e7c7a77eaa67a20e6d0ac025d5bd96295bf95e2e875ab2a9da5c0e547b7d00ca7ede33c1b03893",
+            "signer": "0x42eefcda06ead475cde3731b8eb138e88cd0bac3",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "1",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x043c53ea6e1964e0670dc9ac72b3224207885d4c5f08cabe1e1080c662fdec278e7e833798757cb5cf121447dcd02a15f010eb4aa87cceecb23daa4bf904112e77",
+            "signer": "0x5973918275c01f50555d44e92c9d9b353cadad54",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "5",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x0479efe8c50b1f9923f48a467ecac0a64c2d6bcaa9ae67e135df84cac5aed5321f9cbb29c115f26dc84f2ef0e5fea29615848c79d690cb205cc10d688324ae8bce",
+            "signer": "0x7fcd58c2d53d980b247f1612fdba93e9a76193e6",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "4",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x04b4e1d56b3429f7756452426be611e595debcb858d59f47d29ec9dd6e4b547dce1539f9b7144420bc309de496b70d6dc5f13345eee85e6b7fb332cd9f364ef12f",
+            "signer": "0xb702f1c9154ac9c08da247a8e30ee6f2f3373f41",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "2",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x04d6b06c725f5410e4ccbd65906ece180364ebea4902b21232c1fb5892a76be7eec22480397d6bf653e9abe7ac50435ee472b59364fe78b17acb2be2116f92a76f",
+            "signer": "0xb8bb158b93c94ed35c1970d610d1e2b34e26652c",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "3",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x040600efda73e1404b0c596e08c78c5ed51631fc173e5f39d21deeddd5712fcd7d6d440c53d211eb48b03063a05b2c0c0eb084053dfcf1c6540def705c8e028456",
+            "signer": "0xf84c74dea96df0ec22e11e7c33996c73fcc2d822",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          }
+        ],
+        "proposer": {
+          "ID": "6",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x0447ed13442b485dd6990efc01d4297d798e90d3fa8467dd9c2f50ffe3238c8bf722f6c774f584b5fe91364b7b430c5a24fe57aca48665cf778030266f2c452bd9",
+          "signer": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "-60000"
+        }
+      },
+      "staking_sequences": null
+    },
+    "supply": {
+      "supply": {
+        "total": []
+      }
+    },
+    "topup": {
+      "tx_sequences": null,
+      "dividend_accounts": [
+        {
+          "user": "0x5973918275c01f50555d44e92c9d9b353cadad54",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0xb8bb158b93c94ed35c1970d610d1e2b34e26652c",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0xf84c74dea96df0ec22e11e7c33996c73fcc2d822",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0xb702f1c9154ac9c08da247a8e30ee6f2f3373f41",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0x7fcd58c2d53d980b247f1612fdba93e9a76193e6",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0x0375b2fc7140977c9c76d45421564e354ed42277",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0x42eefcda06ead475cde3731b8eb138e88cd0bac3",
+          "feeAmount": "0"
+        }
+      ]
+    }
+  }
+}

--- a/helper/allocs/mumbai.json
+++ b/helper/allocs/mumbai.json
@@ -3,12 +3,12 @@
   "chain_id": "heimdall-80001",
   "consensus_params": {
     "block": {
-      "max_bytes": 22020096,
-      "max_gas": 25000000,
-      "time_iota_ms": 1000
+      "max_bytes": "22020096",
+      "max_gas": "25000000",
+      "time_iota_ms": "1000"
     },
     "evidence": {
-      "max_age": 100000
+      "max_age": "100000"
     },
     "validator": {
       "pub_key_types": [

--- a/helper/allocs/mumbai.json
+++ b/helper/allocs/mumbai.json
@@ -1,0 +1,519 @@
+{
+  "genesis_time": "2020-06-04T10:47:20.806665Z",
+  "chain_id": "heimdall-80001",
+  "consensus_params": {
+    "block": {
+      "max_bytes": 22020096,
+      "max_gas": 25000000,
+      "time_iota_ms": 1000
+    },
+    "evidence": {
+      "max_age": 100000
+    },
+    "validator": {
+      "pub_key_types": [
+        "secp256k1"
+      ]
+    }
+  },
+  "app_hash": "",
+  "app_state": {
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000",
+        "max_tx_gas": "1000000",
+        "tx_fees": "1000000000000000"
+      },
+      "accounts": [
+        {
+          "address": "0xc26880a0af2ea0c7e8130e6ec47af756465452e8",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "1000000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0xbe188d6641e8b680743a4815dfa0f6208038960f",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "1000000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0xc275dc8be39f50d12f66b6a63629c39da5bae5bd",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "1000000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0xf903ba9e006193c1527bfbe65fe2123704ea3f99",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "1000000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        },
+        {
+          "address": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+          "coins": [
+            {
+              "denom": "matic",
+              "amount": "1000000000000000000000"
+            }
+          ],
+          "sequence_number": "0",
+          "account_number": "0",
+          "module_name": "",
+          "module_permissions": null
+        }
+      ]
+    },
+    "bank": {
+      "send_enabled": true
+    },
+    "bor": {
+      "params": {
+        "sprint_duration": "64",
+        "span_duration": "6400",
+        "producer_count": "11"
+      },
+      "spans": [
+        {
+          "span_id": "0",
+          "start_block": "0",
+          "end_block": "255",
+          "validator_set": {
+            "validators": [
+              {
+                "ID": "5",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x04a267a9c19d2bc85bc8d7419e864eded7e193581fd98915d07cae86fd8a03aeb66ed87b02003a7897654562d29677221808d7790b300e69162ad86c1b7b24cd07",
+                "signer": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "-40000"
+              },
+              {
+                "ID": "2",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x04888a737a003f4e522ccf23bd9980fdbe7ef2b54365249deba0f9acd45279d66355b1864173b2cf9e75a1cbfb45e65a1a72b9ea76e47aa4bd50d79772ef301769",
+                "signer": "0xbe188d6641e8b680743a4815dfa0f6208038960f",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "1",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x040bec8102c221c7cfff3e250bb6cc01c3b9a3964fb1bf4d53e91905320eef09595acb09ee0950e7374ec19488ff2523f186f6b1a9164c78dba8602e4e3c4eb013",
+                "signer": "0xc26880a0af2ea0c7e8130e6ec47af756465452e8",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "3",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x04f3f18a027c929380417d2bd7d2a489cb662d4977e9daff335bc51f23c1c5f5f468aa19c6c8e937a745462ef2550bce42e4f38608dffb5a06e7b9d27d964cffee",
+                "signer": "0xc275dc8be39f50d12f66b6a63629c39da5bae5bd",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              },
+              {
+                "ID": "4",
+                "startEpoch": "0",
+                "endEpoch": "0",
+                "nonce": "1",
+                "power": "10000",
+                "pubKey": "0x04dcd2883416e7b8663caafbfc885e757b0ea809657df8d6f322f01a0c5a11fd033bf13d3e0d5e88feff92ba415d32d626e3f7d9dd7b5ec7c2fef8ded83d660ac2",
+                "signer": "0xf903ba9e006193c1527bfbe65fe2123704ea3f99",
+                "last_updated": "",
+                "jailed": false,
+                "accum": "10000"
+              }
+            ],
+            "proposer": {
+              "ID": "5",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x04a267a9c19d2bc85bc8d7419e864eded7e193581fd98915d07cae86fd8a03aeb66ed87b02003a7897654562d29677221808d7790b300e69162ad86c1b7b24cd07",
+              "signer": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "-40000"
+            }
+          },
+          "selected_producers": [
+            {
+              "ID": "5",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x04a267a9c19d2bc85bc8d7419e864eded7e193581fd98915d07cae86fd8a03aeb66ed87b02003a7897654562d29677221808d7790b300e69162ad86c1b7b24cd07",
+              "signer": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "-40000"
+            },
+            {
+              "ID": "2",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x04888a737a003f4e522ccf23bd9980fdbe7ef2b54365249deba0f9acd45279d66355b1864173b2cf9e75a1cbfb45e65a1a72b9ea76e47aa4bd50d79772ef301769",
+              "signer": "0xbe188d6641e8b680743a4815dfa0f6208038960f",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "10000"
+            },
+            {
+              "ID": "1",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x040bec8102c221c7cfff3e250bb6cc01c3b9a3964fb1bf4d53e91905320eef09595acb09ee0950e7374ec19488ff2523f186f6b1a9164c78dba8602e4e3c4eb013",
+              "signer": "0xc26880a0af2ea0c7e8130e6ec47af756465452e8",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "10000"
+            },
+            {
+              "ID": "3",
+              "startEpoch": "0",
+              "endEpoch": "0",
+              "nonce": "1",
+              "power": "10000",
+              "pubKey": "0x04f3f18a027c929380417d2bd7d2a489cb662d4977e9daff335bc51f23c1c5f5f468aa19c6c8e937a745462ef2550bce42e4f38608dffb5a06e7b9d27d964cffee",
+              "signer": "0xc275dc8be39f50d12f66b6a63629c39da5bae5bd",
+              "last_updated": "",
+              "jailed": false,
+              "accum": "10000"
+            }
+          ],
+          "bor_chain_id": "80001"
+        }
+      ]
+    },
+    "chainmanager": {
+      "params": {
+        "mainchain_tx_confirmations": "6",
+        "maticchain_tx_confirmations": "10",
+        "chain_params": {
+          "bor_chain_id": "80001",
+          "matic_token_address": "0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae",
+          "staking_manager_address": "0x4864d89DCE4e24b2eDF64735E014a7E4154bfA7A",
+          "slash_manager_address": "0x93D8f8A1A88498b258ceb69dD82311962374269C",
+          "root_chain_address": "0x2890bA17EfE978480615e330ecB65333b880928e",
+          "staking_info_address": "0x318EeD65F064904Bc6E0e3842940c5972BC8E38f",
+          "state_sender_address": "0xEAa852323826C71cd7920C3b4c007184234c3945",
+          "state_receiver_address": "0x0000000000000000000000000000000000001001",
+          "validator_set_address": "0x0000000000000000000000000000000000001000"
+        }
+      }
+    },
+    "checkpoint": {
+      "params": {
+        "checkpoint_buffer_time": "1000000000000",
+        "avg_checkpoint_length": "256",
+        "max_checkpoint_length": "1024",
+        "child_chain_block_interval": "10000"
+      },
+      "buffered_checkpoint": null,
+      "last_no_ack": "0",
+      "ack_count": "0",
+      "checkpoints": null
+    },
+    "clerk": {
+      "event_records": [],
+      "record_sequences": null
+    },
+    "gov": {
+      "starting_proposal_id": "1",
+      "deposits": null,
+      "votes": null,
+      "proposals": null,
+      "deposit_params": {
+        "min_deposit": [
+          {
+            "denom": "matic",
+            "amount": "10000000000000000000"
+          }
+        ],
+        "max_deposit_period": "3600000000000"
+      },
+      "voting_params": {
+        "voting_period": "3600000000000"
+      },
+      "tally_params": {
+        "quorum": "0.334000000000000000",
+        "threshold": "0.500000000000000000",
+        "veto": "0.334000000000000000"
+      }
+    },
+    "params": null,
+    "sidechannel": {
+      "past_commits": []
+    },
+    "slashing": {
+      "params": {
+        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.500000000000000000",
+        "downtime_jail_duration": "600000000000",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.010000000000000000",
+        "slash_fraction_limit": "0.333333333333333333",
+        "jail_fraction_limit": "0.333333333333333333",
+        "max_evidence_age": "120000000000",
+        "enable_slashing": false
+      },
+      "signing_infos": {
+        "2": {
+          "valID": "2",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "3": {
+          "valID": "3",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "4": {
+          "valID": "4",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "5": {
+          "valID": "5",
+          "startHeight": "0",
+          "indexOffset": "0"
+        },
+        "1": {
+          "valID": "1",
+          "startHeight": "0",
+          "indexOffset": "0"
+        }
+      },
+      "missed_blocks": {},
+      "buffer_val_slash_info": null,
+      "tick_val_slash_info": null,
+      "tick_count": "0"
+    },
+    "staking": {
+      "validators": [
+        {
+          "ID": "1",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x040bec8102c221c7cfff3e250bb6cc01c3b9a3964fb1bf4d53e91905320eef09595acb09ee0950e7374ec19488ff2523f186f6b1a9164c78dba8602e4e3c4eb013",
+          "signer": "0xc26880a0af2ea0c7e8130e6ec47af756465452e8",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "2",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x04888a737a003f4e522ccf23bd9980fdbe7ef2b54365249deba0f9acd45279d66355b1864173b2cf9e75a1cbfb45e65a1a72b9ea76e47aa4bd50d79772ef301769",
+          "signer": "0xbe188d6641e8b680743a4815dfa0f6208038960f",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "3",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x04f3f18a027c929380417d2bd7d2a489cb662d4977e9daff335bc51f23c1c5f5f468aa19c6c8e937a745462ef2550bce42e4f38608dffb5a06e7b9d27d964cffee",
+          "signer": "0xc275dc8be39f50d12f66b6a63629c39da5bae5bd",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "4",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x04dcd2883416e7b8663caafbfc885e757b0ea809657df8d6f322f01a0c5a11fd033bf13d3e0d5e88feff92ba415d32d626e3f7d9dd7b5ec7c2fef8ded83d660ac2",
+          "signer": "0xf903ba9e006193c1527bfbe65fe2123704ea3f99",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        },
+        {
+          "ID": "5",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x04a267a9c19d2bc85bc8d7419e864eded7e193581fd98915d07cae86fd8a03aeb66ed87b02003a7897654562d29677221808d7790b300e69162ad86c1b7b24cd07",
+          "signer": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "0"
+        }
+      ],
+      "current_val_set": {
+        "validators": [
+          {
+            "ID": "5",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x04a267a9c19d2bc85bc8d7419e864eded7e193581fd98915d07cae86fd8a03aeb66ed87b02003a7897654562d29677221808d7790b300e69162ad86c1b7b24cd07",
+            "signer": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "-40000"
+          },
+          {
+            "ID": "2",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x04888a737a003f4e522ccf23bd9980fdbe7ef2b54365249deba0f9acd45279d66355b1864173b2cf9e75a1cbfb45e65a1a72b9ea76e47aa4bd50d79772ef301769",
+            "signer": "0xbe188d6641e8b680743a4815dfa0f6208038960f",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "1",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x040bec8102c221c7cfff3e250bb6cc01c3b9a3964fb1bf4d53e91905320eef09595acb09ee0950e7374ec19488ff2523f186f6b1a9164c78dba8602e4e3c4eb013",
+            "signer": "0xc26880a0af2ea0c7e8130e6ec47af756465452e8",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "3",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x04f3f18a027c929380417d2bd7d2a489cb662d4977e9daff335bc51f23c1c5f5f468aa19c6c8e937a745462ef2550bce42e4f38608dffb5a06e7b9d27d964cffee",
+            "signer": "0xc275dc8be39f50d12f66b6a63629c39da5bae5bd",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          },
+          {
+            "ID": "4",
+            "startEpoch": "0",
+            "endEpoch": "0",
+            "nonce": "1",
+            "power": "10000",
+            "pubKey": "0x04dcd2883416e7b8663caafbfc885e757b0ea809657df8d6f322f01a0c5a11fd033bf13d3e0d5e88feff92ba415d32d626e3f7d9dd7b5ec7c2fef8ded83d660ac2",
+            "signer": "0xf903ba9e006193c1527bfbe65fe2123704ea3f99",
+            "last_updated": "",
+            "jailed": false,
+            "accum": "10000"
+          }
+        ],
+        "proposer": {
+          "ID": "5",
+          "startEpoch": "0",
+          "endEpoch": "0",
+          "nonce": "1",
+          "power": "10000",
+          "pubKey": "0x04a267a9c19d2bc85bc8d7419e864eded7e193581fd98915d07cae86fd8a03aeb66ed87b02003a7897654562d29677221808d7790b300e69162ad86c1b7b24cd07",
+          "signer": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+          "last_updated": "",
+          "jailed": false,
+          "accum": "-40000"
+        }
+      },
+      "staking_sequences": null
+    },
+    "supply": {
+      "supply": {
+        "total": []
+      }
+    },
+    "topup": {
+      "tx_sequences": null,
+      "dividend_accounts": [
+        {
+          "user": "0xc26880a0af2ea0c7e8130e6ec47af756465452e8",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0xbe188d6641e8b680743a4815dfa0f6208038960f",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0xc275dc8be39f50d12f66b6a63629c39da5bae5bd",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0xf903ba9e006193c1527bfbe65fe2123704ea3f99",
+          "feeAmount": "0"
+        },
+        {
+          "user": "0x928ed6a3e94437bbd316ccad78479f1d163a6a8c",
+          "feeAmount": "0"
+        }
+      ]
+    }
+  }
+}

--- a/helper/config.go
+++ b/helper/config.go
@@ -217,12 +217,12 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFilePath string) {
 	cdc.MustUnmarshalBinaryBare(privVal.Key.PrivKey.Bytes(), &privObject)
 	cdc.MustUnmarshalBinaryBare(privObject.PubKey().Bytes(), &pubObject)
 
-	// get chain from viper/cobra flag and set newSelectionAlgoHeight
+	// get chain from viper/cobra flag or config and set newSelectionAlgoHeight
 	chain := viper.GetString(ChainFlag)
-	if chain == "" {
-		chain = GetConfig().Chain
+	if chain != "" {
+		conf.Chain = chain
 	}
-	setNewSelectionAlgoHeight(chain)
+	setNewSelectionAlgoHeight(conf.Chain)
 }
 
 // GetDefaultHeimdallConfig returns configration with default params

--- a/helper/genesis_file.go
+++ b/helper/genesis_file.go
@@ -1,0 +1,42 @@
+package helper
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	tmTypes "github.com/tendermint/tendermint/types"
+)
+
+//go:embed allocs
+var allocs embed.FS
+
+func WriteGenesisFile(chain string, filePath string) (bool, error) {
+	switch chain {
+	case "mumbai", "mainnet":
+		fn := fmt.Sprintf("allocs/%s.json", chain)
+		genDoc, err := readPrealloc(fn)
+		if err == nil {
+			err = genDoc.SaveAs(filePath)
+		}
+		return err == nil, err
+	default:
+		return false, nil
+	}
+}
+
+func readPrealloc(filename string) (result tmTypes.GenesisDoc, err error) {
+	f, err := allocs.Open(filename)
+	if err != nil {
+		err = errors.Errorf("Could not open genesis preallocation for %s: %v", filename, err)
+		return
+	}
+	defer f.Close()
+	decoder := json.NewDecoder(f)
+	err = decoder.Decode(&result)
+	if err != nil {
+		err = errors.Errorf("Could not parse genesis preallocation for %s: %v", filename, err)
+	}
+	return
+}

--- a/sidechannel/keeper_test.go
+++ b/sidechannel/keeper_test.go
@@ -2,6 +2,7 @@ package sidechannel_test
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -148,7 +149,7 @@ func (suite *KeeperTestSuite) TestValidators() {
 	validators := make([]abci.Validator, 10)
 	for i := 0; i < 10; i++ {
 		validators[i] = abci.Validator{
-			Address: []byte("address" + string(i)),
+			Address: []byte("address" + strconv.Itoa(i)),
 			Power:   int64(i+1) * 1000,
 		}
 	}


### PR DESCRIPTION
We advise to users to use our Ansible scripts to deploy the Bor and Heimdall nodes using this playbook:

https://github.com/maticnetwork/node-ansible

There is a step in this process that runs a setup script for Heimdall to:

start the destination folder with $ heimdalld init

copy the cosmos genesis file to the folder, it is only available in the launch repo.

https://github.com/maticnetwork/node-ansible/blob/b7ab3f8078efd4a7337085fc68f672096f550708/roles/setup-network/tasks/setup.yml#L17

Unless this process is done, Heimdall cannot start.

The goal of this issue is to remove the need for this setup step.

Proposal

Move the code from the init command to its own function.

https://github.com/maticnetwork/heimdall/blob/master/cmd/heimdalld/init.go#L35

On starting the daemon, check if you need to run this script.

Embed in the Heimdall binary the cosmos-sdk genesis file for mainnet and mumbai chains.

This is for mainnet https://github.com/maticnetwork/launch/blob/master/mainnet-v1/without-sentry/heimdall/config/genesis.json

During the new init in the daemon, if the user does not supply any custom genesis file already, copy the prebuild embed genesis file to the destination folder (as the setup function does).

Notes

Do not remove the current init function, just move its functionality to the start command as well.

Since now we have the genesis file embed in the binary we might be tempted to load it from there instead of doing in it from a json file in the config directory, do not. Do not modify how the genesis file is being loaded.