### PR TITLE
POS 32 Heimdall add seeds into code for mainnet

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -97,6 +97,8 @@ const (
 
 	DefaultMainnetSeeds string = "f4f605d60b8ffaaf15240564e58a81103510631c@159.203.9.164:26656,4fb1bc820088764a564d4f66bba1963d47d82329@44.232.55.71:26656,2eadba4be3ce47ac8db0a3538cb923b57b41c927@35.199.4.13:26656,3b23b20017a6f348d329c102ddc0088f0a10a444@35.221.13.28:26656,25f5f65a09c56e9f1d2d90618aa70cd358aa68da@35.230.116.151:26656"
 
+	DefaultTestnetSeeds string = "4cd60c1d76e44b05f7dfd8bab3f447b119e87042@54.147.31.250:26656,b18bbe1f3d8576f4b73d9b18976e71c65e839149@34.226.134.117:26656"
+
 	secretFilePerm = 0600
 )
 
@@ -737,7 +739,12 @@ func UpdateTendermintConfig(tendermintConfig *cfg.Config, v *viper.Viper) {
 		tendermintConfig.P2P.Seeds = seedsFlagValue
 	}
 
-	if tendermintConfig.P2P.Seeds == "" && conf.Chain == "mainnet" {
-		tendermintConfig.P2P.Seeds = DefaultMainnetSeeds
+	if tendermintConfig.P2P.Seeds == "" {
+		switch conf.Chain {
+		case "mainnet":
+			tendermintConfig.P2P.Seeds = DefaultMainnetSeeds
+		case "mumbai":
+			tendermintConfig.P2P.Seeds = DefaultTestnetSeeds
+		}
 	}
 }

--- a/helper/config_test.go
+++ b/helper/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	cfg "github.com/tendermint/tendermint/config"
 )
 
 //  Test - to check heimdall config
@@ -37,4 +38,41 @@ func TestHeimdallConfigNewSelectionAlgoHeight(t *testing.T) {
 			t.Errorf("Invalid GetNewSelectionAlgoHeight = %d for chain %s", nsah, chain)
 		}
 	}
+}
+
+func TestHeimdallConfigUpdateTendermintConfig(t *testing.T) {
+	type teststruct struct {
+		chain string
+		viper string
+		def   string
+		value string
+	}
+
+	data := []teststruct{
+		{chain: "mumbai", viper: "viper", def: "default", value: "viper"},
+		{chain: "mumbai", viper: "viper", def: "", value: "viper"},
+		{chain: "mumbai", viper: "", def: "default", value: "default"},
+		{chain: "mumbai", viper: "", def: "", value: DefaultTestnetSeeds},
+		{chain: "mainnet", viper: "viper", def: "default", value: "viper"},
+		{chain: "mainnet", viper: "viper", def: "", value: "viper"},
+		{chain: "mainnet", viper: "", def: "default", value: "default"},
+		{chain: "mainnet", viper: "", def: "", value: DefaultMainnetSeeds},
+		{chain: "local", viper: "viper", def: "default", value: "viper"},
+		{chain: "local", viper: "viper", def: "", value: "viper"},
+		{chain: "local", viper: "", def: "default", value: "default"},
+		{chain: "local", viper: "", def: "", value: ""},
+	}
+	oldConf := conf.Chain
+	viperObj := viper.New()
+	tendermintConfig := cfg.DefaultConfig()
+	for _, ts := range data {
+		conf.Chain = ts.chain
+		tendermintConfig.P2P.Seeds = ts.def
+		viperObj.Set(SeedsFlag, ts.viper)
+		UpdateTendermintConfig(tendermintConfig, viperObj)
+		if tendermintConfig.P2P.Seeds != ts.value {
+			t.Errorf("Invalid UpdateTendermintConfig, tendermintConfig.P2P.Seeds not set correctly")
+		}
+	}
+	conf.Chain = oldConf
 }

--- a/server/root.go
+++ b/server/root.go
@@ -266,21 +266,3 @@ func registerSwaggerUI(mux *mux.Router) {
 	staticServer := http.FileServer(statikFS)
 	mux.PathPrefix("/swagger-ui/").Handler(http.StripPrefix("/swagger-ui/", staticServer))
 }
-
-// Check locally if rest server port has been opened
-func restServerHealthCheck(restCh chan struct{}) {
-	address := viper.GetString(client.FlagListenAddr)
-	for {
-		conn, err := net.Dial("tcp", address[6:])
-		if err != nil {
-			time.Sleep(10 * time.Millisecond)
-			continue
-		}
-		if conn != nil {
-			defer conn.Close()
-		}
-
-		close(restCh)
-		break
-	}
-}


### PR DESCRIPTION
As part of the deployment of Heimdall in the PoS mainnet. The users have to use the seed/bootnode files defined in the Polygon docs to start the Heimdall process and connect to the network. This is not very UX friendly.

https://docs.polygon.technology/docs/validate/validate/run-validator-ansible/#configure-the-heimdall-service

Since the seed nodes do not change, this issue proposes to hardcode the values of this nodes inside the binary so that the user can run $ heimdall --chain mainnet and connect immediately to the network.

Otherwise, it would require to create a config file, check the docs to get the specific nodes and run Heimdall with that config. Note that this also make it difficult to run in automatic deployments.

Notes:

- If the user supplies other seed nodes either from flags (POS-17) or in the config file, we should use those seed nodes instead of the predefined ones

- unused function is deleted from server/root.go