### PR TITLE
implement rpc timeout using context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install:
 	go install $(BUILD_FLAGS) ./cmd/heimdalld
 	go install $(BUILD_FLAGS) ./cmd/heimdallcli
 	go install $(BUILD_FLAGS) bridge/bridge.go
-	@echo "====================================================\n==================Build For Overriding Spans Successful==================\n===================================================="
+	@echo "====================================================\n==================Build Successful==================\n===================================================="
 
 contracts:
 	abigen --abi=contracts/rootchain/rootchain.abi --pkg=rootchain --out=contracts/rootchain/rootchain.go

--- a/bridge/setu/broadcaster/broadcaster.go
+++ b/bridge/setu/broadcaster/broadcaster.go
@@ -128,8 +128,12 @@ func (tb *TxBroadcaster) BroadcastToMatic(msg bor.CallMsg) error {
 
 	tb.logger.Info("Sending transaction to bor", "txHash", signedTx.Hash())
 
+	// create a context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), helper.GetConfig().BorRPCTimeout)
+	defer cancel()
+
 	// broadcast transaction
-	if err := maticClient.SendTransaction(context.Background(), signedTx); err != nil {
+	if err := maticClient.SendTransaction(ctx, signedTx); err != nil {
 		tb.logger.Error("Error while broadcasting the transaction to maticchain", "error", err)
 		return err
 	}

--- a/bridge/setu/listener/rootchain.go
+++ b/bridge/setu/listener/rootchain.go
@@ -161,7 +161,11 @@ func (rl *RootChainListener) queryAndBroadcastEvents(rootchainContext *RootChain
 		chainParams.StateSenderAddress.EthAddress(),
 	}}
 	// get logs from rootchain by filter
-	logs, err := rl.contractConnector.MainChainClient.FilterLogs(context.Background(), query)
+
+	ethClientTimeout := rl.contractConnector.MainChainTimeout
+	ctx, cancel := context.WithTimeout(context.Background(), ethClientTimeout)
+	defer cancel()
+	logs, err := rl.contractConnector.MainChainClient.FilterLogs(ctx, query)
 	if err != nil {
 		rl.Logger.Error("Error while filtering logs", "error", err)
 		return

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -54,7 +54,7 @@ const (
 
 	TransactionTimeout      = 1 * time.Minute
 	CommitTimeout           = 2 * time.Minute
-	TaskDelayBetweenEachVal = 6 * time.Second
+	TaskDelayBetweenEachVal = 24 * time.Second
 	RetryTaskDelay          = 12 * time.Second
 
 	BridgeDBFlag = "bridge-db"

--- a/checkpoint/client/rest/query.go
+++ b/checkpoint/client/rest/query.go
@@ -365,7 +365,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 		// Get ack count
 		//
 
-		ackcountBytes, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryAckCount), nil)
+		ackcountBytes, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryAckCount), nil)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -410,7 +410,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 		if ok := hmRest.ReturnNotFoundIfNoContent(w, res, "No checkpoint found"); !ok {
 			return
 		}
-
+		cliCtx = cliCtx.WithHeight(height)
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }
@@ -438,7 +438,7 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		// query checkpoint
-		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryCheckpoint), queryParams)
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryCheckpoint), queryParams)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -448,7 +448,7 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 		if ok := hmRest.ReturnNotFoundIfNoContent(w, res, "No checkpoint found"); !ok {
 			return
 		}
-
+		cliCtx = cliCtx.WithHeight(height)
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }
@@ -483,7 +483,7 @@ func checkpointListhandlerFn(
 		}
 
 		// query checkpoint
-		res, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryCheckpointList), queryParams)
+		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryCheckpointList), queryParams)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -493,7 +493,7 @@ func checkpointListhandlerFn(
 		if ok := hmRest.ReturnNotFoundIfNoContent(w, res, "No checkpoints found"); !ok {
 			return
 		}
-
+		cliCtx = cliCtx.WithHeight(height)
 		rest.PostProcessResponse(w, cliCtx, res)
 	}
 }

--- a/helper/config.go
+++ b/helper/config.go
@@ -44,8 +44,13 @@ const (
 	BroadcastAsync = "async"
 	// --
 
+	// RPC Endpoints
 	DefaultMainRPCUrl = "http://localhost:9545"
 	DefaultBorRPCUrl  = "http://localhost:8545"
+
+	// RPC Timeouts
+	DefaultEthRPCTimeout = 5 * time.Second
+	DefaultBorRPCTimeout = 5 * time.Second
 
 	// Services
 
@@ -97,6 +102,9 @@ type Configuration struct {
 	EthRPCUrl        string `mapstructure:"eth_rpc_url"`        // RPC endpoint for main chain
 	BorRPCUrl        string `mapstructure:"bor_rpc_url"`        // RPC endpoint for bor chain
 	TendermintRPCUrl string `mapstructure:"tendermint_rpc_url"` // tendemint node url
+
+	EthRPCTimeout time.Duration `mapstructure:"eth_rpc_timeout"` // timeout for eth rpc
+	BorRPCTimeout time.Duration `mapstructure:"bor_rpc_timeout"` // timeout for bor rpc
 
 	AmqpURL           string `mapstructure:"amqp_url"`             // amqp url
 	HeimdallServerURL string `mapstructure:"heimdall_rest_server"` // heimdall server url
@@ -188,6 +196,19 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFilePath string) {
 		log.Fatalln("Unable to unmarshall config", "Error", err)
 	}
 
+	// perform checks for timeout
+	if conf.EthRPCTimeout == 0 {
+		// fallback to default
+		Logger.Debug("Invalid ETH RPC timeout provided, falling back to default value", "timeout", DefaultEthRPCTimeout)
+		conf.EthRPCTimeout = DefaultEthRPCTimeout
+	}
+
+	if conf.BorRPCTimeout == 0 {
+		// fallback to default
+		Logger.Debug("Invalid BOR RPC timeout provided, falling back to default value", "timeout", DefaultEthRPCTimeout)
+		conf.BorRPCTimeout = DefaultBorRPCTimeout
+	}
+
 	if mainRPCClient, err = rpc.Dial(conf.EthRPCUrl); err != nil {
 		log.Fatalln("Unable to dial via ethClient", "URL=", conf.EthRPCUrl, "chain=eth", "Error", err)
 	}
@@ -221,6 +242,9 @@ func GetDefaultHeimdallConfig() Configuration {
 		EthRPCUrl:        DefaultMainRPCUrl,
 		BorRPCUrl:        DefaultBorRPCUrl,
 		TendermintRPCUrl: DefaultTendermintNodeURL,
+
+		EthRPCTimeout: DefaultEthRPCTimeout,
+		BorRPCTimeout: DefaultBorRPCTimeout,
 
 		AmqpURL:           DefaultAmqpURL,
 		HeimdallServerURL: DefaultHeimdallServerURL,

--- a/mumbai.toml
+++ b/mumbai.toml
@@ -1,2 +1,2 @@
 new_selection_algo_height = 282500
-span_override_height = 10085000
+span_override_height = 10205000


### PR DESCRIPTION
This PR adds timeout to the RPC calls happening to main chain and child chain. It adds 2 new config params named `EthRPCTimeout` and `BorRPCTimeout`, with default time set to 5 seconds. 

Linear: [POS 192: Heimdall get receipt context timeout](https://linear.app/matic/issue/POS-192/heimdall-get-receipt-context-timeout)