### PR TITLE
bridge/setu: add state-sync flag for clerk module

### DIFF
--- a/bridge/cmd/start.go
+++ b/bridge/cmd/start.go
@@ -137,6 +137,13 @@ func GetStartCmd() *cobra.Command {
 	if err := viper.BindPFlag("only", startCmd.Flags().Lookup("only")); err != nil {
 		logger.Error("GetStartCmd | BindPFlag | only", "Error", err)
 	}
+
+	// add a flag to run state-sync processor (clerk module) explicitly
+	startCmd.Flags().Bool("state-sync", false, "start state sync")
+	if err := viper.BindPFlag("state-sync", startCmd.Flags().Lookup("state-sync")); err != nil {
+		logger.Error("GetStartCmd | BindPFlag | state-sync", "Error", err)
+	}
+
 	return startCmd
 }
 

--- a/bridge/setu/processor/service.go
+++ b/bridge/setu/processor/service.go
@@ -82,12 +82,12 @@ func NewProcessorService(
 	// add into processor list
 	startAll := viper.GetBool("all")
 	onlyServices := viper.GetStringSlice("only")
+	stateSync := viper.GetBool("state-sync")
 
 	if startAll {
 		processorService.processors = append(processorService.processors,
 			checkpointProcessor,
 			stakingProcessor,
-			clerkProcessor,
 			feeProcessor,
 			spanProcessor,
 			slashingProcessor,
@@ -99,8 +99,6 @@ func NewProcessorService(
 				processorService.processors = append(processorService.processors, checkpointProcessor)
 			case "staking":
 				processorService.processors = append(processorService.processors, stakingProcessor)
-			case "clerk":
-				processorService.processors = append(processorService.processors, clerkProcessor)
 			case "fee":
 				processorService.processors = append(processorService.processors, feeProcessor)
 			case "span":
@@ -111,8 +109,13 @@ func NewProcessorService(
 		}
 	}
 
+	// Check for state-sync flag
+	if stateSync {
+		processorService.processors = append(processorService.processors, clerkProcessor)
+	}
+
 	if len(processorService.processors) == 0 {
-		panic("No processors selected. Use --all or --only <coma-seprated processors>")
+		panic("No processors selected. Use --all or --only <coma-seprated processors> or --state-sync")
 	}
 
 	return processorService


### PR DESCRIPTION
This PR adds a new `state-sync` flag for the heimdall bridge, which can be used to start the respective processor (clerk). It makes sure that clerk processor is not started by any other means. 

RFC 36: [Add state-sync flag in heimdall bridge](https://www.notion.so/polygontechnology/RFC-36-15fda2ddf69d4ee7803ddfb54126da71)

Linear: POS 276: [Add state-sync flag in heimdall bridge](https://linear.app/matic/issue/POS-276/add-state-sync-flag-for-bridge)