### PR TITLE
POS-86: Graceful shutdown of Heimdall deamon, REST and Bridge

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -5,10 +5,14 @@ import (
 	"os"
 
 	"github.com/maticnetwork/heimdall/bridge/cmd"
+	"github.com/maticnetwork/heimdall/helper"
+	"github.com/spf13/viper"
 )
 
 func main() {
-	rootCmd := cmd.BridgeCommands()
+	var logger = helper.Logger.With("module", "bridge/cmd/")
+	rootCmd := cmd.BridgeCommands(viper.GetViper(), logger, "bridge-main")
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/bridge/cmd/root.go
+++ b/bridge/cmd/root.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/maticnetwork/heimdall/helper"
+	logger "github.com/tendermint/tendermint/libs/log"
 )
 
 const (
@@ -26,58 +28,72 @@ var rootCmd = &cobra.Command{
 }
 
 // BridgeCommands returns command for bridge service
-func BridgeCommands() *cobra.Command {
+func BridgeCommands(v *viper.Viper, loggerInstance logger.Logger, caller string) *cobra.Command {
+	DecorateWithBridgeRootFlags(rootCmd, v, loggerInstance, caller)
 	return rootCmd
 }
 
-// initTendermintViperConfig sets global viper configuration needed to heimdall
-func initTendermintViperConfig(cmd *cobra.Command) {
-	tendermintNode, _ := cmd.Flags().GetString(helper.TendermintNodeFlag)
-	homeValue, _ := cmd.Flags().GetString(helper.HomeFlag)
-	withHeimdallConfigValue, _ := cmd.Flags().GetString(helper.WithHeimdallConfigFlag)
+// function is called when bridge flags needs to be added to command
+func DecorateWithBridgeRootFlags(cmd *cobra.Command, v *viper.Viper, loggerInstance logger.Logger, caller string) {
+	cmd.PersistentFlags().StringP(helper.TendermintNodeFlag, "n", helper.DefaultTendermintNode, "Node to connect to")
+	if err := v.BindPFlag(helper.TendermintNodeFlag, cmd.PersistentFlags().Lookup(helper.TendermintNodeFlag)); err != nil {
+		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, helper.TendermintNodeFlag), "Error", err)
+	}
+
+	cmd.PersistentFlags().String(helper.HomeFlag, helper.DefaultNodeHome, "directory for config and data")
+	if err := v.BindPFlag(helper.HomeFlag, cmd.PersistentFlags().Lookup(helper.HomeFlag)); err != nil {
+		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, helper.HomeFlag), "Error", err)
+	}
+
+	cmd.PersistentFlags().String(
+		helper.WithHeimdallConfigFlag,
+		"",
+		"Heimdall config file path (default <home>/config/heimdall-config.json)",
+	)
+	if err := v.BindPFlag(helper.WithHeimdallConfigFlag, cmd.PersistentFlags().Lookup(helper.WithHeimdallConfigFlag)); err != nil {
+		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, helper.WithHeimdallConfigFlag), "Error", err)
+	}
+
+	// bridge storage db
+	cmd.PersistentFlags().String(
+		bridgeDBFlag,
+		"",
+		"Bridge db path (default <home>/bridge/storage)",
+	)
+	if err := v.BindPFlag(bridgeDBFlag, cmd.PersistentFlags().Lookup(bridgeDBFlag)); err != nil {
+		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, bridgeDBFlag), "Error", err)
+	}
+
+	// bridge chain id
+	cmd.PersistentFlags().String(
+		borChainIDFlag,
+		helper.DefaultBorChainID,
+		"Bor chain id",
+	)
+	if err := v.BindPFlag(borChainIDFlag, cmd.PersistentFlags().Lookup(borChainIDFlag)); err != nil {
+		loggerInstance.Error(fmt.Sprintf("%v | BindPFlag | %v", caller, borChainIDFlag), "Error", err)
+	}
+}
+
+// function is called to set appropriate bridge db path
+func AdjustBridgeDBValue(cmd *cobra.Command, v *viper.Viper) {
 	bridgeDBValue, _ := cmd.Flags().GetString(bridgeDBFlag)
-	borChainIDValue, _ := cmd.Flags().GetString(borChainIDFlag)
+	homeValue, _ := cmd.Flags().GetString(helper.HomeFlag)
 
 	// bridge-db directory (default storage)
 	if bridgeDBValue == "" {
 		bridgeDBValue = filepath.Join(homeValue, "bridge", "storage")
 	}
 
-	// set to viper
-	viper.Set(helper.TendermintNodeFlag, tendermintNode)
-	viper.Set(helper.HomeFlag, homeValue)
-	viper.Set(helper.WithHeimdallConfigFlag, withHeimdallConfigValue)
-	viper.Set(bridgeDBFlag, bridgeDBValue)
-	viper.Set(borChainIDFlag, borChainIDValue)
+	v.Set(bridgeDBFlag, bridgeDBValue)
+}
+
+// initTendermintViperConfig sets global viper configuration needed to heimdall
+func initTendermintViperConfig(cmd *cobra.Command) {
+
+	// set appropriate bridge DB
+	AdjustBridgeDBValue(cmd, viper.GetViper())
 
 	// start heimdall config
 	helper.InitHeimdallConfig("")
-}
-
-func init() {
-	var logger = helper.Logger.With("module", "bridge/cmd/")
-	rootCmd.PersistentFlags().StringP(helper.TendermintNodeFlag, "n", helper.DefaultTendermintNode, "Node to connect to")
-	rootCmd.PersistentFlags().String(helper.HomeFlag, helper.DefaultNodeHome, "directory for config and data")
-	rootCmd.PersistentFlags().String(
-		helper.WithHeimdallConfigFlag,
-		"",
-		"Heimdall config file path (default <home>/config/heimdall-config.json)",
-	)
-	// bridge storage db
-	rootCmd.PersistentFlags().String(
-		bridgeDBFlag,
-		"",
-		"Bridge db path (default <home>/bridge/storage)",
-	)
-	// bridge chain id
-	rootCmd.PersistentFlags().String(
-		borChainIDFlag,
-		helper.DefaultBorChainID,
-		"Bor chain id",
-	)
-
-	// bind all flags with viper
-	if err := viper.BindPFlags(rootCmd.Flags()); err != nil {
-		logger.Error("init | BindPFlag | rootCmd.Flags", "Error", err)
-	}
 }

