### PR TITLE
helper: fix typo of displaying bor rpc timeout instead of eth

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -205,7 +205,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFilePath string) {
 
 	if conf.BorRPCTimeout == 0 {
 		// fallback to default
-		Logger.Debug("Invalid BOR RPC timeout provided, falling back to default value", "timeout", DefaultEthRPCTimeout)
+		Logger.Debug("Invalid BOR RPC timeout provided, falling back to default value", "timeout", DefaultBorRPCTimeout)
 		conf.BorRPCTimeout = DefaultBorRPCTimeout
 	}
 


### PR DESCRIPTION
This PR contains a minor fix while printing the default bor rpc timeout. 