### PR TITLE
new: dev: pos-620 introduce cache for contracts ABIs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -988,6 +988,7 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/helper/call.go
+++ b/helper/call.go
@@ -847,6 +847,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[RootChainABI] == nil {
 		if contractCallerObj.RootChainABI, err = getABI(rootchain.RootchainABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", RootChainABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[RootChainABI] = &contractCallerObj.RootChainABI
@@ -858,6 +859,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[StakingInfoABI] == nil {
 		if contractCallerObj.StakingInfoABI, err = getABI(stakinginfo.StakinginfoABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", StakingInfoABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[StakingInfoABI] = &contractCallerObj.StakingInfoABI
@@ -869,6 +871,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[ValidatorSetABI] == nil {
 		if contractCallerObj.ValidatorSetABI, err = getABI(validatorset.ValidatorsetABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", ValidatorSetABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[ValidatorSetABI] = &contractCallerObj.ValidatorSetABI
@@ -880,6 +883,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[StateReceiverABI] == nil {
 		if contractCallerObj.StateReceiverABI, err = getABI(statereceiver.StatereceiverABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", StateReceiverABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[StateReceiverABI] = &contractCallerObj.StateReceiverABI
@@ -891,6 +895,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[StateSenderABI] == nil {
 		if contractCallerObj.StateSenderABI, err = getABI(statesender.StatesenderABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", StateSenderABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[StateSenderABI] = &contractCallerObj.StateSenderABI
@@ -902,6 +907,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[StakeManagerABI] == nil {
 		if contractCallerObj.StakeManagerABI, err = getABI(stakemanager.StakemanagerABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", StakeManagerABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[StakeManagerABI] = &contractCallerObj.StakeManagerABI
@@ -913,6 +919,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[SlashManagerABI] == nil {
 		if contractCallerObj.SlashManagerABI, err = getABI(slashmanager.SlashmanagerABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", SlashManagerABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[SlashManagerABI] = &contractCallerObj.SlashManagerABI
@@ -924,6 +931,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 
 	if ContractsABIsMap[MaticTokenABI] == nil {
 		if contractCallerObj.MaticTokenABI, err = getABI(erc20.Erc20ABI); err != nil {
+			Logger.Error("Error while getting ABI for contract caller", "name", MaticTokenABI, "error", err)
 			return
 		} else {
 			ContractsABIsMap[MaticTokenABI] = &contractCallerObj.MaticTokenABI

--- a/helper/call.go
+++ b/helper/call.go
@@ -942,6 +942,7 @@ func populateABIs(contractCallerObj *ContractCaller) error {
 	} else {
 		contractCallerObj.MaticTokenABI = *ContractsABIsMap[MaticTokenABI]
 	}
+
 	return nil
 }
 

--- a/helper/call.go
+++ b/helper/call.go
@@ -142,7 +142,7 @@ func NewContractCaller() (contractCallerObj ContractCaller, err error) {
 	// listeners and processors instance cache (address->ABI)
 	contractCallerObj.ContractInstanceCache = make(map[common.Address]interface{})
 	// package global cache (string->ABI)
-	PopulateABIs(&contractCallerObj)
+	populateABIs(&contractCallerObj)
 
 	return
 }
@@ -838,10 +838,10 @@ func NewLru(size int) (*lru.Cache, error) {
 	return lruObj, nil
 }
 
-// PopulateABIs fills the package level cache for contracts' ABIs
+// populateABIs fills the package level cache for contracts' ABIs
 // It uses ABIs' names instead of contracts addresses, as the latter might not be available at init time
 // This reduces the number of calls to json decode methods made by the contract caller
-func PopulateABIs(contractCallerObj *ContractCaller) {
+func populateABIs(contractCallerObj *ContractCaller) {
 	var err error
 
 	if ContractsABIsMap[RootChainABI] == nil {
@@ -849,7 +849,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[RootChainABI] = &contractCallerObj.RootChainABI
-			Logger.Info("ABI initialized", "name", RootChainABI)
+			Logger.Debug("ABI initialized", "name", RootChainABI)
 		}
 	}
 
@@ -858,7 +858,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[StakingInfoABI] = &contractCallerObj.StakingInfoABI
-			Logger.Info("ABI initialized", "name", StakingInfoABI)
+			Logger.Debug("ABI initialized", "name", StakingInfoABI)
 		}
 	}
 
@@ -867,7 +867,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[ValidatorSetABI] = &contractCallerObj.ValidatorSetABI
-			Logger.Info("ABI initialized", "name", ValidatorSetABI)
+			Logger.Debug("ABI initialized", "name", ValidatorSetABI)
 		}
 	}
 
@@ -876,7 +876,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[StateReceiverABI] = &contractCallerObj.StateReceiverABI
-			Logger.Info("ABI initialized", "name", StateReceiverABI)
+			Logger.Debug("ABI initialized", "name", StateReceiverABI)
 		}
 	}
 
@@ -885,7 +885,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[StateSenderABI] = &contractCallerObj.StateSenderABI
-			Logger.Info("ABI initialized", "name", StateSenderABI)
+			Logger.Debug("ABI initialized", "name", StateSenderABI)
 		}
 	}
 
@@ -894,7 +894,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[StakeManagerABI] = &contractCallerObj.StakeManagerABI
-			Logger.Info("ABI initialized", "name", StakeManagerABI)
+			Logger.Debug("ABI initialized", "name", StakeManagerABI)
 		}
 	}
 
@@ -903,7 +903,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[SlashManagerABI] = &contractCallerObj.SlashManagerABI
-			Logger.Info("ABI initialized", "name", SlashManagerABI)
+			Logger.Debug("ABI initialized", "name", SlashManagerABI)
 		}
 	}
 
@@ -912,7 +912,7 @@ func PopulateABIs(contractCallerObj *ContractCaller) {
 			return
 		} else {
 			ContractsABIsMap[MaticTokenABI] = &contractCallerObj.MaticTokenABI
-			Logger.Info("ABI initialized", "name", MaticTokenABI)
+			Logger.Debug("ABI initialized", "name", MaticTokenABI)
 		}
 	}
 }

--- a/helper/call.go
+++ b/helper/call.go
@@ -497,8 +497,8 @@ func (c *ContractCaller) DecodeNewHeaderBlockEvent(contractAddress common.Addres
 	return event, nil
 }
 
-// DecodeValidatorTopUpFeesEvent represents topUp for fees tokens
-func (c *ContractCaller) DecodeValidatorTopUpFeesEvent(contractAddress common.Address, receipt *ethTypes.Receipt, logIndex uint64) (*stakinginfo.StakinginfoTopUpFee, error) {
+// DecodeValidatorTopupFeesEvent represents topUp for fees tokens
+func (c *ContractCaller) DecodeValidatorTopupFeesEvent(contractAddress common.Address, receipt *ethTypes.Receipt, logIndex uint64) (*stakinginfo.StakinginfoTopUpFee, error) {
 	var (
 		event = new(stakinginfo.StakinginfoTopUpFee)
 		found = false

--- a/helper/call.go
+++ b/helper/call.go
@@ -127,6 +127,7 @@ func NewContractCaller() (contractCallerObj ContractCaller, err error) {
 	contractCallerObj.MainChainRPC = GetMainChainRPCClient()
 	contractCallerObj.MaticChainRPC = GetMaticRPCClient()
 	contractCallerObj.ReceiptCache, err = lru.New(1000)
+
 	if err != nil {
 		return contractCallerObj, err
 	}
@@ -827,8 +828,8 @@ func (c *ContractCaller) GetCheckpointSign(txHash common.Hash) ([]byte, []byte, 
 // This reduces the number of calls to json decode methods made by the contract caller
 // It uses ABIs' definitions instead of contracts addresses, as the latter might not be available at init time
 func populateABIs(contractCallerObj *ContractCaller) error {
-
 	var ccAbi *abi.ABI
+
 	var err error
 
 	contractsABIs := [8]string{rootchain.RootchainABI, stakinginfo.StakinginfoABI, validatorset.ValidatorsetABI,
@@ -842,6 +843,7 @@ func populateABIs(contractCallerObj *ContractCaller) error {
 			Logger.Error("Error while fetching contract caller ABI", "error", err)
 			return err
 		}
+
 		if ContractsABIsMap[contractABI] == nil {
 			// fills cached abi map
 			if *ccAbi, err = getABI(contractABI); err != nil {
@@ -880,6 +882,7 @@ func chooseContractCallerABI(contractCallerObj *ContractCaller, abi string) (*ab
 	case erc20.Erc20ABI:
 		return &contractCallerObj.MaticTokenABI, nil
 	}
+
 	return nil, errors.New("no ABI associated with such data")
 }
 

--- a/helper/call.go
+++ b/helper/call.go
@@ -142,9 +142,11 @@ func NewContractCaller() (contractCallerObj ContractCaller, err error) {
 	// listeners and processors instance cache (address->ABI)
 	contractCallerObj.ContractInstanceCache = make(map[common.Address]interface{})
 	// package global cache (string->ABI)
-	populateABIs(&contractCallerObj)
+	if err = populateABIs(&contractCallerObj); err != nil {
+		return contractCallerObj, err
+	}
 
-	return
+	return contractCallerObj, nil
 }
 
 // GetRootChainInstance returns RootChain contract instance for selected base chain
@@ -842,13 +844,13 @@ func NewLru(size int) (*lru.Cache, error) {
 // When called the first time, ContractsABIsMap will be filled and getABI method won't be invoked the next times
 // This reduces the number of calls to json decode methods made by the contract caller
 // It uses ABIs' names instead of contracts addresses, as the latter might not be available at init time
-func populateABIs(contractCallerObj *ContractCaller) {
+func populateABIs(contractCallerObj *ContractCaller) error {
 	var err error
 
 	if ContractsABIsMap[RootChainABI] == nil {
 		if contractCallerObj.RootChainABI, err = getABI(rootchain.RootchainABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", RootChainABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[RootChainABI] = &contractCallerObj.RootChainABI
 			Logger.Debug("ABI initialized", "name", RootChainABI)
@@ -860,7 +862,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	if ContractsABIsMap[StakingInfoABI] == nil {
 		if contractCallerObj.StakingInfoABI, err = getABI(stakinginfo.StakinginfoABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", StakingInfoABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[StakingInfoABI] = &contractCallerObj.StakingInfoABI
 			Logger.Debug("ABI initialized", "name", StakingInfoABI)
@@ -872,7 +874,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	if ContractsABIsMap[ValidatorSetABI] == nil {
 		if contractCallerObj.ValidatorSetABI, err = getABI(validatorset.ValidatorsetABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", ValidatorSetABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[ValidatorSetABI] = &contractCallerObj.ValidatorSetABI
 			Logger.Debug("ABI initialized", "name", ValidatorSetABI)
@@ -884,7 +886,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	if ContractsABIsMap[StateReceiverABI] == nil {
 		if contractCallerObj.StateReceiverABI, err = getABI(statereceiver.StatereceiverABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", StateReceiverABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[StateReceiverABI] = &contractCallerObj.StateReceiverABI
 			Logger.Debug("ABI initialized", "name", StateReceiverABI)
@@ -896,7 +898,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	if ContractsABIsMap[StateSenderABI] == nil {
 		if contractCallerObj.StateSenderABI, err = getABI(statesender.StatesenderABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", StateSenderABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[StateSenderABI] = &contractCallerObj.StateSenderABI
 			Logger.Debug("ABI initialized", "name", StateSenderABI)
@@ -908,7 +910,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	if ContractsABIsMap[StakeManagerABI] == nil {
 		if contractCallerObj.StakeManagerABI, err = getABI(stakemanager.StakemanagerABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", StakeManagerABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[StakeManagerABI] = &contractCallerObj.StakeManagerABI
 			Logger.Debug("ABI initialized", "name", StakeManagerABI)
@@ -920,7 +922,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	if ContractsABIsMap[SlashManagerABI] == nil {
 		if contractCallerObj.SlashManagerABI, err = getABI(slashmanager.SlashmanagerABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", SlashManagerABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[SlashManagerABI] = &contractCallerObj.SlashManagerABI
 			Logger.Debug("ABI initialized", "name", SlashManagerABI)
@@ -932,7 +934,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	if ContractsABIsMap[MaticTokenABI] == nil {
 		if contractCallerObj.MaticTokenABI, err = getABI(erc20.Erc20ABI); err != nil {
 			Logger.Error("Error while getting ABI for contract caller", "name", MaticTokenABI, "error", err)
-			return
+			return err
 		} else {
 			ContractsABIsMap[MaticTokenABI] = &contractCallerObj.MaticTokenABI
 			Logger.Debug("ABI initialized", "name", MaticTokenABI)
@@ -940,6 +942,7 @@ func populateABIs(contractCallerObj *ContractCaller) {
 	} else {
 		contractCallerObj.MaticTokenABI = *ContractsABIsMap[MaticTokenABI]
 	}
+	return nil
 }
 
 // getABI returns the contract's ABI struct from on its JSON representation

--- a/helper/call.go
+++ b/helper/call.go
@@ -38,7 +38,7 @@ const (
 	MaticTokenABI    = "MaticTokenABI"
 )
 
-//var ContractsABIsMap map[string]*abi.ABI
+// ContractsABIsMap is a cached map holding the ABIs of the contracts
 var ContractsABIsMap = make(map[string]*abi.ABI)
 
 // IContractCaller represents contract caller
@@ -839,8 +839,9 @@ func NewLru(size int) (*lru.Cache, error) {
 }
 
 // populateABIs fills the package level cache for contracts' ABIs
-// It uses ABIs' names instead of contracts addresses, as the latter might not be available at init time
+// When called the first time, ContractsABIsMap will be filled and getABI method won't be invoked the next times
 // This reduces the number of calls to json decode methods made by the contract caller
+// It uses ABIs' names instead of contracts addresses, as the latter might not be available at init time
 func populateABIs(contractCallerObj *ContractCaller) {
 	var err error
 

--- a/helper/call.go
+++ b/helper/call.go
@@ -27,17 +27,6 @@ import (
 	"github.com/maticnetwork/heimdall/types"
 )
 
-const (
-	RootChainABI     = "RootChainABI"
-	StakingInfoABI   = "StakingInfoABI"
-	ValidatorSetABI  = "ValidatorSetABI"
-	StateReceiverABI = "StateReceiverABI"
-	StateSenderABI   = "StateSenderABI"
-	StakeManagerABI  = "StakeManagerABI"
-	SlashManagerABI  = "SlashManagerABI"
-	MaticTokenABI    = "MaticTokenABI"
-)
-
 // ContractsABIsMap is a cached map holding the ABIs of the contracts
 var ContractsABIsMap = make(map[string]*abi.ABI)
 
@@ -49,8 +38,8 @@ type IContractCaller interface {
 	GetLastChildBlock(rootChainInstance *rootchain.Rootchain) (uint64, error)
 	CurrentHeaderBlock(rootChainInstance *rootchain.Rootchain, childBlockInterval uint64) (uint64, error)
 	GetBalance(address common.Address) (*big.Int, error)
-	SendCheckpoint(sigedData []byte, sigs [][3]*big.Int, rootchainAddress common.Address, rootChainInstance *rootchain.Rootchain) (err error)
-	SendTick(sigedData []byte, sigs []byte, slashManagerAddress common.Address, slashManagerInstance *slashmanager.Slashmanager) (err error)
+	SendCheckpoint(signedData []byte, sigs [][3]*big.Int, rootChainAddress common.Address, rootChainInstance *rootchain.Rootchain) (err error)
+	SendTick(signedData []byte, sigs []byte, slashManagerAddress common.Address, slashManagerInstance *slashmanager.Slashmanager) (err error)
 	GetCheckpointSign(txHash common.Hash) ([]byte, []byte, []byte, error)
 	GetMainChainBlock(*big.Int) (*ethTypes.Header, error)
 	GetMaticChainBlock(*big.Int) (*ethTypes.Header, error)
@@ -80,12 +69,12 @@ type IContractCaller interface {
 	CurrentAccountStateRoot(stakingInfoInstance *stakinginfo.Stakinginfo) ([32]byte, error)
 
 	// bor related contracts
-	CurrentSpanNumber(validatorset *validatorset.Validatorset) (Number *big.Int)
-	GetSpanDetails(id *big.Int, validatorset *validatorset.Validatorset) (*big.Int, *big.Int, *big.Int, error)
+	CurrentSpanNumber(validatorSet *validatorset.Validatorset) (Number *big.Int)
+	GetSpanDetails(id *big.Int, validatorSet *validatorset.Validatorset) (*big.Int, *big.Int, *big.Int, error)
 	CurrentStateCounter(stateSenderInstance *statesender.Statesender) (Number *big.Int)
 	CheckIfBlocksExist(end uint64) bool
 
-	GetRootChainInstance(rootchainAddress common.Address) (*rootchain.Rootchain, error)
+	GetRootChainInstance(rootChainAddress common.Address) (*rootchain.Rootchain, error)
 	GetStakingInfoInstance(stakingInfoAddress common.Address) (*stakinginfo.Stakinginfo, error)
 	GetValidatorSetInstance(validatorSetAddress common.Address) (*validatorset.Validatorset, error)
 	GetStakeManagerInstance(stakingManagerAddress common.Address) (*stakemanager.Stakemanager, error)
@@ -137,7 +126,10 @@ func NewContractCaller() (contractCallerObj ContractCaller, err error) {
 	contractCallerObj.MaticChainTimeout = config.BorRPCTimeout
 	contractCallerObj.MainChainRPC = GetMainChainRPCClient()
 	contractCallerObj.MaticChainRPC = GetMaticRPCClient()
-	contractCallerObj.ReceiptCache, _ = NewLru(1000)
+	contractCallerObj.ReceiptCache, err = lru.New(1000)
+	if err != nil {
+		return contractCallerObj, err
+	}
 
 	// listeners and processors instance cache (address->ABI)
 	contractCallerObj.ContractInstanceCache = make(map[common.Address]interface{})
@@ -150,11 +142,11 @@ func NewContractCaller() (contractCallerObj ContractCaller, err error) {
 }
 
 // GetRootChainInstance returns RootChain contract instance for selected base chain
-func (c *ContractCaller) GetRootChainInstance(rootchainAddress common.Address) (*rootchain.Rootchain, error) {
-	contractInstance, ok := c.ContractInstanceCache[rootchainAddress]
+func (c *ContractCaller) GetRootChainInstance(rootChainAddress common.Address) (*rootchain.Rootchain, error) {
+	contractInstance, ok := c.ContractInstanceCache[rootChainAddress]
 	if !ok {
-		ci, err := rootchain.NewRootchain(rootchainAddress, mainChainClient)
-		c.ContractInstanceCache[rootchainAddress] = ci
+		ci, err := rootchain.NewRootchain(rootChainAddress, mainChainClient)
+		c.ContractInstanceCache[rootChainAddress] = ci
 
 		return ci, err
 	}
@@ -162,7 +154,7 @@ func (c *ContractCaller) GetRootChainInstance(rootchainAddress common.Address) (
 	return contractInstance.(*rootchain.Rootchain), nil
 }
 
-// GetStakingInfoInstance returns stakinginfo contract instance for selected base chain
+// GetStakingInfoInstance returns stakingInfo contract instance for selected base chain
 func (c *ContractCaller) GetStakingInfoInstance(stakingInfoAddress common.Address) (*stakinginfo.Stakinginfo, error) {
 	contractInstance, ok := c.ContractInstanceCache[stakingInfoAddress]
 	if !ok {
@@ -175,7 +167,7 @@ func (c *ContractCaller) GetStakingInfoInstance(stakingInfoAddress common.Addres
 	return contractInstance.(*stakinginfo.Stakinginfo), nil
 }
 
-// GetValidatorSetInstance returns stakinginfo contract instance for selected base chain
+// GetValidatorSetInstance returns stakingInfo contract instance for selected base chain
 func (c *ContractCaller) GetValidatorSetInstance(validatorSetAddress common.Address) (*validatorset.Validatorset, error) {
 	contractInstance, ok := c.ContractInstanceCache[validatorSetAddress]
 	if !ok {
@@ -188,7 +180,7 @@ func (c *ContractCaller) GetValidatorSetInstance(validatorSetAddress common.Addr
 	return contractInstance.(*validatorset.Validatorset), nil
 }
 
-// GetStakeManagerInstance returns stakinginfo contract instance for selected base chain
+// GetStakeManagerInstance returns stakingInfo contract instance for selected base chain
 func (c *ContractCaller) GetStakeManagerInstance(stakingManagerAddress common.Address) (*stakemanager.Stakemanager, error) {
 	contractInstance, ok := c.ContractInstanceCache[stakingManagerAddress]
 	if !ok {
@@ -214,7 +206,7 @@ func (c *ContractCaller) GetSlashManagerInstance(slashManagerAddress common.Addr
 	return contractInstance.(*slashmanager.Slashmanager), nil
 }
 
-// GetStateSenderInstance returns stakinginfo contract instance for selected base chain
+// GetStateSenderInstance returns stakingInfo contract instance for selected base chain
 func (c *ContractCaller) GetStateSenderInstance(stateSenderAddress common.Address) (*statesender.Statesender, error) {
 	contractInstance, ok := c.ContractInstanceCache[stateSenderAddress]
 	if !ok {
@@ -227,7 +219,7 @@ func (c *ContractCaller) GetStateSenderInstance(stateSenderAddress common.Addres
 	return contractInstance.(*statesender.Statesender), nil
 }
 
-// GetStateReceiverInstance returns stakinginfo contract instance for selected base chain
+// GetStateReceiverInstance returns stakingInfo contract instance for selected base chain
 func (c *ContractCaller) GetStateReceiverInstance(stateReceiverAddress common.Address) (*statereceiver.Statereceiver, error) {
 	contractInstance, ok := c.ContractInstanceCache[stateReceiverAddress]
 	if !ok {
@@ -240,7 +232,7 @@ func (c *ContractCaller) GetStateReceiverInstance(stateReceiverAddress common.Ad
 	return contractInstance.(*statereceiver.Statereceiver), nil
 }
 
-// GetMaticTokenInstance returns stakinginfo contract instance for selected base chain
+// GetMaticTokenInstance returns stakingInfo contract instance for selected base chain
 func (c *ContractCaller) GetMaticTokenInstance(maticTokenAddress common.Address) (*erc20.Erc20, error) {
 	contractInstance, ok := c.ContractInstanceCache[maticTokenAddress]
 	if !ok {
@@ -262,12 +254,12 @@ func (c *ContractCaller) GetHeaderInfo(number uint64, rootChainInstance *rootcha
 	proposer types.HeimdallAddress,
 	err error,
 ) {
-	// get header from rootchain
+	// get header from rootChain
 	checkpointBigInt := big.NewInt(0).Mul(big.NewInt(0).SetUint64(number), big.NewInt(0).SetUint64(childBlockInterval))
 
 	headerBlock, err := rootChainInstance.HeaderBlocks(nil, checkpointBigInt)
 	if err != nil {
-		return root, start, end, createdAt, proposer, errors.New("Unable to fetch checkpoint block")
+		return root, start, end, createdAt, proposer, errors.New("unable to fetch checkpoint block")
 	}
 
 	return headerBlock.Root,
@@ -295,7 +287,7 @@ func (c *ContractCaller) GetRootHash(start uint64, end uint64, checkpointLength 
 
 	rootHash, err := c.MaticChainClient.GetRootHash(ctx, start, end)
 	if err != nil {
-		return nil, errors.New("Could not fetch roothash from matic chain")
+		return nil, errors.New("could not fetch rootHash from matic chain")
 	}
 
 	return common.FromHex(rootHash), nil
@@ -305,7 +297,7 @@ func (c *ContractCaller) GetRootHash(start uint64, end uint64, checkpointLength 
 func (c *ContractCaller) GetLastChildBlock(rootChainInstance *rootchain.Rootchain) (uint64, error) {
 	GetLastChildBlock, err := rootChainInstance.GetLastChildBlock(nil)
 	if err != nil {
-		Logger.Error("Could not fetch current child block from rootchain contract", "error", err)
+		Logger.Error("Could not fetch current child block from rootChain contract", "error", err)
 		return 0, err
 	}
 
@@ -316,7 +308,7 @@ func (c *ContractCaller) GetLastChildBlock(rootChainInstance *rootchain.Rootchai
 func (c *ContractCaller) CurrentHeaderBlock(rootChainInstance *rootchain.Rootchain, childBlockInterval uint64) (uint64, error) {
 	currentHeaderBlock, err := rootChainInstance.CurrentHeaderBlock(nil)
 	if err != nil {
-		Logger.Error("Could not fetch current header block from rootchain contract", "error", err)
+		Logger.Error("Could not fetch current header block from rootChain contract", "error", err)
 		return 0, err
 	}
 
@@ -413,7 +405,7 @@ func (c *ContractCaller) GetBlockNumberFromTxHash(tx common.Hash) (*big.Int, err
 	}
 
 	if rpcTx.BlockNumber == nil {
-		return nil, errors.New("No tx found")
+		return nil, errors.New("no tx found")
 	}
 
 	blkNum := big.NewInt(0)
@@ -448,7 +440,7 @@ func (c *ContractCaller) GetConfirmedTxReceipt(tx common.Hash, requiredConfirmat
 		// get main tx receipt
 		receipt, err = c.GetMainTxReceipt(tx)
 		if err != nil {
-			Logger.Error("Error while fetching mainchain receipt", "txHash", tx.Hex(), "error", err)
+			Logger.Error("Error while fetching mainChain receipt", "txHash", tx.Hex(), "error", err)
 			return nil, err
 		}
 
@@ -470,7 +462,7 @@ func (c *ContractCaller) GetConfirmedTxReceipt(tx common.Hash, requiredConfirmat
 
 	diff := latestBlk.Number.Uint64() - receipt.BlockNumber.Uint64()
 	if diff < requiredConfirmations {
-		return nil, errors.New("Not enough confirmations")
+		return nil, errors.New("not enough confirmations")
 	}
 
 	return receipt, nil
@@ -499,14 +491,14 @@ func (c *ContractCaller) DecodeNewHeaderBlockEvent(contractAddress common.Addres
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
 }
 
-// DecodeValidatorTopupFeesEvent represents topup for fees tokens
-func (c *ContractCaller) DecodeValidatorTopupFeesEvent(contractAddress common.Address, receipt *ethTypes.Receipt, logIndex uint64) (*stakinginfo.StakinginfoTopUpFee, error) {
+// DecodeValidatorTopUpFeesEvent represents topUp for fees tokens
+func (c *ContractCaller) DecodeValidatorTopUpFeesEvent(contractAddress common.Address, receipt *ethTypes.Receipt, logIndex uint64) (*stakinginfo.StakinginfoTopUpFee, error) {
 	var (
 		event = new(stakinginfo.StakinginfoTopUpFee)
 		found = false
@@ -525,7 +517,7 @@ func (c *ContractCaller) DecodeValidatorTopupFeesEvent(contractAddress common.Ad
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
@@ -550,7 +542,7 @@ func (c *ContractCaller) DecodeValidatorJoinEvent(contractAddress common.Address
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
@@ -576,13 +568,13 @@ func (c *ContractCaller) DecodeValidatorStakeUpdateEvent(contractAddress common.
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
 }
 
-// DecodeValidatorExitEvent represents validator stake unstake event
+// DecodeValidatorExitEvent represents validator stake unStake event
 func (c *ContractCaller) DecodeValidatorExitEvent(contractAddress common.Address, receipt *ethTypes.Receipt, logIndex uint64) (*stakinginfo.StakinginfoUnstakeInit, error) {
 	var (
 		event = new(stakinginfo.StakinginfoUnstakeInit)
@@ -593,7 +585,7 @@ func (c *ContractCaller) DecodeValidatorExitEvent(contractAddress common.Address
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "UnstakeInit", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, "unStakeInit", vLog); err != nil {
 				return nil, err
 			}
 
@@ -602,7 +594,7 @@ func (c *ContractCaller) DecodeValidatorExitEvent(contractAddress common.Address
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
@@ -628,7 +620,7 @@ func (c *ContractCaller) DecodeSignerUpdateEvent(contractAddress common.Address,
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
@@ -654,7 +646,7 @@ func (c *ContractCaller) DecodeStateSyncedEvent(contractAddress common.Address, 
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
@@ -682,13 +674,13 @@ func (c *ContractCaller) DecodeSlashedEvent(contractAddress common.Address, rece
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
 }
 
-// DecodeUnJailedEvent represents unjail on contract
+// DecodeUnJailedEvent represents unJail on contract
 func (c *ContractCaller) DecodeUnJailedEvent(contractAddress common.Address, receipt *ethTypes.Receipt, logIndex uint64) (*stakinginfo.StakinginfoUnJailed, error) {
 	var (
 		event = new(stakinginfo.StakinginfoUnJailed)
@@ -708,7 +700,7 @@ func (c *ContractCaller) DecodeUnJailedEvent(contractAddress common.Address, rec
 	}
 
 	if !found {
-		return nil, errors.New("Event not found")
+		return nil, errors.New("event not found")
 	}
 
 	return event, nil
@@ -723,7 +715,7 @@ func (c *ContractCaller) CurrentAccountStateRoot(stakingInfoInstance *stakinginf
 	accountStateRoot, err := stakingInfoInstance.GetAccountStateRoot(nil)
 
 	if err != nil {
-		Logger.Error("Unable to get current account state roor", "error", err)
+		Logger.Error("Unable to get current account state root", "error", err)
 
 		var emptyArr [32]byte
 
@@ -807,7 +799,7 @@ func (c *ContractCaller) getTxReceipt(ctx context.Context, client *ethclient.Cli
 	return client.TransactionReceipt(ctx, txHash)
 }
 
-// GetCheckpointSign returns sigs input of committed checkpoint tranasction
+// GetCheckpointSign returns sigs input of committed checkpoint transaction
 func (c *ContractCaller) GetCheckpointSign(txHash common.Hash) ([]byte, []byte, []byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.MainChainTimeout)
 	defer cancel()
@@ -819,131 +811,76 @@ func (c *ContractCaller) GetCheckpointSign(txHash common.Hash) ([]byte, []byte, 
 		Logger.Error("Error while Fetching Transaction By hash from MainChain", "error", err)
 		return []byte{}, []byte{}, []byte{}, err
 	} else if isPending {
-		return []byte{}, []byte{}, []byte{}, errors.New("Transaction is still pending")
+		return []byte{}, []byte{}, []byte{}, errors.New("transaction is still pending")
 	}
 
 	payload := transaction.Data()
-	abi := c.RootChainABI
+	chainABI := c.RootChainABI
 
-	return UnpackSigAndVotes(payload, abi)
+	return UnpackSigAndVotes(payload, chainABI)
 }
 
 // utility and helper methods
 
-// NewLru create instance of lru
-func NewLru(size int) (*lru.Cache, error) {
-	lruObj, err := lru.New(size)
-	if err != nil {
-		return nil, err
-	}
-
-	return lruObj, nil
-}
-
 // populateABIs fills the package level cache for contracts' ABIs
 // When called the first time, ContractsABIsMap will be filled and getABI method won't be invoked the next times
 // This reduces the number of calls to json decode methods made by the contract caller
-// It uses ABIs' names instead of contracts addresses, as the latter might not be available at init time
+// It uses ABIs' definitions instead of contracts addresses, as the latter might not be available at init time
 func populateABIs(contractCallerObj *ContractCaller) error {
+
+	var ccAbi *abi.ABI
 	var err error
 
-	if ContractsABIsMap[RootChainABI] == nil {
-		if contractCallerObj.RootChainABI, err = getABI(rootchain.RootchainABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", RootChainABI, "error", err)
-			return err
-		} else {
-			ContractsABIsMap[RootChainABI] = &contractCallerObj.RootChainABI
-			Logger.Debug("ABI initialized", "name", RootChainABI)
-		}
-	} else {
-		contractCallerObj.RootChainABI = *ContractsABIsMap[RootChainABI]
-	}
+	contractsABIs := [8]string{rootchain.RootchainABI, stakinginfo.StakinginfoABI, validatorset.ValidatorsetABI,
+		statereceiver.StatereceiverABI, statesender.StatesenderABI, stakemanager.StakemanagerABI,
+		slashmanager.SlashmanagerABI, erc20.Erc20ABI}
 
-	if ContractsABIsMap[StakingInfoABI] == nil {
-		if contractCallerObj.StakingInfoABI, err = getABI(stakinginfo.StakinginfoABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", StakingInfoABI, "error", err)
+	// iterate over supported ABIs
+	for _, contractABI := range contractsABIs {
+		ccAbi, err = chooseContractCallerABI(contractCallerObj, contractABI)
+		if err != nil {
+			Logger.Error("Error while fetching contract caller ABI", "error", err)
 			return err
-		} else {
-			ContractsABIsMap[StakingInfoABI] = &contractCallerObj.StakingInfoABI
-			Logger.Debug("ABI initialized", "name", StakingInfoABI)
 		}
-	} else {
-		contractCallerObj.StakingInfoABI = *ContractsABIsMap[StakingInfoABI]
-	}
-
-	if ContractsABIsMap[ValidatorSetABI] == nil {
-		if contractCallerObj.ValidatorSetABI, err = getABI(validatorset.ValidatorsetABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", ValidatorSetABI, "error", err)
-			return err
+		if ContractsABIsMap[contractABI] == nil {
+			// fills cached abi map
+			if *ccAbi, err = getABI(contractABI); err != nil {
+				Logger.Error("Error while getting ABI for contract caller", "name", contractABI, "error", err)
+				return err
+			} else {
+				ContractsABIsMap[contractABI] = ccAbi
+				Logger.Debug("ABI initialized", "name", contractABI)
+			}
 		} else {
-			ContractsABIsMap[ValidatorSetABI] = &contractCallerObj.ValidatorSetABI
-			Logger.Debug("ABI initialized", "name", ValidatorSetABI)
+			// use cached abi
+			*ccAbi = *ContractsABIsMap[contractABI]
 		}
-	} else {
-		contractCallerObj.ValidatorSetABI = *ContractsABIsMap[ValidatorSetABI]
-	}
-
-	if ContractsABIsMap[StateReceiverABI] == nil {
-		if contractCallerObj.StateReceiverABI, err = getABI(statereceiver.StatereceiverABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", StateReceiverABI, "error", err)
-			return err
-		} else {
-			ContractsABIsMap[StateReceiverABI] = &contractCallerObj.StateReceiverABI
-			Logger.Debug("ABI initialized", "name", StateReceiverABI)
-		}
-	} else {
-		contractCallerObj.StateReceiverABI = *ContractsABIsMap[StateReceiverABI]
-	}
-
-	if ContractsABIsMap[StateSenderABI] == nil {
-		if contractCallerObj.StateSenderABI, err = getABI(statesender.StatesenderABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", StateSenderABI, "error", err)
-			return err
-		} else {
-			ContractsABIsMap[StateSenderABI] = &contractCallerObj.StateSenderABI
-			Logger.Debug("ABI initialized", "name", StateSenderABI)
-		}
-	} else {
-		contractCallerObj.StateSenderABI = *ContractsABIsMap[StateSenderABI]
-	}
-
-	if ContractsABIsMap[StakeManagerABI] == nil {
-		if contractCallerObj.StakeManagerABI, err = getABI(stakemanager.StakemanagerABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", StakeManagerABI, "error", err)
-			return err
-		} else {
-			ContractsABIsMap[StakeManagerABI] = &contractCallerObj.StakeManagerABI
-			Logger.Debug("ABI initialized", "name", StakeManagerABI)
-		}
-	} else {
-		contractCallerObj.StakeManagerABI = *ContractsABIsMap[StakeManagerABI]
-	}
-
-	if ContractsABIsMap[SlashManagerABI] == nil {
-		if contractCallerObj.SlashManagerABI, err = getABI(slashmanager.SlashmanagerABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", SlashManagerABI, "error", err)
-			return err
-		} else {
-			ContractsABIsMap[SlashManagerABI] = &contractCallerObj.SlashManagerABI
-			Logger.Debug("ABI initialized", "name", SlashManagerABI)
-		}
-	} else {
-		contractCallerObj.SlashManagerABI = *ContractsABIsMap[SlashManagerABI]
-	}
-
-	if ContractsABIsMap[MaticTokenABI] == nil {
-		if contractCallerObj.MaticTokenABI, err = getABI(erc20.Erc20ABI); err != nil {
-			Logger.Error("Error while getting ABI for contract caller", "name", MaticTokenABI, "error", err)
-			return err
-		} else {
-			ContractsABIsMap[MaticTokenABI] = &contractCallerObj.MaticTokenABI
-			Logger.Debug("ABI initialized", "name", MaticTokenABI)
-		}
-	} else {
-		contractCallerObj.MaticTokenABI = *ContractsABIsMap[MaticTokenABI]
 	}
 
 	return nil
+}
+
+// chooseContractCallerABI extracts and returns the abo.ABI object from the contractCallerObj based on its abi string
+func chooseContractCallerABI(contractCallerObj *ContractCaller, abi string) (*abi.ABI, error) {
+	switch abi {
+	case rootchain.RootchainABI:
+		return &contractCallerObj.RootChainABI, nil
+	case stakinginfo.StakinginfoABI:
+		return &contractCallerObj.StakingInfoABI, nil
+	case validatorset.ValidatorsetABI:
+		return &contractCallerObj.ValidatorSetABI, nil
+	case statereceiver.StatereceiverABI:
+		return &contractCallerObj.StateReceiverABI, nil
+	case statesender.StatesenderABI:
+		return &contractCallerObj.StateSenderABI, nil
+	case stakemanager.StakemanagerABI:
+		return &contractCallerObj.StakeManagerABI, nil
+	case slashmanager.SlashmanagerABI:
+		return &contractCallerObj.SlashManagerABI, nil
+	case erc20.Erc20ABI:
+		return &contractCallerObj.MaticTokenABI, nil
+	}
+	return nil, errors.New("no ABI associated with such data")
 }
 
 // getABI returns the contract's ABI struct from on its JSON representation

--- a/helper/call.go
+++ b/helper/call.go
@@ -851,6 +851,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[RootChainABI] = &contractCallerObj.RootChainABI
 			Logger.Debug("ABI initialized", "name", RootChainABI)
 		}
+	} else {
+		contractCallerObj.RootChainABI = *ContractsABIsMap[RootChainABI]
 	}
 
 	if ContractsABIsMap[StakingInfoABI] == nil {
@@ -860,6 +862,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[StakingInfoABI] = &contractCallerObj.StakingInfoABI
 			Logger.Debug("ABI initialized", "name", StakingInfoABI)
 		}
+	} else {
+		contractCallerObj.StakingInfoABI = *ContractsABIsMap[StakingInfoABI]
 	}
 
 	if ContractsABIsMap[ValidatorSetABI] == nil {
@@ -869,6 +873,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[ValidatorSetABI] = &contractCallerObj.ValidatorSetABI
 			Logger.Debug("ABI initialized", "name", ValidatorSetABI)
 		}
+	} else {
+		contractCallerObj.ValidatorSetABI = *ContractsABIsMap[ValidatorSetABI]
 	}
 
 	if ContractsABIsMap[StateReceiverABI] == nil {
@@ -878,6 +884,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[StateReceiverABI] = &contractCallerObj.StateReceiverABI
 			Logger.Debug("ABI initialized", "name", StateReceiverABI)
 		}
+	} else {
+		contractCallerObj.StateReceiverABI = *ContractsABIsMap[StateReceiverABI]
 	}
 
 	if ContractsABIsMap[StateSenderABI] == nil {
@@ -887,6 +895,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[StateSenderABI] = &contractCallerObj.StateSenderABI
 			Logger.Debug("ABI initialized", "name", StateSenderABI)
 		}
+	} else {
+		contractCallerObj.StateSenderABI = *ContractsABIsMap[StateSenderABI]
 	}
 
 	if ContractsABIsMap[StakeManagerABI] == nil {
@@ -896,6 +906,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[StakeManagerABI] = &contractCallerObj.StakeManagerABI
 			Logger.Debug("ABI initialized", "name", StakeManagerABI)
 		}
+	} else {
+		contractCallerObj.StakeManagerABI = *ContractsABIsMap[StakeManagerABI]
 	}
 
 	if ContractsABIsMap[SlashManagerABI] == nil {
@@ -905,6 +917,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[SlashManagerABI] = &contractCallerObj.SlashManagerABI
 			Logger.Debug("ABI initialized", "name", SlashManagerABI)
 		}
+	} else {
+		contractCallerObj.SlashManagerABI = *ContractsABIsMap[SlashManagerABI]
 	}
 
 	if ContractsABIsMap[MaticTokenABI] == nil {
@@ -914,6 +928,8 @@ func populateABIs(contractCallerObj *ContractCaller) {
 			ContractsABIsMap[MaticTokenABI] = &contractCallerObj.MaticTokenABI
 			Logger.Debug("ABI initialized", "name", MaticTokenABI)
 		}
+	} else {
+		contractCallerObj.MaticTokenABI = *ContractsABIsMap[MaticTokenABI]
 	}
 }
 

--- a/helper/call_test.go
+++ b/helper/call_test.go
@@ -2,13 +2,20 @@ package helper
 
 import (
 	"encoding/hex"
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/maticnetwork/bor/common"
 	authTypes "github.com/maticnetwork/heimdall/auth/types"
+	"github.com/maticnetwork/heimdall/contracts/erc20"
+	"github.com/maticnetwork/heimdall/contracts/rootchain"
+	"github.com/maticnetwork/heimdall/contracts/slashmanager"
+	"github.com/maticnetwork/heimdall/contracts/stakemanager"
+	"github.com/maticnetwork/heimdall/contracts/stakinginfo"
+	"github.com/maticnetwork/heimdall/contracts/statereceiver"
+	"github.com/maticnetwork/heimdall/contracts/statesender"
 	"github.com/maticnetwork/heimdall/types"
+
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +34,7 @@ func TestCheckpointSigs(t *testing.T) {
 
 	contractCallerObj, err := NewContractCaller()
 	if err != nil {
-		fmt.Println("Error creating contract caller")
+		t.Error("Error creating contract caller")
 	}
 
 	txHashStr := "0x9c2a9e20e1fecdae538f72b01dd0fd5008cc90176fd603b92b59274d754cbbd8"
@@ -35,17 +42,17 @@ func TestCheckpointSigs(t *testing.T) {
 
 	voteSignBytes, sigs, txData, err := contractCallerObj.GetCheckpointSign(txHash)
 	if err != nil {
-		fmt.Println("Error fetching checkpoint tx input args")
+		t.Error("Error fetching checkpoint tx input args")
 	}
 
-	fmt.Println("checkpoint args", "vote", hex.EncodeToString(voteSignBytes), "sigs", hex.EncodeToString(sigs), "txData", hex.EncodeToString(txData))
+	t.Log("checkpoint args", "vote", hex.EncodeToString(voteSignBytes), "sigs", hex.EncodeToString(sigs), "txData", hex.EncodeToString(txData))
 
 	signerList, err := FetchSigners(voteSignBytes, sigs)
 	if err != nil {
-		fmt.Println("Error fetching signer list from tx input args")
+		t.Error("Error fetching signer list from tx input args")
 	}
 
-	fmt.Println("signers list", signerList)
+	t.Log("signers list", signerList)
 }
 
 // FetchSigners fetches the signers' list
@@ -60,7 +67,6 @@ func FetchSigners(voteBytes []byte, sigInput []byte) ([]string, error) {
 
 		pKey, err := authTypes.RecoverPubkey(voteBytes, signature)
 		if err != nil {
-			fmt.Println("Error Recovering PubKey", "Error", err)
 			return nil, err
 		}
 
@@ -79,81 +85,81 @@ func TestPopulateABIs(t *testing.T) {
 	viper.Set("log_level", "info")
 	InitHeimdallConfig(os.ExpandEnv("$HOME/.heimdalld"))
 
-	fmt.Println("ABIs map should be empty and all ABIs not found")
+	t.Log("ABIs map should be empty and all ABIs not found")
 	assert.True(t, len(ContractsABIsMap) == 0)
-	_, found := ContractsABIsMap[RootChainABI]
+	_, found := ContractsABIsMap[rootchain.RootchainABI]
 	assert.False(t, found)
-	_, found = ContractsABIsMap[StakingInfoABI]
+	_, found = ContractsABIsMap[stakinginfo.StakinginfoABI]
 	assert.False(t, found)
-	_, found = ContractsABIsMap[StateReceiverABI]
+	_, found = ContractsABIsMap[statereceiver.StatereceiverABI]
 	assert.False(t, found)
-	_, found = ContractsABIsMap[StateSenderABI]
+	_, found = ContractsABIsMap[statesender.StatesenderABI]
 	assert.False(t, found)
-	_, found = ContractsABIsMap[StakeManagerABI]
+	_, found = ContractsABIsMap[stakemanager.StakemanagerABI]
 	assert.False(t, found)
-	_, found = ContractsABIsMap[SlashManagerABI]
+	_, found = ContractsABIsMap[slashmanager.SlashmanagerABI]
 	assert.False(t, found)
-	_, found = ContractsABIsMap[MaticTokenABI]
+	_, found = ContractsABIsMap[erc20.Erc20ABI]
 	assert.False(t, found)
 
-	fmt.Println("Should create a new contract caller and populate its ABIs by decoding json")
+	t.Log("Should create a new contract caller and populate its ABIs by decoding json")
 
 	contractCallerObjFirst, err := NewContractCaller()
 	if err != nil {
-		fmt.Println("Error creating contract caller")
+		t.Error("Error creating contract caller")
 	}
 
-	assert.Equalf(t, ContractsABIsMap[RootChainABI], &contractCallerObjFirst.RootChainABI,
-		"values for %s not equals", RootChainABI)
-	assert.Equalf(t, ContractsABIsMap[StakingInfoABI], &contractCallerObjFirst.StakingInfoABI,
-		"values for %s not equals", StakingInfoABI)
-	assert.Equalf(t, ContractsABIsMap[StateReceiverABI], &contractCallerObjFirst.StateReceiverABI,
-		"values for %s not equals", StateReceiverABI)
-	assert.Equalf(t, ContractsABIsMap[StateSenderABI], &contractCallerObjFirst.StateSenderABI,
-		"values for %s not equals", StateSenderABI)
-	assert.Equalf(t, ContractsABIsMap[StakeManagerABI], &contractCallerObjFirst.StakeManagerABI,
-		"values for %s not equals", StakeManagerABI)
-	assert.Equalf(t, ContractsABIsMap[SlashManagerABI], &contractCallerObjFirst.SlashManagerABI,
-		"values for %s not equals", SlashManagerABI)
-	assert.Equalf(t, ContractsABIsMap[MaticTokenABI], &contractCallerObjFirst.MaticTokenABI,
-		"values for %s not equals", MaticTokenABI)
+	assert.Equalf(t, ContractsABIsMap[rootchain.RootchainABI], &contractCallerObjFirst.RootChainABI,
+		"values for %s not equals", rootchain.RootchainABI)
+	assert.Equalf(t, ContractsABIsMap[stakinginfo.StakinginfoABI], &contractCallerObjFirst.StakingInfoABI,
+		"values for %s not equals", stakinginfo.StakinginfoABI)
+	assert.Equalf(t, ContractsABIsMap[statereceiver.StatereceiverABI], &contractCallerObjFirst.StateReceiverABI,
+		"values for %s not equals", statereceiver.StatereceiverABI)
+	assert.Equalf(t, ContractsABIsMap[statesender.StatesenderABI], &contractCallerObjFirst.StateSenderABI,
+		"values for %s not equals", statesender.StatesenderABI)
+	assert.Equalf(t, ContractsABIsMap[stakemanager.StakemanagerABI], &contractCallerObjFirst.StakeManagerABI,
+		"values for %s not equals", stakemanager.StakemanagerABI)
+	assert.Equalf(t, ContractsABIsMap[slashmanager.SlashmanagerABI], &contractCallerObjFirst.SlashManagerABI,
+		"values for %s not equals", slashmanager.SlashmanagerABI)
+	assert.Equalf(t, ContractsABIsMap[erc20.Erc20ABI], &contractCallerObjFirst.MaticTokenABI,
+		"values for %s not equals", erc20.Erc20ABI)
 
-	fmt.Println("ABIs map should not be empty and all ABIs found")
+	t.Log("ABIs map should not be empty and all ABIs found")
 	assert.True(t, len(ContractsABIsMap) == 8)
-	_, found = ContractsABIsMap[RootChainABI]
+	_, found = ContractsABIsMap[rootchain.RootchainABI]
 	assert.True(t, found)
-	_, found = ContractsABIsMap[StakingInfoABI]
+	_, found = ContractsABIsMap[stakinginfo.StakinginfoABI]
 	assert.True(t, found)
-	_, found = ContractsABIsMap[StateReceiverABI]
+	_, found = ContractsABIsMap[statereceiver.StatereceiverABI]
 	assert.True(t, found)
-	_, found = ContractsABIsMap[StateSenderABI]
+	_, found = ContractsABIsMap[statesender.StatesenderABI]
 	assert.True(t, found)
-	_, found = ContractsABIsMap[StakeManagerABI]
+	_, found = ContractsABIsMap[stakemanager.StakemanagerABI]
 	assert.True(t, found)
-	_, found = ContractsABIsMap[SlashManagerABI]
+	_, found = ContractsABIsMap[slashmanager.SlashmanagerABI]
 	assert.True(t, found)
-	_, found = ContractsABIsMap[MaticTokenABI]
+	_, found = ContractsABIsMap[erc20.Erc20ABI]
 	assert.True(t, found)
 
-	fmt.Println("Should create a new contract caller and populate its ABIs by using cached map")
+	t.Log("Should create a new contract caller and populate its ABIs by using cached map")
 
 	contractCallerObjSecond, err := NewContractCaller()
 	if err != nil {
-		fmt.Println("Error creating contract caller")
+		t.Log("Error creating contract caller")
 	}
 
-	assert.Equalf(t, ContractsABIsMap[RootChainABI], &contractCallerObjSecond.RootChainABI,
-		"values for %s not equals", RootChainABI)
-	assert.Equalf(t, ContractsABIsMap[StakingInfoABI], &contractCallerObjSecond.StakingInfoABI,
-		"values for %s not equals", StakingInfoABI)
-	assert.Equalf(t, ContractsABIsMap[StateReceiverABI], &contractCallerObjSecond.StateReceiverABI,
-		"values for %s not equals", StateReceiverABI)
-	assert.Equalf(t, ContractsABIsMap[StateSenderABI], &contractCallerObjSecond.StateSenderABI,
-		"values for %s not equals", StateSenderABI)
-	assert.Equalf(t, ContractsABIsMap[StakeManagerABI], &contractCallerObjSecond.StakeManagerABI,
-		"values for %s not equals", StakeManagerABI)
-	assert.Equalf(t, ContractsABIsMap[SlashManagerABI], &contractCallerObjSecond.SlashManagerABI,
-		"values for %s not equals", SlashManagerABI)
-	assert.Equalf(t, ContractsABIsMap[MaticTokenABI], &contractCallerObjSecond.MaticTokenABI,
-		"values for %s not equals", MaticTokenABI)
+	assert.Equalf(t, ContractsABIsMap[rootchain.RootchainABI], &contractCallerObjSecond.RootChainABI,
+		"values for %s not equals", rootchain.RootchainABI)
+	assert.Equalf(t, ContractsABIsMap[stakinginfo.StakinginfoABI], &contractCallerObjSecond.StakingInfoABI,
+		"values for %s not equals", stakinginfo.StakinginfoABI)
+	assert.Equalf(t, ContractsABIsMap[statereceiver.StatereceiverABI], &contractCallerObjSecond.StateReceiverABI,
+		"values for %s not equals", statereceiver.StatereceiverABI)
+	assert.Equalf(t, ContractsABIsMap[statesender.StatesenderABI], &contractCallerObjSecond.StateSenderABI,
+		"values for %s not equals", statesender.StatesenderABI)
+	assert.Equalf(t, ContractsABIsMap[stakemanager.StakemanagerABI], &contractCallerObjSecond.StakeManagerABI,
+		"values for %s not equals", stakemanager.StakemanagerABI)
+	assert.Equalf(t, ContractsABIsMap[slashmanager.SlashmanagerABI], &contractCallerObjSecond.SlashManagerABI,
+		"values for %s not equals", slashmanager.SlashmanagerABI)
+	assert.Equalf(t, ContractsABIsMap[erc20.Erc20ABI], &contractCallerObjSecond.MaticTokenABI,
+		"values for %s not equals", erc20.Erc20ABI)
 }

--- a/helper/call_test.go
+++ b/helper/call_test.go
@@ -94,6 +94,7 @@ func TestPopulateABIs(t *testing.T) {
 	_, found = ContractsABIsMap[SlashManagerABI]
 	assert.False(t, found)
 	_, found = ContractsABIsMap[MaticTokenABI]
+	assert.False(t, found)
 
 	fmt.Println("Should create a new contract caller and populate its ABIs by decoding json")
 
@@ -132,6 +133,7 @@ func TestPopulateABIs(t *testing.T) {
 	_, found = ContractsABIsMap[SlashManagerABI]
 	assert.True(t, found)
 	_, found = ContractsABIsMap[MaticTokenABI]
+	assert.True(t, found)
 
 	fmt.Println("Should create a new contract caller and populate its ABIs by using cached map")
 
@@ -139,14 +141,6 @@ func TestPopulateABIs(t *testing.T) {
 	if err != nil {
 		fmt.Println("Error creating contract caller")
 	}
-
-	//assert.Emptyf(t, &contractCallerObjSecond.RootChainABI, "contract caller %s not empty", RootChainABI)
-	//assert.Emptyf(t, &contractCallerObjSecond.StakingInfoABI, "contract caller %s not empty", StakingInfoABI)
-	//assert.Emptyf(t, &contractCallerObjSecond.StateReceiverABI, "contract caller %s not empty", StateReceiverABI)
-	//assert.Emptyf(t, &contractCallerObjSecond.StateSenderABI, "contract caller %s not empty", StateSenderABI)
-	//assert.Emptyf(t, &contractCallerObjSecond.StakeManagerABI, "contract caller %s not empty", StakeManagerABI)
-	//assert.Emptyf(t, &contractCallerObjSecond.SlashManagerABI, "contract caller %s not empty", SlashManagerABI)
-	//assert.Emptyf(t, &contractCallerObjSecond.MaticTokenABI, "contract caller %s not empty", MaticTokenABI)
 
 	assert.Equalf(t, ContractsABIsMap[RootChainABI], &contractCallerObjSecond.RootChainABI,
 		"values for %s not equals", RootChainABI)

--- a/helper/call_test.go
+++ b/helper/call_test.go
@@ -79,7 +79,21 @@ func TestPopulateABIs(t *testing.T) {
 	viper.Set("log_level", "info")
 	InitHeimdallConfig(os.ExpandEnv("$HOME/.heimdalld"))
 
+	fmt.Println("ABIs map should be empty and all ABIs not found")
 	assert.True(t, len(ContractsABIsMap) == 0)
+	_, found := ContractsABIsMap[RootChainABI]
+	assert.False(t, found)
+	_, found = ContractsABIsMap[StakingInfoABI]
+	assert.False(t, found)
+	_, found = ContractsABIsMap[StateReceiverABI]
+	assert.False(t, found)
+	_, found = ContractsABIsMap[StateSenderABI]
+	assert.False(t, found)
+	_, found = ContractsABIsMap[StakeManagerABI]
+	assert.False(t, found)
+	_, found = ContractsABIsMap[SlashManagerABI]
+	assert.False(t, found)
+	_, found = ContractsABIsMap[MaticTokenABI]
 
 	fmt.Println("Should create a new contract caller and populate its ABIs by decoding json")
 
@@ -103,6 +117,22 @@ func TestPopulateABIs(t *testing.T) {
 	assert.Equalf(t, ContractsABIsMap[MaticTokenABI], &contractCallerObjFirst.MaticTokenABI,
 		"values for %s not equals", MaticTokenABI)
 
+	fmt.Println("ABIs map should not be empty and all ABIs found")
+	assert.True(t, len(ContractsABIsMap) == 8)
+	_, found = ContractsABIsMap[RootChainABI]
+	assert.True(t, found)
+	_, found = ContractsABIsMap[StakingInfoABI]
+	assert.True(t, found)
+	_, found = ContractsABIsMap[StateReceiverABI]
+	assert.True(t, found)
+	_, found = ContractsABIsMap[StateSenderABI]
+	assert.True(t, found)
+	_, found = ContractsABIsMap[StakeManagerABI]
+	assert.True(t, found)
+	_, found = ContractsABIsMap[SlashManagerABI]
+	assert.True(t, found)
+	_, found = ContractsABIsMap[MaticTokenABI]
+
 	fmt.Println("Should create a new contract caller and populate its ABIs by using cached map")
 
 	contractCallerObjSecond, err := NewContractCaller()
@@ -110,11 +140,27 @@ func TestPopulateABIs(t *testing.T) {
 		fmt.Println("Error creating contract caller")
 	}
 
-	assert.Emptyf(t, &contractCallerObjSecond.RootChainABI, "contract caller %s not empty", RootChainABI)
-	assert.Emptyf(t, &contractCallerObjSecond.StakingInfoABI, "contract caller %s not empty", StakingInfoABI)
-	assert.Emptyf(t, &contractCallerObjSecond.StateReceiverABI, "contract caller %s not empty", StateReceiverABI)
-	assert.Emptyf(t, &contractCallerObjSecond.StateSenderABI, "contract caller %s not empty", StateSenderABI)
-	assert.Emptyf(t, &contractCallerObjSecond.StakeManagerABI, "contract caller %s not empty", StakeManagerABI)
-	assert.Emptyf(t, &contractCallerObjSecond.SlashManagerABI, "contract caller %s not empty", SlashManagerABI)
-	assert.Emptyf(t, &contractCallerObjSecond.MaticTokenABI, "contract caller %s not empty", MaticTokenABI)
+	//assert.Emptyf(t, &contractCallerObjSecond.RootChainABI, "contract caller %s not empty", RootChainABI)
+	//assert.Emptyf(t, &contractCallerObjSecond.StakingInfoABI, "contract caller %s not empty", StakingInfoABI)
+	//assert.Emptyf(t, &contractCallerObjSecond.StateReceiverABI, "contract caller %s not empty", StateReceiverABI)
+	//assert.Emptyf(t, &contractCallerObjSecond.StateSenderABI, "contract caller %s not empty", StateSenderABI)
+	//assert.Emptyf(t, &contractCallerObjSecond.StakeManagerABI, "contract caller %s not empty", StakeManagerABI)
+	//assert.Emptyf(t, &contractCallerObjSecond.SlashManagerABI, "contract caller %s not empty", SlashManagerABI)
+	//assert.Emptyf(t, &contractCallerObjSecond.MaticTokenABI, "contract caller %s not empty", MaticTokenABI)
+
+	assert.Equalf(t, ContractsABIsMap[RootChainABI], &contractCallerObjSecond.RootChainABI,
+		"values for %s not equals", RootChainABI)
+	assert.Equalf(t, ContractsABIsMap[StakingInfoABI], &contractCallerObjSecond.StakingInfoABI,
+		"values for %s not equals", StakingInfoABI)
+	assert.Equalf(t, ContractsABIsMap[StateReceiverABI], &contractCallerObjSecond.StateReceiverABI,
+		"values for %s not equals", StateReceiverABI)
+	assert.Equalf(t, ContractsABIsMap[StateSenderABI], &contractCallerObjSecond.StateSenderABI,
+		"values for %s not equals", StateSenderABI)
+	assert.Equalf(t, ContractsABIsMap[StakeManagerABI], &contractCallerObjSecond.StakeManagerABI,
+		"values for %s not equals", StakeManagerABI)
+	assert.Equalf(t, ContractsABIsMap[SlashManagerABI], &contractCallerObjSecond.SlashManagerABI,
+		"values for %s not equals", SlashManagerABI)
+	assert.Equalf(t, ContractsABIsMap[MaticTokenABI], &contractCallerObjSecond.MaticTokenABI,
+		"values for %s not equals", MaticTokenABI)
+
 }

--- a/helper/call_test.go
+++ b/helper/call_test.go
@@ -156,5 +156,4 @@ func TestPopulateABIs(t *testing.T) {
 		"values for %s not equals", SlashManagerABI)
 	assert.Equalf(t, ContractsABIsMap[MaticTokenABI], &contractCallerObjSecond.MaticTokenABI,
 		"values for %s not equals", MaticTokenABI)
-
 }


### PR DESCRIPTION
This PR optimise the `helper.NewContractCaller` method. This method has been identified as one of the most consuming during cpu and memory profiling, because of the massive usage of `getABI` function and its underlying json decoding.

By introducing a package level cache map of ABIs, the method will not use json decoding features after the first time `NewContractCaller` has been called, and the map has been initialised.
Unit test has been provided to prove the cache works as expected.

Benchmark results without cache:
```
# go test -run=XXX -bench=.

goos: darwin
goarch: amd64
pkg: github.com/maticnetwork/heimdall/bridge/setu/processor
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz

BenchmarkSendStateSyncedToHeimdall-12    4741   248158 ns/op   49238 B/op   497 allocs/op
BenchmarkIsOldTx-12                     21034    55521 ns/op   10829 B/op    70 allocs/op
BenchmarkSendTaskWithDelay-12            6002   235112 ns/op    6922 B/op    97 allocs/op
BenchmarkCalculateTaskDelay-12           5157   251163 ns/op   87223 B/op   473 allocs/op
BenchmarkGetUnconfirmedTxnCount-12      23643    49690 ns/op    8169 B/op    54 allocs/op
```

Benchmark results with cache:
```
# go test -run=XXX -bench=.

goos: darwin
goarch: amd64
pkg: github.com/maticnetwork/heimdall/bridge/setu/processor
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz

BenchmarkSendStateSyncedToHeimdall-12    5644   227676 ns/op   48926 B/op   497 allocs/op
BenchmarkIsOldTx-12                     43140    29809 ns/op   10793 B/op    70 allocs/op
BenchmarkSendTaskWithDelay-12            9776   135342 ns/op    6539 B/op    96 allocs/op
BenchmarkCalculateTaskDelay-12           5446   218444 ns/op   87044 B/op   473 allocs/op
BenchmarkGetUnconfirmedTxnCount-12       54327   23923 ns/op    8138 B/op    54 allocs/op
```


Most important are the profiling results for the `helper.NewContractCaller` function.
These can be obtained by using `pprof` with/without caching ABIs

Cumulative CPU usage obtained by `pprof`.
Without cache: `38.35%  github.com/maticnetwork/heimdall/helper.NewContractCaller`
With cache:  not reported, << 0.5%
Cumulative memory usage obtained by `pprof`.
Without cache: `92.62%  github.com/maticnetwork/heimdall/helper.NewContractCaller`
With cache: `1.63%  github.com/maticnetwork/heimdall/helper.NewContractCaller`

