### PR TITLE
Two stage build for Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:latest AS builder
 
 ARG HEIMDALL_DIR=/heimdall
 ENV HEIMDALL_DIR=$HEIMDALL_DIR
@@ -12,9 +12,23 @@ COPY . .
 
 RUN make install
 
-COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+# Seconds stage
+FROM alpine:3.15
 
-ENV SHELL /bin/bash
+WORKDIR /app
+COPY --from=builder /go/bin/* /app/
+
+RUN apk add --no-cache --virtual=.build-dependencies wget ca-certificates \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
+    && apk add --no-cache glibc-2.34-r0.apk \
+    && rm glibc-2.34-r0.apk \
+    && apk del .build-dependencies
+
+ENV PATH /app:$PATH
+
+# add volumes
+VOLUME [ "/root/.heimdalld" ]
+
+# expose ports
 EXPOSE 1317 26656 26657
-
-ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
This PR includes modification of `Dockerfile` to apply two stage build.
For running environment, Alpine linux is used and that improves security and reduces image size.

Unfortunately, Alpine linux does not include `glibc` package which is required for running Heimdall.
So `glibc` package is built by manually on second stage.

As a result, docker image size is reduced to 144MB compared to 2GB origin.