### PR TITLE
Docker changes for v0.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:latest
 
-ARG HEIMDALL_DIR=/heimdall
+ARG HEIMDALL_DIR=/var/lib/heimdall
 ENV HEIMDALL_DIR=$HEIMDALL_DIR
 
 RUN apt-get update -y && apt-get upgrade -y \
     && apt install build-essential git -y \
-    && mkdir -p /heimdall
+    && mkdir -p $HEIMDALL_DIR
 
-WORKDIR ${HEIMDALL_DIR}
+WORKDIR /heimdall
 COPY . .
 
 RUN make install

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env sh
 
-if [ ! -f $HEIMDALL_DIR/config/heimdall-config.toml ]; then
-    heimdalld --home=$HEIMDALL_DIR init
-fi;
-
-if [ "$1" = 'bridge' ]; then
-    shift
-    exec bridge --home=$HEIMDALL_DIR "$@"
-fi
-
 if [ "$1" = 'heimdallcli' ]; then
     shift
     exec heimdallcli --home=$HEIMDALL_DIR "$@"


### PR DESCRIPTION
Change default heimdall home to `/var/lib/heimdall`. Remove initialization step from entry point since heimdalld is able to initialize configs automatically.