### PR TITLE
[Bug fix] Add --all flag to bridge

### DIFF
--- a/builder/files/heimdalld.service
+++ b/builder/files/heimdalld.service
@@ -8,7 +8,7 @@
   WorkingDirectory=/usr/local/bin
   ExecStart=/usr/local/bin/heimdalld start --home /var/lib/heimdall \
     --chain=mainnet \
-    --bridge \
+    --bridge --all \
     --rest-server
   Type=simple
   User=root


### PR DESCRIPTION
We need to provide flag `--all` to enable all bridge services. Otherwise the cli will fail
immediately.