--- a/bridge/cmd/start.go
+++ b/bridge/cmd/start.go
@@ -62,25 +62,23 @@ func StartBridgeWithCtx(shutdownCtx context.Context) error {
 	cliCtx.BroadcastMode = client.BroadcastAsync
 	cliCtx.TrustNode = true
 
+	g := new(errgroup.Group)
 	// start bridge services only when node fully synced
-
 	loop := true
 	for loop {
-
 		select {
 		case <-shutdownCtx.Done():
-			loop = false
+			return nil
 		case <-time.After(waitDuration):
 			if !util.IsCatchingUp(cliCtx) {
 				logger.Info("Node up to date, starting bridge services")
-				loop = true
+				loop = false
 			} else {
 				logger.Info("Waiting for heimdall to be synced")
 			}
 		}
 	}
 
-	g := new(errgroup.Group)
 	// start services
 	for _, service := range services {
 		// loop variable must be captured
@@ -204,7 +202,7 @@ func StartBridge(isStandAlone bool) {
 		time.Sleep(waitDuration)
 	}
 
-	// strt all processes
+	// start all processes
 	for _, service := range services {
 		go func(serv common.Service) {
 			defer wg.Done()

--- a/bridge/cmd/start.go
+++ b/bridge/cmd/start.go
@@ -54,7 +54,8 @@ func StartBridgeWithCtx(shutdownCtx context.Context) error {
 	// Start http client
 	err := _httpClient.Start()
 	if err != nil {
-		panic(fmt.Sprintf("Error connecting to server %v", err))
+		logger.Error("Error connecting to server: %v", err)
+		return err
 	}
 
 	// cli context

--- a/bridge/cmd/start.go
+++ b/bridge/cmd/start.go
@@ -80,6 +80,7 @@ func StartBridgeWithCtx(shutdownCtx context.Context) error {
 	}
 
 	// start services
+	g := new(errgroup.Group)
 	for _, service := range services {
 		// loop variable must be captured
 		srv := service

--- a/bridge/cmd/start.go
+++ b/bridge/cmd/start.go
@@ -62,7 +62,6 @@ func StartBridgeWithCtx(shutdownCtx context.Context) error {
 	cliCtx.BroadcastMode = client.BroadcastAsync
 	cliCtx.TrustNode = true
 
-	g := new(errgroup.Group)
 	// start bridge services only when node fully synced
 	loop := true
 	for loop {

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -264,10 +264,6 @@ which accepts a path for the resulting pprof file.
 	cmd.Flags().String(flagCPUProfile, "", "Enable CPU profiling and write to the provided file")
 	cmd.Flags().String(helper.FlagClientHome, helper.DefaultCLIHome, "client's home directory")
 
-	// Heimdall flags - ADDED WITH REST SERVER
-	//cmd.Flags().String(client.FlagChainID, "", "The chain ID to connect to")
-	//cmd.Flags().String(client.FlagNode, helper.DefaultTendermintNode, "Address of the node to connect to")
-
 	// add support for all Tendermint-specific command line options
 	tcmd.AddNodeFlags(cmd)
 	return cmd

--- a/server/root.go
+++ b/server/root.go
@@ -175,7 +175,7 @@ func startRPCServer(shutdownCtx ctx.Context, listener net.Listener, handler http
 		},
 	}
 
-	g, gCtx := errgroup.WithContext(shutdownCtx)
+	g := new(errgroup.Group)
 	g.Go(func() error {
 		return s.Serve(listener)
 	})
@@ -183,7 +183,7 @@ func startRPCServer(shutdownCtx ctx.Context, listener net.Listener, handler http
 	g.Go(func() error {
 		// wait for interrupt signal comming from mainCtx
 		// and then go to server shutdown
-		<-gCtx.Done()
+		<-shutdownCtx.Done()
 		ctx, cancel := ctx.WithTimeout(ctx.Background(), shutdownTimeout)
 		defer cancel()
 

--- a/server/root.go
+++ b/server/root.go
@@ -87,6 +87,7 @@ func StartRestServer(mainCtx ctx.Context, cdc *codec.Codec, registerRoutesFn fun
 	})
 	// wait here
 	if err := g.Wait(); err != nil {
+		// TODO: cast server errors
 		logger.Error("Cannot start REST server.", "Error", err)
 		return err
 	}
@@ -156,15 +157,13 @@ func startRPCServer(shutdownCtx ctx.Context, listener net.Listener, handler http
 		Handler: http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
-			for {
-				select {
-				case <-ctx.Done():
-					fmt.Println("gracefull handler exit")
-					rw.WriteHeader(http.StatusOK)
-					return
-				default:
-					recoverHandler(rw, r)
-				}
+			select {
+			case <-ctx.Done():
+				fmt.Println("gracefull handler exit")
+				rw.WriteHeader(http.StatusOK)
+				return
+			default:
+				recoverHandler(rw, r)
 			}
 		}),
 		ReadTimeout:    cfg.ReadTimeout,

--- a/server/root.go
+++ b/server/root.go
@@ -1,20 +1,28 @@
 package server
 
 import (
+	ctx "context"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/lcd"
+	"github.com/cosmos/cosmos-sdk/client/context"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	tmLog "github.com/tendermint/tendermint/libs/log"
+	rpcserver "github.com/tendermint/tendermint/rpc/lib/server"
+	rpctypes "github.com/tendermint/tendermint/rpc/lib/types"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/maticnetwork/heimdall/app"
 	tx "github.com/maticnetwork/heimdall/client/tx"
@@ -24,35 +32,183 @@ import (
 	_ "github.com/maticnetwork/heimdall/server/statik"
 )
 
-func StartRestServer(cdc *codec.Codec, registerRoutesFn func(*lcd.RestServer), restCh chan struct{}) error {
-	rs := lcd.NewRestServer(cdc)
-	registerRoutesFn(rs)
+const shutdownTimeout = 10 * time.Second
+
+type options struct {
+	listenAddr   string
+	maxOpen      int
+	readTimeout  uint
+	writeTimeout uint
+}
+
+func StartRestServer(mainCtx ctx.Context, cdc *codec.Codec, registerRoutesFn func(ctx client.CLIContext, mux *mux.Router), restCh chan struct{}) error {
+	// init vars for the Light Client Rest server
+	cliCtx := context.NewCLIContext().WithCodec(cdc)
+	router := mux.NewRouter()
 	logger := tmLog.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "rest-server")
-	go restServerHealthCheck(restCh)
-	err := rs.Start(
-		viper.GetString(client.FlagListenAddr),
-		viper.GetInt(client.FlagMaxOpenConnections),
-		0,
-		0,
-	)
+	registerRoutesFn(cliCtx, router)
+
+	// server configuration
+	cfg := rpcserver.DefaultConfig()
+	cfg.MaxOpenConnections = viper.GetInt(client.FlagMaxOpenConnections)
+	cfg.ReadTimeout = time.Duration(0) * time.Second
+	cfg.WriteTimeout = time.Duration(0) * time.Second
+	listenAddr := viper.GetString(client.FlagListenAddr)
+
+	// this uses net.Listener underneath
+	// which doesn't block, it runs in background
+	// in other means it simply spawns a socket connection in OS level
+	// and returns with the details we use to proxy orders to that socket
+	listener, err := rpcserver.Listen(listenAddr, cfg)
 	if err != nil {
+		// TODO: log here
+		return err
+	}
+	// no err? -> signal here that server is open for business
+	close(restCh)
+
+	logger.Info(
+		fmt.Sprintf(
+			"Starting application REST service (chain-id: %q)...",
+			viper.GetString(flags.FlagChainID),
+		),
+	)
+
+	g, gCtx := errgroup.WithContext(mainCtx)
+	// start serving
+	g.Go(func() error {
+		return startRPCServer(mainCtx, listener, router, logger, cfg)
+	})
+
+	g.Go(func() error {
+		// wait for os interrupt, then close Listener
+		<-gCtx.Done()
+		return listener.Close()
+	})
+	// wait here
+	if err := g.Wait(); err != nil {
 		logger.Error("Cannot start REST server.", "Error", err)
+		return err
 	}
 
-	return err
+	return nil
+}
+
+// this is borrowed from maticnetwork rpcserver
+type maxBytesHandler struct {
+	h http.Handler
+	n int64
+}
+
+func (h maxBytesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, h.n)
+	h.h.ServeHTTP(w, r)
+}
+
+func recoverAndLog(handler http.Handler, logger tmLog.Logger) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Wrap the ResponseWriter to remember the status
+		rww := &rpcserver.ResponseWriterWrapper{-1, w}
+		begin := time.Now()
+
+		rww.Header().Set("X-Server-Time", fmt.Sprintf("%v", begin.Unix()))
+
+		defer func() {
+			// Send a 500 error if a panic happens during a handler.
+			// Without this, Chrome & Firefox were retrying aborted ajax requests,
+			// at least to my localhost.
+			if e := recover(); e != nil {
+
+				// If RPCResponse
+				if res, ok := e.(rpctypes.RPCResponse); ok {
+					rpcserver.WriteRPCResponseHTTP(rww, res)
+				} else {
+					// For the rest,
+					logger.Error(
+						"Panic in RPC HTTP handler", "err", e, "stack",
+						string(debug.Stack()),
+					)
+					rpcserver.WriteRPCResponseHTTPError(rww, http.StatusInternalServerError, rpctypes.RPCInternalError(rpctypes.JSONRPCStringID(""), e.(error)))
+				}
+			}
+
+			// Finally, log.
+			durationMS := time.Since(begin).Nanoseconds() / 1000000
+			if rww.Status == -1 {
+				rww.Status = 200
+			}
+			logger.Info("Served RPC HTTP response",
+				"method", r.Method, "url", r.URL,
+				"status", rww.Status, "duration", durationMS,
+				"remoteAddr", r.RemoteAddr,
+			)
+		}()
+
+		handler.ServeHTTP(rww, r)
+	}
+}
+
+func startRPCServer(shutdownCtx ctx.Context, listener net.Listener, handler http.Handler, logger tmLog.Logger, cfg *rpcserver.Config) error {
+	logger.Info(fmt.Sprintf("Starting RPC HTTP server on %s", listener.Addr()))
+	recoverHandler := recoverAndLog(maxBytesHandler{h: handler, n: cfg.MaxBodyBytes}, logger)
+
+	s := &http.Server{
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			for {
+				select {
+				case <-ctx.Done():
+					fmt.Println("gracefull handler exit")
+					rw.WriteHeader(http.StatusOK)
+					return
+				default:
+					recoverHandler(rw, r)
+				}
+			}
+		}),
+		ReadTimeout:    cfg.ReadTimeout,
+		WriteTimeout:   cfg.WriteTimeout,
+		MaxHeaderBytes: cfg.MaxHeaderBytes,
+		BaseContext: func(_ net.Listener) ctx.Context {
+			return shutdownCtx
+		},
+	}
+
+	g, gCtx := errgroup.WithContext(shutdownCtx)
+	g.Go(func() error {
+		return s.Serve(listener)
+	})
+
+	g.Go(func() error {
+		// wait for interrupt signal comming from mainCtx
+		// and then go to server shutdown
+		<-gCtx.Done()
+		ctx, cancel := ctx.WithTimeout(ctx.Background(), shutdownTimeout)
+		defer cancel()
+
+		return s.Shutdown(ctx)
+	})
+
+	if err := g.Wait(); err != nil {
+		logger.Info("RPC HTTP server stopped", "err", err)
+		return err
+	}
+
+	return nil
 }
 
 // ServeCommands will generate a long-running rest server
 // (aka Light Client Daemon) that exposes functionality similar
 // to the cli, but over rest
-func ServeCommands(cdc *codec.Codec, registerRoutesFn func(*lcd.RestServer)) *cobra.Command {
+func ServeCommands(shutdownCtx ctx.Context, cdc *codec.Codec, registerRoutesFn func(ctx client.CLIContext, mux *mux.Router)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rest-server",
 		Short: "Start LCD (light-client daemon), a local REST server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			helper.InitHeimdallConfig("")
 			restCh := make(chan struct{}, 1)
-			err := StartRestServer(cdc, registerRoutesFn, restCh)
+			err := StartRestServer(shutdownCtx, cdc, registerRoutesFn, restCh)
 			return err
 		},
 	}
@@ -66,11 +222,11 @@ func ServeCommands(cdc *codec.Codec, registerRoutesFn func(*lcd.RestServer)) *co
 }
 
 // RegisterRoutes register routes of all modules
-func RegisterRoutes(rs *lcd.RestServer) {
-	registerSwaggerUI(rs)
+func RegisterRoutes(ctx client.CLIContext, mux *mux.Router) {
+	registerSwaggerUI(mux)
 
-	rpc.RegisterRPCRoutes(rs.CliCtx, rs.Mux)
-	tx.RegisterRoutes(rs.CliCtx, rs.Mux)
+	rpc.RegisterRPCRoutes(ctx, mux)
+	tx.RegisterRoutes(ctx, mux)
 
 	// auth.RegisterRoutes(rs.CliCtx, rs.Mux)
 	// bank.RegisterRoutes(rs.CliCtx, rs.Mux)
@@ -81,7 +237,7 @@ func RegisterRoutes(rs *lcd.RestServer) {
 	// clerk.RegisterRoutes(rs.CliCtx, rs.Mux, rs.Cdc)
 
 	// register rest routes
-	app.ModuleBasics.RegisterRESTRoutes(rs.CliCtx, rs.Mux)
+	app.ModuleBasics.RegisterRESTRoutes(ctx, mux)
 
 	// list all paths
 	// rs.Mux.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
@@ -98,13 +254,13 @@ func RegisterRoutes(rs *lcd.RestServer) {
 	// })
 }
 
-func registerSwaggerUI(rs *lcd.RestServer) {
+func registerSwaggerUI(mux *mux.Router) {
 	statikFS, err := fs.New()
 	if err != nil {
 		panic(err)
 	}
 	staticServer := http.FileServer(statikFS)
-	rs.Mux.PathPrefix("/swagger-ui/").Handler(http.StripPrefix("/swagger-ui/", staticServer))
+	mux.PathPrefix("/swagger-ui/").Handler(http.StripPrefix("/swagger-ui/", staticServer))
 }
 
 // Check locally if rest server port has been opened

--- a/server/root.go
+++ b/server/root.go
@@ -219,9 +219,10 @@ func ServeCommands(shutdownCtx ctx.Context, cdc *codec.Codec, registerRoutesFn f
 func DecorateWithRestFlags(cmd *cobra.Command) {
 	cmd.Flags().String(client.FlagListenAddr, "tcp://0.0.0.0:1317", "The address for the server to listen on")
 	cmd.Flags().Bool(client.FlagTrustNode, true, "Trust connected full node (don't verify proofs for responses)")
+	cmd.Flags().Int(client.FlagMaxOpenConnections, 1000, "The number of maximum open connections")
+	// heimdall specific flags for rest server start
 	cmd.Flags().String(client.FlagChainID, "", "The chain ID to connect to")
 	cmd.Flags().String(client.FlagNode, helper.DefaultTendermintNode, "Address of the node to connect to")
-	cmd.Flags().Int(client.FlagMaxOpenConnections, 1000, "The number of maximum open connections")
 }
 
 // RegisterRoutes register routes of all modules


### PR DESCRIPTION
- Graceful shutdown of Heimdall, REST, and Bridge are all initiated by the same context signaled by the OS on interrupt and program termination
- Necessary code duplications are due to the private functions and types from Cosmos SDK that needed changes to accommodate shutdowns