### PR TITLE
bridge/setu: check state sync tx against mempool while broadcast

### DIFF
--- a/bridge/setu/broadcaster/broadcaster_test.go
+++ b/bridge/setu/broadcaster/broadcaster_test.go
@@ -1,6 +1,7 @@
 package broadcaster
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -35,7 +36,7 @@ func TestBroadcastToHeimdall(t *testing.T) {
 	}
 
 	for index, test := range testData {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(fmt.Sprint(index), func(t *testing.T) {
 			// create and send checkpoint message
 			msg := checkpointTypes.NewMsgCheckpointBlock(
 				test.Proposer,
@@ -43,6 +44,7 @@ func TestBroadcastToHeimdall(t *testing.T) {
 				test.EndBlock,
 				test.RootHash,
 				test.AccountRootHash,
+				"1234",
 			)
 
 			err := _txBroadcaster.BroadcastToHeimdall(msg)

--- a/bridge/setu/broadcaster/broadcaster_test.go
+++ b/bridge/setu/broadcaster/broadcaster_test.go
@@ -1,6 +1,10 @@
 package broadcaster
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"testing"
 
@@ -17,7 +21,8 @@ func TestBroadcastToHeimdall(t *testing.T) {
 	t.Parallel()
 	cdc := app.MakeCodec()
 	// cli context
-	tendermintNode := "tcp://localhost:26657"
+
+	tendermintNode := "http://localhost:26657"
 	viper.Set(helper.NodeFlag, tendermintNode)
 	viper.Set("log_level", "info")
 	// cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
@@ -29,13 +34,13 @@ func TestBroadcastToHeimdall(t *testing.T) {
 
 	testData := []checkpointTypes.MsgCheckpoint{
 		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 64, EndBlock: 1024, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 1025, EndBlock: 2048, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 2049, EndBlock: 3124, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
+		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
+		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
+		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
 	}
 
 	for index, test := range testData {
-		t.Run(string(index), func(t *testing.T) {
+		t.Run(string(rune(index)), func(t *testing.T) {
 			// create and send checkpoint message
 			msg := checkpointTypes.NewMsgCheckpointBlock(
 				test.Proposer,
@@ -43,9 +48,50 @@ func TestBroadcastToHeimdall(t *testing.T) {
 				test.EndBlock,
 				test.RootHash,
 				test.AccountRootHash,
+				"1234",
 			)
 
-			err := _txBroadcaster.BroadcastToHeimdall(msg)
+			response, err := http.Get(_txBroadcaster.cliCtx.NodeURI + "/unconfirmed_txs")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			body, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var Response struct {
+				Result struct {
+					Total string   `json:"total"`
+					Txs   []string `json:"txs"`
+				} `json:"result"`
+			}
+
+			err = json.Unmarshal(body, &Response)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(Response.Result.Txs) != 0 {
+				for _, txn := range Response.Result.Txs {
+					txBytes, err := base64.StdEncoding.DecodeString(txn)
+					if err != nil {
+						t.Fatal(err)
+					}
+					decodedTxn, err := helper.GetTxDecoder(cdc)(txBytes)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					txnMsg := decodedTxn.GetMsgs()[0]
+					if txnMsg.Type() == msg.Type() {
+
+					}
+				}
+			}
+
+			err = _txBroadcaster.BroadcastToHeimdall(msg)
 			assert.Empty(t, err, "Error broadcasting tx to heimdall", err)
 		})
 	}

--- a/bridge/setu/broadcaster/broadcaster_test.go
+++ b/bridge/setu/broadcaster/broadcaster_test.go
@@ -1,10 +1,6 @@
 package broadcaster
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"testing"
 
@@ -21,8 +17,7 @@ func TestBroadcastToHeimdall(t *testing.T) {
 	t.Parallel()
 	cdc := app.MakeCodec()
 	// cli context
-
-	tendermintNode := "http://localhost:26657"
+	tendermintNode := "tcp://localhost:26657"
 	viper.Set(helper.NodeFlag, tendermintNode)
 	viper.Set("log_level", "info")
 	// cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
@@ -34,13 +29,13 @@ func TestBroadcastToHeimdall(t *testing.T) {
 
 	testData := []checkpointTypes.MsgCheckpoint{
 		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
+		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 64, EndBlock: 1024, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
+		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 1025, EndBlock: 2048, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
+		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 2049, EndBlock: 3124, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
 	}
 
 	for index, test := range testData {
-		t.Run(string(rune(index)), func(t *testing.T) {
+		t.Run(string(index), func(t *testing.T) {
 			// create and send checkpoint message
 			msg := checkpointTypes.NewMsgCheckpointBlock(
 				test.Proposer,
@@ -48,50 +43,9 @@ func TestBroadcastToHeimdall(t *testing.T) {
 				test.EndBlock,
 				test.RootHash,
 				test.AccountRootHash,
-				"1234",
 			)
 
-			response, err := http.Get(_txBroadcaster.cliCtx.NodeURI + "/unconfirmed_txs")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			body, err := ioutil.ReadAll(response.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			var Response struct {
-				Result struct {
-					Total string   `json:"total"`
-					Txs   []string `json:"txs"`
-				} `json:"result"`
-			}
-
-			err = json.Unmarshal(body, &Response)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if len(Response.Result.Txs) != 0 {
-				for _, txn := range Response.Result.Txs {
-					txBytes, err := base64.StdEncoding.DecodeString(txn)
-					if err != nil {
-						t.Fatal(err)
-					}
-					decodedTxn, err := helper.GetTxDecoder(cdc)(txBytes)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					txnMsg := decodedTxn.GetMsgs()[0]
-					if txnMsg.Type() == msg.Type() {
-
-					}
-				}
-			}
-
-			err = _txBroadcaster.BroadcastToHeimdall(msg)
+			err := _txBroadcaster.BroadcastToHeimdall(msg)
 			assert.Empty(t, err, "Error broadcasting tx to heimdall", err)
 		})
 	}

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -106,7 +106,7 @@ func (bp *BaseProcessor) Stop() {
 
 // isOldTx checks if the transaction already exists in the chain or not
 // It is a generic function, which is consumed in all processors
-func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64, eventType string) (bool, error) {
+func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64, eventType util.BridgeEvent) (bool, error) {
 	queryParam := map[string]interface{}{
 		"txhash":   txHash,
 		"logindex": logIndex,
@@ -115,13 +115,13 @@ func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, lo
 	// define the endpoint based on the type of event
 	var endpoint string
 	switch eventType {
-	case "staking":
+	case util.StakingEvent:
 		endpoint = helper.GetHeimdallServerEndpoint(util.StakingTxStatusURL)
-	case "topup":
+	case util.TopupEvent:
 		endpoint = helper.GetHeimdallServerEndpoint(util.TopupTxStatusURL)
-	case "clerk":
+	case util.ClerkEvent:
 		endpoint = helper.GetHeimdallServerEndpoint(util.ClerkTxStatusURL)
-	case "slashing":
+	case util.SlashingEvent:
 		endpoint = helper.GetHeimdallServerEndpoint(util.SlashingTxStatusURL)
 	}
 	url, err := util.CreateURLWithQuery(endpoint, queryParam)

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -106,13 +106,24 @@ func (bp *BaseProcessor) Stop() {
 
 // isOldTx checks if the transaction already exists in the chain or not
 // It is a generic function, which is consumed in all processors
-func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64) (bool, error) {
+func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64, eventType string) (bool, error) {
 	queryParam := map[string]interface{}{
 		"txhash":   txHash,
 		"logindex": logIndex,
 	}
 
-	endpoint := helper.GetHeimdallServerEndpoint(util.StakingTxStatusURL)
+	// define the endpoint based on the type of event
+	var endpoint string
+	switch eventType {
+	case "staking":
+		endpoint = helper.GetHeimdallServerEndpoint(util.StakingTxStatusURL)
+	case "topup":
+		endpoint = helper.GetHeimdallServerEndpoint(util.TopupTxStatusURL)
+	case "clerk":
+		endpoint = helper.GetHeimdallServerEndpoint(util.ClerkTxStatusURL)
+	case "slashing":
+		endpoint = helper.GetHeimdallServerEndpoint(util.SlashingTxStatusURL)
+	}
 	url, err := util.CreateURLWithQuery(endpoint, queryParam)
 	if err != nil {
 		bp.Logger.Error("Error in creating url", "endpoint", endpoint, "error", err)

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -1,9 +1,16 @@
 package processor
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/types"
+	clerkTypes "github.com/maticnetwork/heimdall/clerk/types"
 	"github.com/spf13/viper"
 	"github.com/syndtr/goleveldb/leveldb"
 
@@ -95,4 +102,113 @@ func (bp *BaseProcessor) String() string {
 // OnStop stops all necessary go routines
 func (bp *BaseProcessor) Stop() {
 	// override to stop any go-routines in individual processors
+}
+
+// isOldTx checks if the transaction already exists in the chain or not
+// It is a generic function, which is consumed in all processors
+func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64) (bool, error) {
+	queryParam := map[string]interface{}{
+		"txhash":   txHash,
+		"logindex": logIndex,
+	}
+
+	endpoint := helper.GetHeimdallServerEndpoint(util.StakingTxStatusURL)
+	url, err := util.CreateURLWithQuery(endpoint, queryParam)
+	if err != nil {
+		bp.Logger.Error("Error in creating url", "endpoint", endpoint, "error", err)
+		return false, err
+	}
+
+	res, err := helper.FetchFromAPI(bp.cliCtx, url)
+	if err != nil {
+		bp.Logger.Error("Error fetching tx status", "url", url, "error", err)
+		return false, err
+	}
+
+	var status bool
+	if err := json.Unmarshal(res.Result, &status); err != nil {
+		bp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
+		return false, err
+	}
+
+	return status, nil
+}
+
+// checkTxAgainstMempool checks if the transaction is already in the mempool or not
+// It is consumed only for `clerk` processor
+func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg) (bool, error) {
+	endpoint := helper.GetConfig().TendermintRPCUrl + "/unconfirmed_txs"
+	resp, err := http.Get(endpoint)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		bp.Logger.Error("Error fetching mempool tx", "url", endpoint, "error", err)
+		return false, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		bp.Logger.Error("Error fetching mempool tx", "error", err)
+		return false, err
+	}
+
+	// a minimal response of the unconfirmed txs
+	var Response struct {
+		Result struct {
+			Total string   `json:"total"`
+			Txs   []string `json:"txs"`
+		} `json:"result"`
+	}
+
+	err = json.Unmarshal(body, &Response)
+	if err != nil {
+		bp.Logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)
+		return false, err
+	}
+
+	// Iterate over txs present in the mempool
+	// We can verify if the message we're about to send is present by
+	// checking the type of transaction, the transaction hash and log index
+	// present in the data of transaction
+
+	status := false
+Loop:
+	for _, txn := range Response.Result.Txs {
+		// Tenderming encodes the transactions with base64 encoding. Decode it first.
+		txBytes, err := base64.StdEncoding.DecodeString(txn)
+		if err != nil {
+			continue
+		}
+
+		// Unmarshal the transaction from bytes
+		decodedTx, err := helper.GetTxDecoder(bp.cliCtx.Codec)(txBytes)
+		if err != nil {
+			continue
+		}
+		txMsg := decodedTx.GetMsgs()[0]
+
+		// We only need to check for `event-record` type transactions.
+		// If required, add case for others here.
+		switch txMsg.Type() {
+		case "event-record":
+			// typecase the txs for clerk type message
+			mempoolTxMsg := txMsg.(clerkTypes.MsgEventRecord)
+			clerkMsg := msg.(clerkTypes.MsgEventRecord)
+
+			// check the transaction hash in message
+			if clerkMsg.GetTxHash() != mempoolTxMsg.GetTxHash() {
+				continue Loop
+			}
+
+			// check the log index in the message
+			if clerkMsg.GetLogIndex() != mempoolTxMsg.GetLogIndex() {
+				continue Loop
+			}
+
+			// If we reach here, there's already a same transaction in the mempool
+			status = true
+			break Loop
+		default:
+			// ignore
+		}
+	}
+
+	return status, nil
 }

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -174,12 +174,14 @@ Loop:
 		// Tendermint encodes the transactions with base64 encoding. Decode it first.
 		txBytes, err := base64.StdEncoding.DecodeString(txn)
 		if err != nil {
+			bp.Logger.Error("Error decoding tx (base64 decoder) while checking against mempool", "error", err)
 			continue
 		}
 
 		// Unmarshal the transaction from bytes
 		decodedTx, err := helper.GetTxDecoder(bp.cliCtx.Codec)(txBytes)
 		if err != nil {
+			bp.Logger.Error("Error decoding tx (tx decoder) while checking against mempool", "error", err)
 			continue
 		}
 		txMsg := decodedTx.GetMsgs()[0]
@@ -192,14 +194,14 @@ Loop:
 			// typecast the txs for clerk type message
 			mempoolTxMsg, ok := txMsg.(clerkTypes.MsgEventRecord)
 			if !ok {
-				bp.Logger.Error("Unable to typecast message to clerk event Record")
+				bp.Logger.Error("Unable to typecast message to clerk event record while checking against mempool")
 				continue Loop
 			}
 
 			// typecast the msg for clerk type message
 			clerkMsg, ok := msg.(clerkTypes.MsgEventRecord)
 			if !ok {
-				bp.Logger.Error("Unable to typecast message to clerk event Record")
+				bp.Logger.Error("Unable to typecast message to clerk event record while checking against mempool")
 				continue Loop
 			}
 

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -161,14 +161,9 @@ func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg) (bool, error) {
 	}
 
 	// a minimal response of the unconfirmed txs
-	var Response struct {
-		Result struct {
-			Total string   `json:"total"`
-			Txs   []string `json:"txs"`
-		} `json:"result"`
-	}
+	var response util.TendermintUnconfirmedTxs
 
-	err = json.Unmarshal(body, &Response)
+	err = json.Unmarshal(body, &response)
 	if err != nil {
 		bp.Logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)
 		return false, err
@@ -181,7 +176,7 @@ func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg) (bool, error) {
 
 	status := false
 Loop:
-	for _, txn := range Response.Result.Txs {
+	for _, txn := range response.Result.Txs {
 		// Tendermint encodes the transactions with base64 encoding. Decode it first.
 		txBytes, err := base64.StdEncoding.DecodeString(txn)
 		if err != nil {

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -118,10 +118,8 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 		// Don't drop the transaction. Keep retrying in 12 seconds, until the transaction
 		// in mempool is processed or cancelled.
 		if inMempool, _ := cp.checkTxAgainstMempool(msg); inMempool {
-			cp.Logger.Info("Similar transaction already in mempool. Retrying after 12 seconds", "event", eventName)
+			cp.Logger.Info("Similar transaction already in mempool, Will retry in sometime", "event", eventName)
 			return tasks.NewErrRetryTaskLater("transaction already in mempool", util.RetryTaskDelay)
-		} else {
-			cp.Logger.Info("Transaction not in mempool. Proceeding to broadcast", "event", eventName)
 		}
 
 		// return broadcast to heimdall

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -69,7 +69,7 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 	if err := helper.UnpackLog(cp.stateSenderAbi, event, eventName, &vLog); err != nil {
 		cp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := cp.isOldTx(cp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "clerk"); isOld {
+		if isOld, _ := cp.isOldTx(cp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.ClerkEvent); isOld {
 			cp.Logger.Info("Ignoring task to send deposit to heimdall as already processed",
 				"event", eventName,
 				"id", event.Id,

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -69,7 +69,7 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 	if err := helper.UnpackLog(cp.stateSenderAbi, event, eventName, &vLog); err != nil {
 		cp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := cp.isOldTx(cp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := cp.isOldTx(cp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "clerk"); isOld {
 			cp.Logger.Info("Ignoring task to send deposit to heimdall as already processed",
 				"event", eventName,
 				"id", event.Id,

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -115,11 +115,11 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 		)
 
 		// Check if we have the same transaction in mempool or not
-		// Don't drop the transaction. Keep retrying in 12 seconds, until the transaction
-		// in mempool is processed or cancelled.
+		// Don't drop the transaction. Keep retrying after `util.RetryStateSyncTaskDelay = 24 seconds`,
+		// until the transaction in mempool is processed or cancelled.
 		if inMempool, _ := cp.checkTxAgainstMempool(msg); inMempool {
-			cp.Logger.Info("Similar transaction already in mempool, Will retry in sometime", "event", eventName)
-			return tasks.NewErrRetryTaskLater("transaction already in mempool", util.RetryTaskDelay)
+			cp.Logger.Info("Similar transaction already in mempool, retrying in sometime", "event", eventName, "retry delay", util.RetryStateSyncTaskDelay)
+			return tasks.NewErrRetryTaskLater("transaction already in mempool", util.RetryStateSyncTaskDelay)
 		}
 
 		// return broadcast to heimdall

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -53,7 +53,7 @@ func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string
 	if err := helper.UnpackLog(fp.stakingInfoAbi, event, eventName, &vLog); err != nil {
 		fp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := fp.isOldTx(fp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := fp.isOldTx(fp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "topup"); isOld {
 			fp.Logger.Info("Ignoring task to send topup to heimdall as already processed",
 				"event", eventName,
 				"user", event.User,

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -3,10 +3,8 @@ package processor
 import (
 	"encoding/json"
 
-	cliContext "github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
-	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/contracts/stakinginfo"
 	"github.com/maticnetwork/heimdall/helper"
 	topupTypes "github.com/maticnetwork/heimdall/topup/types"
@@ -86,33 +84,4 @@ func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string
 		}
 	}
 	return nil
-}
-
-// isOldTx  checks if tx is already processed or not
-func (fp *FeeProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64) (bool, error) {
-	queryParam := map[string]interface{}{
-		"txhash":   txHash,
-		"logindex": logIndex,
-	}
-
-	endpoint := helper.GetHeimdallServerEndpoint(util.TopupTxStatusURL)
-	url, err := util.CreateURLWithQuery(endpoint, queryParam)
-	if err != nil {
-		fp.Logger.Error("Error in creating url", "endpoint", endpoint, "error", err)
-		return false, err
-	}
-
-	res, err := helper.FetchFromAPI(fp.cliCtx, url)
-	if err != nil {
-		fp.Logger.Error("Error fetching tx status", "url", url, "error", err)
-		return false, err
-	}
-
-	var status bool
-	if err := json.Unmarshal(res.Result, &status); err != nil {
-		fp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
-		return false, err
-	}
-
-	return status, nil
 }

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
+	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/contracts/stakinginfo"
 	"github.com/maticnetwork/heimdall/helper"
 	topupTypes "github.com/maticnetwork/heimdall/topup/types"
@@ -53,7 +54,7 @@ func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string
 	if err := helper.UnpackLog(fp.stakingInfoAbi, event, eventName, &vLog); err != nil {
 		fp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := fp.isOldTx(fp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "topup"); isOld {
+		if isOld, _ := fp.isOldTx(fp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.TopupEvent); isOld {
 			fp.Logger.Info("Ignoring task to send topup to heimdall as already processed",
 				"event", eventName,
 				"user", event.User,

--- a/bridge/setu/processor/processor_test.go
+++ b/bridge/setu/processor/processor_test.go
@@ -14,7 +14,7 @@ import (
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
-func TestBroadcaseWhenTxInMempool(t *testing.T) {
+func TestBroadcastWhenTxInMempool(t *testing.T) {
 	t.Parallel()
 	cdc := app.MakeCodec()
 

--- a/bridge/setu/processor/processor_test.go
+++ b/bridge/setu/processor/processor_test.go
@@ -1,0 +1,86 @@
+package processor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/maticnetwork/heimdall/app"
+	"github.com/maticnetwork/heimdall/bridge/setu/broadcaster"
+	"github.com/maticnetwork/heimdall/helper"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	clerkTypes "github.com/maticnetwork/heimdall/clerk/types"
+	hmTypes "github.com/maticnetwork/heimdall/types"
+)
+
+func TestBroadcaseWhenTxInMempool(t *testing.T) {
+	t.Parallel()
+	cdc := app.MakeCodec()
+
+	tendermintNode := "http://localhost:26657"
+	viper.Set(helper.NodeFlag, tendermintNode)
+	viper.Set("log_level", "info")
+
+	helper.InitHeimdallConfig(os.ExpandEnv("$HOME/.heimdalld"))
+	_txBroadcaster := broadcaster.NewTxBroadcaster(cdc)
+
+	defaultMessage := clerkTypes.MsgEventRecord{
+		From:            hmTypes.BytesToHeimdallAddress(helper.GetAddress()),
+		TxHash:          hmTypes.BytesToHeimdallHash([]byte("0xa86a2f8f30d5fab1bb858e572ecf3f24d691276f833f06fc90a745cea20f4fcb")),
+		LogIndex:        71,
+		BlockNumber:     14475337,
+		ContractAddress: hmTypes.BytesToHeimdallAddress([]byte("0x401f6c983ea34274ec46f84d70b31c151321188b")),
+		Data:            []byte{},
+		ID:              1897091,
+		ChainID:         "15001",
+	}
+
+	// adding clerk messages and errors for testing
+	var testData []clerkTypes.MsgEventRecord
+	var expectedStatus []bool
+
+	// keep the first 2 messages same (default)
+	testData = append(testData, defaultMessage)
+	expectedStatus = append(expectedStatus, false) // 1st message should go through as it's unique in mempool
+	testData = append(testData, defaultMessage)
+	expectedStatus = append(expectedStatus, true) // 2nd message should fail, as it's duplicate
+
+	// change the txhash in the 3rd message
+	defaultMessage2 := defaultMessage
+	defaultMessage2.TxHash = hmTypes.BytesToHeimdallHash([]byte("0x8a83aa78a400fe959b44ccf70d926c967af4e451ba630a849b2e1dedc7e30c07"))
+	testData = append(testData, defaultMessage2)
+	expectedStatus = append(expectedStatus, false) // 3rd message should go through as the txhash is different
+
+	// change the log index in the 4th message
+	defaultMessage2 = defaultMessage
+	defaultMessage2.LogIndex = 72
+	testData = append(testData, defaultMessage2)
+	expectedStatus = append(expectedStatus, false) // 4th message should go through as the log index is different
+
+	// create a mock clerk processor
+	contractCaller, err := helper.NewContractCaller()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cp := NewClerkProcessor(&contractCaller.StateSenderABI)
+	cp.BaseProcessor = *NewBaseProcessor(cdc, nil, nil, nil, "clerk", cp)
+
+	for index, tx := range testData {
+		t.Run(string(rune(index)), func(t *testing.T) {
+			inMempool, err := cp.checkTxAgainstMempool(tx)
+			t.Log("Done checking tx against mempool", "in mempool", inMempool)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, inMempool, expectedStatus[index])
+			if !inMempool {
+				t.Log("Tx not in mempool, broadcasting")
+				err = _txBroadcaster.BroadcastToHeimdall(tx)
+				assert.Empty(t, err, "Error broadcasting tx to heimdall", err)
+			} else {
+				t.Log("Tx is already in mempool, not broadcasting")
+			}
+		})
+	}
+}

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	cliContext "github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/common"
@@ -397,31 +396,6 @@ func (sp *SlashingProcessor) validateTickSlashInfo(slashInfoList []*hmTypes.Vali
 	}
 	sp.Logger.Info("SlashingInfoBytes mismatch", "tickSlashInfoBytes", hex.EncodeToString(tickSlashInfoBytes), "slashInfoBytes", slashInfoBytes)
 	return false, errors.New("Validation failed. tickSlashInfoBytes mismatch")
-}
-
-// isOldTx  checks if tx is already processed or not
-func (sp *SlashingProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64) (bool, error) {
-	queryParam := map[string]interface{}{
-		"txhash":   txHash,
-		"logindex": logIndex,
-	}
-
-	endpoint := helper.GetHeimdallServerEndpoint(util.SlashingTxStatusURL)
-	url, err := util.CreateURLWithQuery(endpoint, queryParam)
-
-	res, err := helper.FetchFromAPI(sp.cliCtx, url)
-	if err != nil {
-		sp.Logger.Error("Error fetching tx status", "url", url, "error", err)
-		return false, err
-	}
-
-	var status bool
-	if err := json.Unmarshal(res.Result, &status); err != nil {
-		sp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
-		return false, err
-	}
-
-	return status, nil
 }
 
 //

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -184,7 +184,7 @@ func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes st
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
 
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "slashing"); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.SlashingEvent); isOld {
 			sp.Logger.Info("Ignoring task to send tick ack to heimdall as already processed",
 				"event", eventName,
 				"tickID", event.Nonce,
@@ -234,7 +234,7 @@ func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes str
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
 
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "slashing"); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.SlashingEvent); isOld {
 			sp.Logger.Info("Ignoring sending unjail to heimdall as already processed",
 				"event", eventName,
 				"ValidatorID", event.ValidatorId,

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -184,7 +184,7 @@ func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes st
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
 
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "slashing"); isOld {
 			sp.Logger.Info("Ignoring task to send tick ack to heimdall as already processed",
 				"event", eventName,
 				"tickID", event.Nonce,
@@ -234,7 +234,7 @@ func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes str
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
 
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "slashing"); isOld {
 			sp.Logger.Info("Ignoring sending unjail to heimdall as already processed",
 				"event", eventName,
 				"ValidatorID", event.ValidatorId,

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -73,7 +73,7 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 		if len(signerPubKey) == 64 {
 			signerPubKey = util.AppendPrefix(signerPubKey)
 		}
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
 			sp.Logger.Info("Ignoring task to send validatorjoin to heimdall as already processed",
 				"event", eventName,
 				"validatorID", event.ValidatorId,
@@ -146,7 +146,7 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 	if err := helper.UnpackLog(sp.stakingInfoAbi, event, eventName, &vLog); err != nil {
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
 			sp.Logger.Info("Ignoring task to send unstakeinit to heimdall as already processed",
 				"event", eventName,
 				"validator", event.User,
@@ -216,7 +216,7 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 	if err := helper.UnpackLog(sp.stakingInfoAbi, event, eventName, &vLog); err != nil {
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
 			sp.Logger.Info("Ignoring task to send unstakeinit to heimdall as already processed",
 				"event", eventName,
 				"validatorID", event.ValidatorId,
@@ -287,7 +287,7 @@ func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logByte
 			newSignerPubKey = util.AppendPrefix(newSignerPubKey)
 		}
 
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index)); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
 			sp.Logger.Info("Ignoring task to send unstakeinit to heimdall as already processed",
 				"event", eventName,
 				"validatorID", event.ValidatorId,

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -346,35 +346,6 @@ func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logByte
 	return nil
 }
 
-// isOldTx  checks if tx is already processed or not
-func (sp *StakingProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, logIndex uint64) (bool, error) {
-	queryParam := map[string]interface{}{
-		"txhash":   txHash,
-		"logindex": logIndex,
-	}
-
-	endpoint := helper.GetHeimdallServerEndpoint(util.StakingTxStatusURL)
-	url, err := util.CreateURLWithQuery(endpoint, queryParam)
-	if err != nil {
-		sp.Logger.Error("Error in creating url", "endpoint", endpoint, "error", err)
-		return false, err
-	}
-
-	res, err := helper.FetchFromAPI(sp.cliCtx, url)
-	if err != nil {
-		sp.Logger.Error("Error fetching tx status", "url", url, "error", err)
-		return false, err
-	}
-
-	var status bool
-	if err := json.Unmarshal(res.Result, &status); err != nil {
-		sp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
-		return false, err
-	}
-
-	return status, nil
-}
-
 func (sp *StakingProcessor) checkValidNonce(validatorId uint64, txnNonce uint64) (bool, uint64, error) {
 	currentNonce, currentHeight, err := util.GetValidatorNonce(sp.cliCtx, validatorId)
 	if err != nil {

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -73,7 +73,7 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 		if len(signerPubKey) == 64 {
 			signerPubKey = util.AppendPrefix(signerPubKey)
 		}
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.StakingEvent); isOld {
 			sp.Logger.Info("Ignoring task to send validatorjoin to heimdall as already processed",
 				"event", eventName,
 				"validatorID", event.ValidatorId,
@@ -146,7 +146,7 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 	if err := helper.UnpackLog(sp.stakingInfoAbi, event, eventName, &vLog); err != nil {
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.StakingEvent); isOld {
 			sp.Logger.Info("Ignoring task to send unstakeinit to heimdall as already processed",
 				"event", eventName,
 				"validator", event.User,
@@ -216,7 +216,7 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 	if err := helper.UnpackLog(sp.stakingInfoAbi, event, eventName, &vLog); err != nil {
 		sp.Logger.Error("Error while parsing event", "name", eventName, "error", err)
 	} else {
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.StakingEvent); isOld {
 			sp.Logger.Info("Ignoring task to send unstakeinit to heimdall as already processed",
 				"event", eventName,
 				"validatorID", event.ValidatorId,
@@ -287,7 +287,7 @@ func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logByte
 			newSignerPubKey = util.AppendPrefix(newSignerPubKey)
 		}
 
-		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), "staking"); isOld {
+		if isOld, _ := sp.isOldTx(sp.cliCtx, vLog.TxHash.String(), uint64(vLog.Index), util.StakingEvent); isOld {
 			sp.Logger.Info("Ignoring task to send unstakeinit to heimdall as already processed",
 				"event", eventName,
 				"validatorID", event.ValidatorId,

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -58,6 +58,7 @@ const (
 	CommitTimeout           = 2 * time.Minute
 	TaskDelayBetweenEachVal = 24 * time.Second
 	RetryTaskDelay          = 12 * time.Second
+	RetryStateSyncTaskDelay = 24 * time.Second
 
 	BridgeDBFlag = "bridge-db"
 )

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -28,6 +28,8 @@ import (
 	hmtypes "github.com/maticnetwork/heimdall/types"
 )
 
+type BridgeEvent string
+
 const (
 	AccountDetailsURL       = "/auth/accounts/%v"
 	LastNoAckURL            = "/checkpoints/last-no-ack"
@@ -59,6 +61,12 @@ const (
 	TaskDelayBetweenEachVal = 24 * time.Second
 	RetryTaskDelay          = 12 * time.Second
 	RetryStateSyncTaskDelay = 24 * time.Second
+
+	// Bridge event types
+	StakingEvent  BridgeEvent = "staking"
+	TopupEvent    BridgeEvent = "topup"
+	ClerkEvent    BridgeEvent = "clerk"
+	SlashingEvent BridgeEvent = "slashing"
 
 	BridgeDBFlag = "bridge-db"
 )

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -52,6 +52,8 @@ const (
 	SlashingTxStatusURL     = "/slashing/isoldtx"
 	SlashingTickCountURL    = "/slashing/tick-count"
 
+	TendermintUnconfirmedTxsURL = "/unconfirmed_txs"
+
 	TransactionTimeout      = 1 * time.Minute
 	CommitTimeout           = 2 * time.Minute
 	TaskDelayBetweenEachVal = 6 * time.Second

--- a/bridge/setu/util/types.go
+++ b/bridge/setu/util/types.go
@@ -1,0 +1,8 @@
+package util
+
+type TendermintUnconfirmedTxs struct {
+	Result struct {
+		Total string   `json:"total"`
+		Txs   []string `json:"txs"`
+	} `json:"result"`
+}


### PR DESCRIPTION
This PR tries to achieve multiple things. 
1. It generalises the `isOldTx` function for all processors by moving it to base processor. 
2. Before broadcasting any state-sync transaction, it will also check with all existing transactions in the mempool through the `checkTxAgainstMempool` function in the base processor for duplicate transaction. This function is kept generic to allow enabling this for other transaction types as well. It will retry the same state-sync transaction post some fixed delay, if a transaction in mempool is found.

Checklist before merging
- [x] Code Implementation
- [x] Unit Tests (Checks for mock state-sync event and a single producer/node)
- [x] Testing in a multi-node devnet for real state-sync transactions
    - [x] Does it work for an actual state-sync transaction
    - [x] Does it work well with same state-sync transactions broadcasted by other peers and are lying in mempool
    - [x] Test the retry mechanism for transactions which encounter such condition
- [ ] Testing the same conditions on an internal node on mumbai and mainnet before release 
- [x] Revert changes in `broadcast_test.go`

Linear task
POS-277: [Mempool check for heimdall transactions](https://linear.app/matic/issue/POS-277/mempool-check-for-heimdall-transactions)