### PR TITLE
Mardizzone/pos 463 create setup to test differences between

### DIFF
--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -61,7 +61,7 @@ const (
 
 	TransactionTimeout      = 1 * time.Minute
 	CommitTimeout           = 2 * time.Minute
-	TaskDelayBetweenEachVal = 24 * time.Second
+	TaskDelayBetweenEachVal = 10 * time.Second
 	RetryTaskDelay          = 12 * time.Second
 	RetryStateSyncTaskDelay = 24 * time.Second
 


### PR DESCRIPTION
Draft PR to reduce timeDelay from 24s to 10s.

Deployed for testing on 
- gcp-validator-node-1(anonymouse-112)
- mainnet-validator/foundation-5
- mainnet-validator/foundation-6
- mainnet-validator/foundation-7

Will analyse the results in a couple of days from now and eventually remove the draft