### PR TITLE
Ensure `version` command runs on all binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ tests:
 build: clean
 	go run helper/heimdall-params.template.go $(network)
 	mkdir -p build
-	go build -o build/heimdalld ./cmd/heimdalld
-	go build -o build/heimdallcli ./cmd/heimdallcli
-	go build -o build/bridge bridge/bridge.go
+	go build $(BUILD_FLAGS) -o build/heimdalld ./cmd/heimdalld
+	go build $(BUILD_FLAGS) -o build/heimdallcli ./cmd/heimdallcli
+	go build $(BUILD_FLAGS) -o build/bridge bridge/bridge.go
 	@echo "====================================================\n==================Build Successful==================\n===================================================="
 	
 # make install							Will generate for mainnet by default

--- a/bridge/cmd/root.go
+++ b/bridge/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/maticnetwork/heimdall/helper"
+	"github.com/maticnetwork/heimdall/version"
 )
 
 const (
@@ -21,8 +22,10 @@ var rootCmd = &cobra.Command{
 	Use:   "heimdall-bridge",
 	Short: "Heimdall bridge deamon",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// initialize tendermint viper config
-		InitTendermintViperConfig(cmd)
+		if cmd.Use != version.Cmd.Use {
+			// initialize tendermint viper config
+			InitTendermintViperConfig(cmd)
+		}
 	},
 }
 
@@ -61,6 +64,7 @@ func Execute() {
 
 func init() {
 	var logger = helper.Logger.With("module", "bridge/cmd/")
+	rootCmd.AddCommand(version.Cmd)
 	rootCmd.PersistentFlags().StringP(helper.NodeFlag, "n", "tcp://localhost:26657", "Node to connect to")
 	rootCmd.PersistentFlags().String(helper.HomeFlag, os.ExpandEnv("$HOME/.heimdalld"), "directory for config and data")
 	rootCmd.PersistentFlags().String(

--- a/cmd/heimdallcli/main.go
+++ b/cmd/heimdallcli/main.go
@@ -49,8 +49,10 @@ var (
 		Use:   "heimdallcli",
 		Short: "Heimdall light-client",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// initialise config
-			initTendermintViperConfig(cmd)
+			if cmd.Use != version.Cmd.Use {
+				// initialise config
+				initTendermintViperConfig(cmd)
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
This PR ensures that the `version` command can be used with all binaries (`heimdalld`, `heimdallcli` and `bridge`).

One issue was that a config file was required in order to run any command (which is now only required when not running the `version` command).

Another issue was that the `BUILD_FLAGS` weren't passed to the `go build` command.