### PR TITLE
new: dev: pos-621 replace encoding/json with jsoniter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -503,7 +503,7 @@ func (app *HeimdallApp) Name() string { return app.BaseApp.Name() }
 func (app *HeimdallApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	var genesisState GenesisState
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)

--- a/app/app.go
+++ b/app/app.go
@@ -502,7 +502,8 @@ func (app *HeimdallApp) Name() string { return app.BaseApp.Name() }
 // InitChainer initializes chain
 func (app *HeimdallApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	var genesisState GenesisState
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)

--- a/app/app.go
+++ b/app/app.go
@@ -503,7 +503,7 @@ func (app *HeimdallApp) Name() string { return app.BaseApp.Name() }
 func (app *HeimdallApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	var genesisState GenesisState
 
-	if err := jsoniter.ConfigFastest.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
+	if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -1,13 +1,13 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
 
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
@@ -174,8 +174,8 @@ func (d ModuleCommunicator) SendCoins(ctx sdk.Context, fromAddr types.HeimdallAd
 	return d.App.BankKeeper.SendCoins(ctx, fromAddr, toAddr, amt)
 }
 
-// Create ValidatorSigningInfo used by slashing module
-func (d ModuleCommunicator) CreateValiatorSigningInfo(ctx sdk.Context, valID types.ValidatorID, valSigningInfo types.ValidatorSigningInfo) {
+// CreateValidatorSigningInfo used by slashing module
+func (d ModuleCommunicator) CreateValidatorSigningInfo(ctx sdk.Context, valID types.ValidatorID, valSigningInfo types.ValidatorSigningInfo) {
 	d.App.SlashingKeeper.SetValidatorSigningInfo(ctx, valID, valSigningInfo)
 }
 
@@ -502,6 +502,8 @@ func (app *HeimdallApp) Name() string { return app.BaseApp.Name() }
 // InitChainer initializes chain
 func (app *HeimdallApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	var genesisState GenesisState
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -503,9 +503,7 @@ func (app *HeimdallApp) Name() string { return app.BaseApp.Name() }
 func (app *HeimdallApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	var genesisState GenesisState
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -503,7 +503,7 @@ func (app *HeimdallApp) Name() string { return app.BaseApp.Name() }
 func (app *HeimdallApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.ResponseInitChain {
 	var genesisState GenesisState
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if err := json.Unmarshal(req.AppStateBytes, &genesisState); err != nil {
 		panic(err)

--- a/app/export.go
+++ b/app/export.go
@@ -19,7 +19,7 @@ func (app *HeimdallApp) ExportAppStateAndValidators() (
 	result := app.mm.ExportGenesis(ctx)
 
 	// create app state
-	appState, err = jsoniter.ConfigFastest.Marshal(result)
+	appState, err = jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(result)
 
 	return appState, validators, err
 }

--- a/app/export.go
+++ b/app/export.go
@@ -19,9 +19,7 @@ func (app *HeimdallApp) ExportAppStateAndValidators() (
 	result := app.mm.ExportGenesis(ctx)
 
 	// create app state
-	// appState, err = codec.MarshalJSONIndent(app.cdc, genState)
-	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
-	appState, err = jsonLib.Marshal(result)
+	appState, err = jsoniter.ConfigFastest.Marshal(result)
 
 	return appState, validators, err
 }

--- a/app/export.go
+++ b/app/export.go
@@ -3,6 +3,7 @@ package app
 import (
 	"encoding/json"
 
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmTypes "github.com/tendermint/tendermint/types"
 )
@@ -19,7 +20,8 @@ func (app *HeimdallApp) ExportAppStateAndValidators() (
 
 	// create app state
 	// appState, err = codec.MarshalJSONIndent(app.cdc, genState)
-	appState, err = json.Marshal(result)
+	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
+	appState, err = jsonLib.Marshal(result)
 
 	return appState, validators, err
 }

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-// GenesisState the genesis state of the blockchain is represented here as a map of raw json messages key'd by a identifier string
+// GenesisState the genesis state of the blockchain is represented here as a map of raw json messages keyed by an identifier string
 type GenesisState map[string]json.RawMessage
 
 // NewDefaultGenesisState generates the default state for the application.

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -1,8 +1,8 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
-	jsoniter "github.com/json-iterator/go"
 	"math/rand"
 	"os"
 	"testing"
@@ -239,7 +239,7 @@ func TestAppStateDeterminism(t *testing.T) {
 
 	numSeeds := 3
 	numTimesToRunPerSeed := 5
-	appHashList := make([]jsoniter.RawMessage, numTimesToRunPerSeed)
+	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
 
 	for i := 0; i < numSeeds; i++ {
 		config.Seed = rand.Int63()

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -1,8 +1,8 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
+	jsoniter "github.com/json-iterator/go"
 	"math/rand"
 	"os"
 	"testing"
@@ -239,7 +239,7 @@ func TestAppStateDeterminism(t *testing.T) {
 
 	numSeeds := 3
 	numTimesToRunPerSeed := 5
-	appHashList := make([]json.RawMessage, numTimesToRunPerSeed)
+	appHashList := make([]jsoniter.RawMessage, numTimesToRunPerSeed)
 
 	for i := 0; i < numSeeds; i++ {
 		config.Seed = rand.Int63()

--- a/app/utils.go
+++ b/app/utils.go
@@ -89,6 +89,7 @@ func CheckExportSimulation(app App, config simTypes.Config, params simTypes.Para
 		fmt.Println("exporting simulation params...")
 
 		json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 		paramsBz, err := json.MarshalIndent(params, "", " ")
 		if err != nil {
 			return err

--- a/app/utils.go
+++ b/app/utils.go
@@ -88,7 +88,7 @@ func CheckExportSimulation(app App, config simTypes.Config, params simTypes.Para
 	if config.ExportParamsPath != "" {
 		fmt.Println("exporting simulation params...")
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		paramsBz, err := json.MarshalIndent(params, "", " ")
 		if err != nil {
 			return err

--- a/app/utils.go
+++ b/app/utils.go
@@ -88,7 +88,7 @@ func CheckExportSimulation(app App, config simTypes.Config, params simTypes.Para
 	if config.ExportParamsPath != "" {
 		fmt.Println("exporting simulation params...")
 
-		paramsBz, err := jsoniter.ConfigFastest.MarshalIndent(params, "", " ")
+		paramsBz, err := jsoniter.ConfigCompatibleWithStandardLibrary.MarshalIndent(params, "", " ")
 		if err != nil {
 			return err
 		}

--- a/app/utils.go
+++ b/app/utils.go
@@ -88,9 +88,7 @@ func CheckExportSimulation(app App, config simTypes.Config, params simTypes.Para
 	if config.ExportParamsPath != "" {
 		fmt.Println("exporting simulation params...")
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-		paramsBz, err := json.MarshalIndent(params, "", " ")
+		paramsBz, err := jsoniter.ConfigFastest.MarshalIndent(params, "", " ")
 		if err != nil {
 			return err
 		}

--- a/app/utils.go
+++ b/app/utils.go
@@ -88,7 +88,7 @@ func CheckExportSimulation(app App, config simTypes.Config, params simTypes.Para
 	if config.ExportParamsPath != "" {
 		fmt.Println("exporting simulation params...")
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		paramsBz, err := json.MarshalIndent(params, "", " ")
 		if err != nil {
 			return err

--- a/app/utils.go
+++ b/app/utils.go
@@ -1,12 +1,12 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
 
@@ -88,6 +88,7 @@ func CheckExportSimulation(app App, config simTypes.Config, params simTypes.Para
 	if config.ExportParamsPath != "" {
 		fmt.Println("exporting simulation params...")
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		paramsBz, err := json.MarshalIndent(params, "", " ")
 		if err != nil {
 			return err

--- a/auth/client/cli/query.go
+++ b/auth/client/cli/query.go
@@ -90,7 +90,7 @@ $ %s query auth params
 			}
 
 			var params types.Params
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			if err := json.Unmarshal(bz, &params); err != nil {
 				return err
 			}

--- a/auth/client/cli/query.go
+++ b/auth/client/cli/query.go
@@ -1,13 +1,13 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 
 	"github.com/maticnetwork/heimdall/auth/types"
@@ -90,6 +90,7 @@ $ %s query auth params
 			}
 
 			var params types.Params
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			if err := json.Unmarshal(bz, &params); err != nil {
 				return err
 			}

--- a/auth/client/cli/query.go
+++ b/auth/client/cli/query.go
@@ -90,7 +90,7 @@ $ %s query auth params
 			}
 
 			var params types.Params
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			if err := json.Unmarshal(bz, &params); err != nil {
 				return err
 			}

--- a/auth/client/cli/query.go
+++ b/auth/client/cli/query.go
@@ -90,8 +90,7 @@ $ %s query auth params
 			}
 
 			var params types.Params
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
-			if err := json.Unmarshal(bz, &params); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(bz, &params); err != nil {
 				return err
 			}
 			return cliCtx.PrintOutput(params)

--- a/auth/querier.go
+++ b/auth/querier.go
@@ -27,6 +27,7 @@ func NewQuerier(keeper AccountKeeper) sdk.Querier {
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper AccountKeeper) ([]byte, sdk.Error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/auth/querier.go
+++ b/auth/querier.go
@@ -26,9 +26,7 @@ func NewQuerier(keeper AccountKeeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper AccountKeeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(keeper.GetParams(ctx))
+	bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/auth/querier.go
+++ b/auth/querier.go
@@ -26,7 +26,7 @@ func NewQuerier(keeper AccountKeeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper AccountKeeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/auth/querier.go
+++ b/auth/querier.go
@@ -26,7 +26,7 @@ func NewQuerier(keeper AccountKeeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper AccountKeeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/auth/querier.go
+++ b/auth/querier.go
@@ -1,11 +1,11 @@
 package auth
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/maticnetwork/heimdall/auth/types"
@@ -26,6 +26,7 @@ func NewQuerier(keeper AccountKeeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper AccountKeeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/auth/querier_test.go
+++ b/auth/querier_test.go
@@ -134,7 +134,8 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	defaultParams := authTypes.DefaultParams()
 
 	var params types.Params
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err2 := json.Unmarshal(res, &params)
 	require.Nil(t, err2)
 	require.Equal(t, defaultParams.MaxMemoCharacters, params.MaxMemoCharacters)

--- a/auth/querier_test.go
+++ b/auth/querier_test.go
@@ -135,7 +135,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 
 	var params types.Params
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err2 := json.Unmarshal(res, &params)
 	require.Nil(t, err2)
 	require.Equal(t, defaultParams.MaxMemoCharacters, params.MaxMemoCharacters)

--- a/auth/querier_test.go
+++ b/auth/querier_test.go
@@ -1,16 +1,16 @@
 package auth_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkAuth "github.com/cosmos/cosmos-sdk/x/auth/types"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkAuth "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/maticnetwork/heimdall/app"
 	"github.com/maticnetwork/heimdall/auth"
 	"github.com/maticnetwork/heimdall/auth/exported"
@@ -134,6 +134,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	defaultParams := authTypes.DefaultParams()
 
 	var params types.Params
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err2 := json.Unmarshal(res, &params)
 	require.Nil(t, err2)
 	require.Equal(t, defaultParams.MaxMemoCharacters, params.MaxMemoCharacters)

--- a/auth/querier_test.go
+++ b/auth/querier_test.go
@@ -135,8 +135,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 
 	var params types.Params
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err2 := json.Unmarshal(res, &params)
+	err2 := jsoniter.ConfigFastest.Unmarshal(res, &params)
 	require.Nil(t, err2)
 	require.Equal(t, defaultParams.MaxMemoCharacters, params.MaxMemoCharacters)
 	require.Equal(t, defaultParams.TxSigLimit, params.TxSigLimit)
@@ -155,7 +154,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NotEmpty(t, string(res))
 
 	var params3 types.Params
-	err3 := json.Unmarshal(res, &params3)
+	err3 := jsoniter.ConfigFastest.Unmarshal(res, &params3)
 	require.NoError(t, err3)
 	require.Equal(t, uint64(10), params.MaxMemoCharacters)
 	require.Equal(t, uint64(8), params.TxSizeCostPerByte)

--- a/auth/querier_test.go
+++ b/auth/querier_test.go
@@ -135,7 +135,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 
 	var params types.Params
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err2 := json.Unmarshal(res, &params)
 	require.Nil(t, err2)
 	require.Equal(t, defaultParams.MaxMemoCharacters, params.MaxMemoCharacters)

--- a/auth/types/stdtx.go
+++ b/auth/types/stdtx.go
@@ -1,10 +1,10 @@
 package types
 
 import (
-	"encoding/json"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/bor/common/hexutil"
 	"github.com/maticnetwork/bor/rlp"
@@ -118,6 +118,7 @@ func (ss *StdSignature) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (ss StdSignature) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(ss.String())
 }
 
@@ -129,6 +130,7 @@ func (ss StdSignature) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (ss *StdSignature) UnmarshalJSON(data []byte) error {
 	var s string
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/auth/types/stdtx.go
+++ b/auth/types/stdtx.go
@@ -118,8 +118,7 @@ func (ss *StdSignature) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (ss StdSignature) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Marshal(ss.String())
+	return jsoniter.ConfigFastest.Marshal(ss.String())
 }
 
 // MarshalYAML marshals to YAML using Bech32.
@@ -130,9 +129,7 @@ func (ss StdSignature) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (ss *StdSignature) UnmarshalJSON(data []byte) error {
 	var s string
-
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err := json.Unmarshal(data, &s); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(data, &s); err != nil {
 		return err
 	}
 

--- a/auth/types/stdtx.go
+++ b/auth/types/stdtx.go
@@ -118,7 +118,7 @@ func (ss *StdSignature) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (ss StdSignature) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(ss.String())
 }
 
@@ -131,7 +131,7 @@ func (ss StdSignature) MarshalYAML() (interface{}, error) {
 func (ss *StdSignature) UnmarshalJSON(data []byte) error {
 	var s string
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/auth/types/stdtx.go
+++ b/auth/types/stdtx.go
@@ -118,7 +118,7 @@ func (ss *StdSignature) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (ss StdSignature) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(ss.String())
 }
 
@@ -131,7 +131,7 @@ func (ss StdSignature) MarshalYAML() (interface{}, error) {
 func (ss *StdSignature) UnmarshalJSON(data []byte) error {
 	var s string
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/auth/types/stdtx.go
+++ b/auth/types/stdtx.go
@@ -118,7 +118,7 @@ func (ss *StdSignature) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (ss StdSignature) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(ss.String())
 }
 
@@ -130,7 +130,8 @@ func (ss StdSignature) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (ss *StdSignature) UnmarshalJSON(data []byte) error {
 	var s string
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/bor/beginblocker.go
+++ b/bor/beginblocker.go
@@ -22,7 +22,8 @@ func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k Keeper) {
 		}
 
 		var spans []*bor.ResponseWithHeight
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		if err := json.Unmarshal(j, &spans); err != nil {
 			k.Logger(ctx).Error("Error Unmarshal spans", "error", err)
 			panic(err)

--- a/bor/beginblocker.go
+++ b/bor/beginblocker.go
@@ -23,8 +23,7 @@ func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k Keeper) {
 
 		var spans []*bor.ResponseWithHeight
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-		if err := json.Unmarshal(j, &spans); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(j, &spans); err != nil {
 			k.Logger(ctx).Error("Error Unmarshal spans", "error", err)
 			panic(err)
 		}
@@ -33,7 +32,7 @@ func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k Keeper) {
 			k.Logger(ctx).Info("overriding span", "height", span.Height, "span", span)
 
 			var heimdallSpan hmTypes.Span
-			if err := json.Unmarshal(span.Result, &heimdallSpan); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(span.Result, &heimdallSpan); err != nil {
 				k.Logger(ctx).Error("Error Unmarshal heimdallSpan", "error", err)
 				panic(err)
 			}

--- a/bor/beginblocker.go
+++ b/bor/beginblocker.go
@@ -23,7 +23,7 @@ func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k Keeper) {
 
 		var spans []*bor.ResponseWithHeight
 
-		if err := jsoniter.ConfigFastest.Unmarshal(j, &spans); err != nil {
+		if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(j, &spans); err != nil {
 			k.Logger(ctx).Error("Error Unmarshal spans", "error", err)
 			panic(err)
 		}

--- a/bor/beginblocker.go
+++ b/bor/beginblocker.go
@@ -23,7 +23,7 @@ func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k Keeper) {
 
 		var spans []*bor.ResponseWithHeight
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		if err := json.Unmarshal(j, &spans); err != nil {
 			k.Logger(ctx).Error("Error Unmarshal spans", "error", err)
 			panic(err)

--- a/bor/beginblocker.go
+++ b/bor/beginblocker.go
@@ -1,12 +1,11 @@
 package bor
 
 import (
-	"encoding/json"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/maticnetwork/bor/consensus/bor"
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	"github.com/maticnetwork/bor/consensus/bor"
 	"github.com/maticnetwork/heimdall/bor/client/rest"
 	"github.com/maticnetwork/heimdall/helper"
 	hmTypes "github.com/maticnetwork/heimdall/types"
@@ -23,6 +22,7 @@ func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k Keeper) {
 		}
 
 		var spans []*bor.ResponseWithHeight
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		if err := json.Unmarshal(j, &spans); err != nil {
 			k.Logger(ctx).Error("Error Unmarshal spans", "error", err)
 			panic(err)

--- a/bor/beginblocker.go
+++ b/bor/beginblocker.go
@@ -23,7 +23,7 @@ func BeginBlocker(ctx sdk.Context, _ abci.RequestBeginBlock, k Keeper) {
 
 		var spans []*bor.ResponseWithHeight
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		if err := json.Unmarshal(j, &spans); err != nil {
 			k.Logger(ctx).Error("Error Unmarshal spans", "error", err)
 			panic(err)

--- a/bor/client/cli/query.go
+++ b/bor/client/cli/query.go
@@ -142,7 +142,7 @@ $ %s query bor params
 			}
 
 			var params types.Params
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			err = json.Unmarshal(bz, &params)
 			if err != nil {
 				return err

--- a/bor/client/cli/query.go
+++ b/bor/client/cli/query.go
@@ -142,8 +142,7 @@ $ %s query bor params
 			}
 
 			var params types.Params
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
-			err = json.Unmarshal(bz, &params)
+			err = jsoniter.ConfigFastest.Unmarshal(bz, &params)
 			if err != nil {
 				return err
 			}

--- a/bor/client/cli/query.go
+++ b/bor/client/cli/query.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -10,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -142,6 +142,7 @@ $ %s query bor params
 			}
 
 			var params types.Params
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			err = json.Unmarshal(bz, &params)
 			if err != nil {
 				return err

--- a/bor/client/cli/query.go
+++ b/bor/client/cli/query.go
@@ -142,7 +142,7 @@ $ %s query bor params
 			}
 
 			var params types.Params
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			err = json.Unmarshal(bz, &params)
 			if err != nil {
 				return err

--- a/bor/client/cli/tx.go
+++ b/bor/client/cli/tx.go
@@ -96,7 +96,7 @@ func PostSendProposeSpanTx(cdc *codec.Codec) *cobra.Command {
 				return errors.New("span duration not found")
 			}
 
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var spanDuration uint64
 			if err := json.Unmarshal(res, &spanDuration); err != nil {
 				return err

--- a/bor/client/cli/tx.go
+++ b/bor/client/cli/tx.go
@@ -96,7 +96,7 @@ func PostSendProposeSpanTx(cdc *codec.Codec) *cobra.Command {
 				return errors.New("span duration not found")
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var spanDuration uint64
 			if err := json.Unmarshal(res, &spanDuration); err != nil {
 				return err

--- a/bor/client/cli/tx.go
+++ b/bor/client/cli/tx.go
@@ -96,9 +96,8 @@ func PostSendProposeSpanTx(cdc *codec.Codec) *cobra.Command {
 				return errors.New("span duration not found")
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var spanDuration uint64
-			if err := json.Unmarshal(res, &spanDuration); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(res, &spanDuration); err != nil {
 				return err
 			}
 
@@ -112,7 +111,7 @@ func PostSendProposeSpanTx(cdc *codec.Codec) *cobra.Command {
 			}
 
 			var seed common.Hash
-			if err := json.Unmarshal(res, &seed); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(res, &seed); err != nil {
 				return err
 			}
 

--- a/bor/client/cli/tx.go
+++ b/bor/client/cli/tx.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -10,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -96,6 +96,7 @@ func PostSendProposeSpanTx(cdc *codec.Codec) *cobra.Command {
 				return errors.New("span duration not found")
 			}
 
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var spanDuration uint64
 			if err := json.Unmarshal(res, &spanDuration); err != nil {
 				return err

--- a/bor/client/rest/query.go
+++ b/bor/client/rest/query.go
@@ -395,9 +395,8 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
-		if err := json.Unmarshal(spanDurationBytes, &spanDuration); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(spanDurationBytes, &spanDuration); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -419,7 +418,7 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		var ackCount uint64
-		if err := json.Unmarshal(ackCountBytes, &ackCount); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(ackCountBytes, &ackCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -440,7 +439,7 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		var _validatorSet hmTypes.ValidatorSet
-		if err = json.Unmarshal(validatorSetBytes, &_validatorSet); err != nil {
+		if err = jsoniter.ConfigFastest.Unmarshal(validatorSetBytes, &_validatorSet); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusNoContent, errors.New("unable to unmarshall JSON").Error())
 			return
 		}
@@ -461,7 +460,7 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		var selectedProducers []hmTypes.Validator
-		if err := json.Unmarshal(nextProducerBytes, &selectedProducers); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(nextProducerBytes, &selectedProducers); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -478,7 +477,7 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			chainID,
 		)
 
-		result, err := json.Marshal(&msg)
+		result, err := jsoniter.ConfigFastest.Marshal(&msg)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -522,15 +521,14 @@ func loadSpanOverrides() {
 		return
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var spans []*bor.ResponseWithHeight
-	if err := json.Unmarshal(j, &spans); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(j, &spans); err != nil {
 		return
 	}
 
 	for _, span := range spans {
 		var heimdallSpan bor.HeimdallSpan
-		if err := json.Unmarshal(span.Result, &heimdallSpan); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(span.Result, &heimdallSpan); err != nil {
 			continue
 		}
 

--- a/bor/client/rest/query.go
+++ b/bor/client/rest/query.go
@@ -395,7 +395,7 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
 		if err := json.Unmarshal(spanDurationBytes, &spanDuration); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -522,7 +522,7 @@ func loadSpanOverrides() {
 		return
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var spans []*bor.ResponseWithHeight
 	if err := json.Unmarshal(j, &spans); err != nil {
 		return

--- a/bor/client/rest/query.go
+++ b/bor/client/rest/query.go
@@ -395,7 +395,7 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
 		if err := json.Unmarshal(spanDurationBytes, &spanDuration); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -522,7 +522,7 @@ func loadSpanOverrides() {
 		return
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var spans []*bor.ResponseWithHeight
 	if err := json.Unmarshal(j, &spans); err != nil {
 		return

--- a/bor/client/rest/query.go
+++ b/bor/client/rest/query.go
@@ -12,7 +12,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -21,6 +20,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/bor/consensus/bor"
 	"github.com/maticnetwork/heimdall/bor/types"
@@ -395,6 +395,7 @@ func prepareNextSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
 		if err := json.Unmarshal(spanDurationBytes, &spanDuration); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -521,6 +522,7 @@ func loadSpanOverrides() {
 		return
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var spans []*bor.ResponseWithHeight
 	if err := json.Unmarshal(j, &spans); err != nil {
 		return

--- a/bor/client/rest/tx.go
+++ b/bor/client/rest/tx.go
@@ -2,7 +2,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/heimdall/bor/types"
@@ -141,6 +141,7 @@ func postProposeSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
 		if err = json.Unmarshal(res, &spanDuration); err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/bor/client/rest/tx.go
+++ b/bor/client/rest/tx.go
@@ -141,7 +141,7 @@ func postProposeSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
 		if err = json.Unmarshal(res, &spanDuration); err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/bor/client/rest/tx.go
+++ b/bor/client/rest/tx.go
@@ -141,7 +141,7 @@ func postProposeSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
 		if err = json.Unmarshal(res, &spanDuration); err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/bor/client/rest/tx.go
+++ b/bor/client/rest/tx.go
@@ -141,9 +141,8 @@ func postProposeSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var spanDuration uint64
-		if err = json.Unmarshal(res, &spanDuration); err != nil {
+		if err = jsoniter.ConfigFastest.Unmarshal(res, &spanDuration); err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -158,7 +157,7 @@ func postProposeSpanHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		var seed common.Hash
-		if err = json.Unmarshal(res, &seed); err != nil {
+		if err = jsoniter.ConfigFastest.Unmarshal(res, &seed); err != nil {
 			return
 		}
 

--- a/bor/querier.go
+++ b/bor/querier.go
@@ -38,7 +38,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if len(path) == 0 {
 		bz, err := json.Marshal(keeper.GetParams(ctx))
@@ -85,7 +85,8 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 
 func handleQuerySpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params types.QuerySpanParams
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if err := keeper.cdc.UnmarshalJSON(req.Data, &params); err != nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("failed to parse params: %s", err))
@@ -121,7 +122,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch span list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -132,7 +133,8 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 
 func handleQueryLatestSpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var defaultSpan hmTypes.Span
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	spans := keeper.GetAllSpans(ctx)
 	if len(spans) == 0 {
@@ -176,7 +178,7 @@ func handleQueryNextProducers(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 		return nil, sdk.ErrInternal((sdk.AppendMsgToErr("cannot fetch next producers from keeper", err.Error())))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextProducers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -193,7 +195,7 @@ func handlerQueryNextSpanSeed(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextSpanSeed)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/bor/querier.go
+++ b/bor/querier.go
@@ -38,7 +38,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if len(path) == 0 {
 		bz, err := json.Marshal(keeper.GetParams(ctx))
@@ -86,7 +86,7 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 func handleQuerySpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params types.QuerySpanParams
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if err := keeper.cdc.UnmarshalJSON(req.Data, &params); err != nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("failed to parse params: %s", err))
@@ -122,7 +122,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch span list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -134,7 +134,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 func handleQueryLatestSpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var defaultSpan hmTypes.Span
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	spans := keeper.GetAllSpans(ctx)
 	if len(spans) == 0 {
@@ -178,7 +178,7 @@ func handleQueryNextProducers(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 		return nil, sdk.ErrInternal((sdk.AppendMsgToErr("cannot fetch next producers from keeper", err.Error())))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextProducers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -195,7 +195,7 @@ func handlerQueryNextSpanSeed(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextSpanSeed)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/bor/querier.go
+++ b/bor/querier.go
@@ -123,6 +123,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -179,6 +180,7 @@ func handleQueryNextProducers(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(nextProducers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -196,6 +198,7 @@ func handlerQueryNextSpanSeed(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(nextSpanSeed)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/bor/querier.go
+++ b/bor/querier.go
@@ -1,10 +1,10 @@
 package bor
 
 import (
-	"encoding/json"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/maticnetwork/heimdall/bor/types"
@@ -38,6 +38,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	if len(path) == 0 {
 		bz, err := json.Marshal(keeper.GetParams(ctx))
 		if err != nil {
@@ -83,6 +85,8 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 
 func handleQuerySpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params types.QuerySpanParams
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	if err := keeper.cdc.UnmarshalJSON(req.Data, &params); err != nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("failed to parse params: %s", err))
 	}
@@ -117,6 +121,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch span list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -127,6 +132,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 
 func handleQueryLatestSpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var defaultSpan hmTypes.Span
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	spans := keeper.GetAllSpans(ctx)
 	if len(spans) == 0 {
@@ -170,6 +176,7 @@ func handleQueryNextProducers(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 		return nil, sdk.ErrInternal((sdk.AppendMsgToErr("cannot fetch next producers from keeper", err.Error())))
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextProducers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -186,6 +193,7 @@ func handlerQueryNextSpanSeed(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextSpanSeed)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/bor/querier.go
+++ b/bor/querier.go
@@ -38,7 +38,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if len(path) == 0 {
 		bz, err := json.Marshal(keeper.GetParams(ctx))
@@ -86,7 +86,7 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 func handleQuerySpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params types.QuerySpanParams
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if err := keeper.cdc.UnmarshalJSON(req.Data, &params); err != nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("failed to parse params: %s", err))
@@ -122,7 +122,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch span list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -134,7 +134,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 func handleQueryLatestSpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var defaultSpan hmTypes.Span
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	spans := keeper.GetAllSpans(ctx)
 	if len(spans) == 0 {
@@ -178,7 +178,7 @@ func handleQueryNextProducers(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 		return nil, sdk.ErrInternal((sdk.AppendMsgToErr("cannot fetch next producers from keeper", err.Error())))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextProducers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -195,7 +195,7 @@ func handlerQueryNextSpanSeed(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(nextSpanSeed)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/bor/querier.go
+++ b/bor/querier.go
@@ -38,10 +38,8 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	if len(path) == 0 {
-		bz, err := json.Marshal(keeper.GetParams(ctx))
+		bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx))
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 		}
@@ -51,28 +49,28 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 
 	switch path[0] {
 	case types.ParamSpan:
-		bz, err := json.Marshal(keeper.GetParams(ctx).SpanDuration)
+		bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx).SpanDuration)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 		}
 
 		return bz, nil
 	case types.ParamSprint:
-		bz, err := json.Marshal(keeper.GetParams(ctx).SprintDuration)
+		bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx).SprintDuration)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 		}
 
 		return bz, nil
 	case types.ParamProducerCount:
-		bz, err := json.Marshal(keeper.GetParams(ctx).ProducerCount)
+		bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx).ProducerCount)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 		}
 
 		return bz, nil
 	case types.ParamLastEthBlock:
-		bz, err := json.Marshal(keeper.GetLastEthBlock(ctx))
+		bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetLastEthBlock(ctx))
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 		}
@@ -85,8 +83,6 @@ func queryParams(ctx sdk.Context, path []string, req abci.RequestQuery, keeper K
 
 func handleQuerySpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var params types.QuerySpanParams
-
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	if err := keeper.cdc.UnmarshalJSON(req.Data, &params); err != nil {
 		return nil, sdk.ErrInternal(fmt.Sprintf("failed to parse params: %s", err))
@@ -103,7 +99,7 @@ func handleQuerySpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]b
 	}
 
 	// json record
-	bz, err := json.Marshal(span)
+	bz, err := jsoniter.ConfigFastest.Marshal(span)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -122,9 +118,7 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch span list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(res)
+	bz, err := jsoniter.ConfigFastest.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -135,12 +129,10 @@ func handleQuerySpanList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 func handleQueryLatestSpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	var defaultSpan hmTypes.Span
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	spans := keeper.GetAllSpans(ctx)
 	if len(spans) == 0 {
 		// json record
-		bz, err := json.Marshal(defaultSpan)
+		bz, err := jsoniter.ConfigFastest.Marshal(defaultSpan)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 		}
@@ -160,7 +152,7 @@ func handleQueryLatestSpan(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 	}
 
 	// json record
-	bz, err := json.Marshal(span)
+	bz, err := jsoniter.ConfigFastest.Marshal(span)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -179,9 +171,7 @@ func handleQueryNextProducers(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 		return nil, sdk.ErrInternal((sdk.AppendMsgToErr("cannot fetch next producers from keeper", err.Error())))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(nextProducers)
+	bz, err := jsoniter.ConfigFastest.Marshal(nextProducers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -197,9 +187,7 @@ func handlerQueryNextSpanSeed(ctx sdk.Context, req abci.RequestQuery, keeper Kee
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(nextSpanSeed)
+	bz, err := jsoniter.ConfigFastest.Marshal(nextSpanSeed)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/bor/selection_test.go
+++ b/bor/selection_test.go
@@ -85,7 +85,7 @@ func TestSelectNextProducers(t *testing.T) {
 
 	var validators []hmTypes.Validator
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal([]byte(testValidators), &validators)
 	require.NoError(t, err)
 	require.Equal(t, 5, len(validators), "Total validators should be 5")

--- a/bor/selection_test.go
+++ b/bor/selection_test.go
@@ -84,9 +84,7 @@ func TestSelectNextProducers(t *testing.T) {
 	}
 
 	var validators []hmTypes.Validator
-
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := json.Unmarshal([]byte(testValidators), &validators)
+	err := jsoniter.ConfigFastest.Unmarshal([]byte(testValidators), &validators)
 	require.NoError(t, err)
 	require.Equal(t, 5, len(validators), "Total validators should be 5")
 

--- a/bor/selection_test.go
+++ b/bor/selection_test.go
@@ -85,7 +85,7 @@ func TestSelectNextProducers(t *testing.T) {
 
 	var validators []hmTypes.Validator
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal([]byte(testValidators), &validators)
 	require.NoError(t, err)
 	require.Equal(t, 5, len(validators), "Total validators should be 5")

--- a/bor/selection_test.go
+++ b/bor/selection_test.go
@@ -1,13 +1,14 @@
 package bor
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+
 	"github.com/maticnetwork/bor/common"
 	hmTypes "github.com/maticnetwork/heimdall/types"
-	"github.com/stretchr/testify/require"
 )
 
 const testValidators = `[
@@ -83,6 +84,7 @@ func TestSelectNextProducers(t *testing.T) {
 	}
 
 	var validators []hmTypes.Validator
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal([]byte(testValidators), &validators)
 	require.NoError(t, err)
 	require.Equal(t, 5, len(validators), "Total validators should be 5")

--- a/bor/selection_test.go
+++ b/bor/selection_test.go
@@ -84,7 +84,8 @@ func TestSelectNextProducers(t *testing.T) {
 	}
 
 	var validators []hmTypes.Validator
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal([]byte(testValidators), &validators)
 	require.NoError(t, err)
 	require.Equal(t, 5, len(validators), "Total validators should be 5")

--- a/bridge/setu/listener/heimdall.go
+++ b/bridge/setu/listener/heimdall.go
@@ -2,17 +2,16 @@ package listener
 
 import (
 	"context"
-	"encoding/json"
 	"strconv"
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
-	"github.com/maticnetwork/bor/core/types"
-	"github.com/maticnetwork/heimdall/helper"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 
+	"github.com/maticnetwork/bor/core/types"
 	checkpointTypes "github.com/maticnetwork/heimdall/checkpoint/types"
+	"github.com/maticnetwork/heimdall/helper"
 	slashingTypes "github.com/maticnetwork/heimdall/slashing/types"
 )
 
@@ -182,6 +181,7 @@ func (hl *HeimdallListener) fetchFromAndToBlock() (uint64, uint64, error) {
 func (hl *HeimdallListener) ProcessBlockEvent(event sdk.StringEvent, blockHeight int64) {
 	hl.Logger.Info("Received block event from Heimdall", "eventType", event.Type)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	eventBytes, err := json.Marshal(event)
 	if err != nil {
 		hl.Logger.Error("Error while parsing block event", "eventType", event.Type, "error", err)

--- a/bridge/setu/listener/heimdall.go
+++ b/bridge/setu/listener/heimdall.go
@@ -181,7 +181,7 @@ func (hl *HeimdallListener) fetchFromAndToBlock() (uint64, uint64, error) {
 func (hl *HeimdallListener) ProcessBlockEvent(event sdk.StringEvent, blockHeight int64) {
 	hl.Logger.Info("Received block event from Heimdall", "eventType", event.Type)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	eventBytes, err := json.Marshal(event)
 	if err != nil {
 		hl.Logger.Error("Error while parsing block event", "eventType", event.Type, "error", err)

--- a/bridge/setu/listener/heimdall.go
+++ b/bridge/setu/listener/heimdall.go
@@ -181,9 +181,7 @@ func (hl *HeimdallListener) fetchFromAndToBlock() (uint64, uint64, error) {
 func (hl *HeimdallListener) ProcessBlockEvent(event sdk.StringEvent, blockHeight int64) {
 	hl.Logger.Info("Received block event from Heimdall", "eventType", event.Type)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	eventBytes, err := json.Marshal(event)
+	eventBytes, err := jsoniter.ConfigFastest.Marshal(event)
 	if err != nil {
 		hl.Logger.Error("Error while parsing block event", "eventType", event.Type, "error", err)
 		return

--- a/bridge/setu/listener/heimdall.go
+++ b/bridge/setu/listener/heimdall.go
@@ -182,6 +182,7 @@ func (hl *HeimdallListener) ProcessBlockEvent(event sdk.StringEvent, blockHeight
 	hl.Logger.Info("Received block event from Heimdall", "eventType", event.Type)
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	eventBytes, err := json.Marshal(event)
 	if err != nil {
 		hl.Logger.Error("Error while parsing block event", "eventType", event.Type, "error", err)

--- a/bridge/setu/listener/heimdall.go
+++ b/bridge/setu/listener/heimdall.go
@@ -181,7 +181,7 @@ func (hl *HeimdallListener) fetchFromAndToBlock() (uint64, uint64, error) {
 func (hl *HeimdallListener) ProcessBlockEvent(event sdk.StringEvent, blockHeight int64) {
 	hl.Logger.Info("Received block event from Heimdall", "eventType", event.Type)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	eventBytes, err := json.Marshal(event)
 	if err != nil {
 		hl.Logger.Error("Error while parsing block event", "eventType", event.Type, "error", err)

--- a/bridge/setu/listener/rootchain_log.go
+++ b/bridge/setu/listener/rootchain_log.go
@@ -40,7 +40,7 @@ func (rl *RootChainListener) handleLog(vLog types.Log, selectedEvent *abi.Event)
 }
 
 func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -53,7 +53,7 @@ func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEve
 }
 
 func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -79,7 +79,7 @@ func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.
 }
 
 func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -99,7 +99,7 @@ func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -121,7 +121,7 @@ func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent
 }
 
 func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -141,7 +141,7 @@ func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -161,7 +161,7 @@ func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -181,7 +181,7 @@ func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *ab
 }
 
 func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -194,7 +194,7 @@ func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi
 }
 
 func (rl *RootChainListener) handleUnJailedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {

--- a/bridge/setu/listener/rootchain_log.go
+++ b/bridge/setu/listener/rootchain_log.go
@@ -40,9 +40,7 @@ func (rl *RootChainListener) handleLog(vLog types.Log, selectedEvent *abi.Event)
 }
 
 func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -53,9 +51,7 @@ func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEve
 }
 
 func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -79,9 +75,7 @@ func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.
 }
 
 func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -99,9 +93,7 @@ func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -121,9 +113,7 @@ func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent
 }
 
 func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -141,9 +131,7 @@ func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -161,9 +149,7 @@ func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -181,9 +167,7 @@ func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *ab
 }
 
 func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}
@@ -194,9 +178,7 @@ func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi
 }
 
 func (rl *RootChainListener) handleUnJailedLog(vLog types.Log, selectedEvent *abi.Event) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	logBytes, err := json.Marshal(vLog)
+	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
 	}

--- a/bridge/setu/listener/rootchain_log.go
+++ b/bridge/setu/listener/rootchain_log.go
@@ -40,7 +40,8 @@ func (rl *RootChainListener) handleLog(vLog types.Log, selectedEvent *abi.Event)
 }
 
 func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -52,7 +53,8 @@ func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEve
 }
 
 func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -77,7 +79,8 @@ func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.
 }
 
 func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -96,7 +99,8 @@ func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -117,7 +121,8 @@ func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent
 }
 
 func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -136,7 +141,8 @@ func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -155,7 +161,8 @@ func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -174,7 +181,8 @@ func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *ab
 }
 
 func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -186,7 +194,8 @@ func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi
 }
 
 func (rl *RootChainListener) handleUnJailedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)

--- a/bridge/setu/listener/rootchain_log.go
+++ b/bridge/setu/listener/rootchain_log.go
@@ -2,11 +2,11 @@ package listener
 
 import (
 	"bytes"
-	"encoding/json"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
-
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/contracts/stakinginfo"
 	"github.com/maticnetwork/heimdall/contracts/statesender"
@@ -40,6 +40,7 @@ func (rl *RootChainListener) handleLog(vLog types.Log, selectedEvent *abi.Event)
 }
 
 func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -51,6 +52,7 @@ func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEve
 }
 
 func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -75,6 +77,7 @@ func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.
 }
 
 func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -93,6 +96,7 @@ func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -113,6 +117,7 @@ func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent
 }
 
 func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -131,6 +136,7 @@ func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -149,6 +155,7 @@ func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -167,6 +174,7 @@ func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *ab
 }
 
 func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
@@ -178,6 +186,7 @@ func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi
 }
 
 func (rl *RootChainListener) handleUnJailedLog(vLog types.Log, selectedEvent *abi.Event) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)

--- a/bridge/setu/listener/rootchain_log.go
+++ b/bridge/setu/listener/rootchain_log.go
@@ -40,7 +40,7 @@ func (rl *RootChainListener) handleLog(vLog types.Log, selectedEvent *abi.Event)
 }
 
 func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -53,7 +53,7 @@ func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEve
 }
 
 func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -79,7 +79,7 @@ func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.
 }
 
 func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -99,7 +99,7 @@ func (rl *RootChainListener) handleStakeUpdateLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -121,7 +121,7 @@ func (rl *RootChainListener) handleSignerChangeLog(vLog types.Log, selectedEvent
 }
 
 func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -141,7 +141,7 @@ func (rl *RootChainListener) handleUnstakeInitLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -161,7 +161,7 @@ func (rl *RootChainListener) handleStateSyncedLog(vLog types.Log, selectedEvent 
 }
 
 func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -181,7 +181,7 @@ func (rl *RootChainListener) handleTopUpFeeLog(vLog types.Log, selectedEvent *ab
 }
 
 func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {
@@ -194,7 +194,7 @@ func (rl *RootChainListener) handleSlashedLog(vLog types.Log, selectedEvent *abi
 }
 
 func (rl *RootChainListener) handleUnJailedLog(vLog types.Log, selectedEvent *abi.Event) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	logBytes, err := json.Marshal(vLog)
 	if err != nil {

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -142,6 +142,7 @@ func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, lo
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var status bool
 	if err := json.Unmarshal(res.Result, &status); err != nil {
 		bp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -171,6 +171,7 @@ func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg, event interface{})
 
 	// a minimal response of the unconfirmed txs
 	var response util.TendermintUnconfirmedTxs
+
 	err = jsoniter.ConfigFastest.Unmarshal(body, &response)
 	if err != nil {
 		bp.Logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -11,16 +10,17 @@ import (
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types"
-	clerkTypes "github.com/maticnetwork/heimdall/clerk/types"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/viper"
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/tendermint/tendermint/libs/log"
+	httpClient "github.com/tendermint/tendermint/rpc/client"
 
 	"github.com/maticnetwork/heimdall/bridge/setu/broadcaster"
 	"github.com/maticnetwork/heimdall/bridge/setu/queue"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
+	clerkTypes "github.com/maticnetwork/heimdall/clerk/types"
 	"github.com/maticnetwork/heimdall/helper"
-	"github.com/tendermint/tendermint/libs/log"
-	httpClient "github.com/tendermint/tendermint/rpc/client"
 )
 
 // Processor defines a block header listerner for Rootchain, Maticchain, Heimdall
@@ -141,6 +141,7 @@ func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, lo
 		return false, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var status bool
 	if err := json.Unmarshal(res.Result, &status); err != nil {
 		bp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
@@ -168,6 +169,8 @@ func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg, event interface{})
 		bp.Logger.Error("Error fetching mempool tx", "error", err)
 		return false, err
 	}
+
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	// a minimal response of the unconfirmed txs
 	var response util.TendermintUnconfirmedTxs

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -141,7 +141,7 @@ func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, lo
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var status bool
 	if err := json.Unmarshal(res.Result, &status); err != nil {
 		bp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
@@ -170,7 +170,7 @@ func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg, event interface{})
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	// a minimal response of the unconfirmed txs
 	var response util.TendermintUnconfirmedTxs

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -141,7 +141,7 @@ func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, lo
 		return false, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var status bool
 	if err := json.Unmarshal(res.Result, &status); err != nil {
 		bp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
@@ -170,7 +170,7 @@ func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg, event interface{})
 		return false, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	// a minimal response of the unconfirmed txs
 	var response util.TendermintUnconfirmedTxs

--- a/bridge/setu/processor/base.go
+++ b/bridge/setu/processor/base.go
@@ -141,10 +141,8 @@ func (bp *BaseProcessor) isOldTx(cliCtx cliContext.CLIContext, txHash string, lo
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var status bool
-	if err := json.Unmarshal(res.Result, &status); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(res.Result, &status); err != nil {
 		bp.Logger.Error("Error unmarshalling tx status received from Heimdall Server", "error", err)
 		return false, err
 	}
@@ -171,12 +169,9 @@ func (bp *BaseProcessor) checkTxAgainstMempool(msg types.Msg, event interface{})
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	// a minimal response of the unconfirmed txs
 	var response util.TendermintUnconfirmedTxs
-
-	err = json.Unmarshal(body, &response)
+	err = jsoniter.ConfigFastest.Unmarshal(body, &response)
 	if err != nil {
 		bp.Logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)
 		return false, err

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -183,7 +183,7 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 func (cp *CheckpointProcessor) sendCheckpointToRootchain(eventBytes string, blockHeight int64) error {
 	cp.Logger.Info("Received sendCheckpointToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
@@ -257,7 +257,7 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 		return err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var log = types.Log{}
 	if err = json.Unmarshal([]byte(checkpointAckStr), &log); err != nil {
@@ -568,7 +568,7 @@ func (cp *CheckpointProcessor) fetchDividendAccountRoot() (accountroothash hmTyp
 
 	cp.Logger.Info("Divident account root fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &accountroothash); err != nil {
 		cp.Logger.Error("Error unmarshalling accountroothash received from Heimdall Server", "error", err)
 		return accountroothash, err
@@ -612,7 +612,7 @@ func (cp *CheckpointProcessor) getLastNoAckTime() uint64 {
 		return 0
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var noackObject Result
 	if err := json.Unmarshal(response.Result, &noackObject); err != nil {
 		cp.Logger.Error("Error unmarshalling no-ack data ", "error", err)

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -183,7 +183,7 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 func (cp *CheckpointProcessor) sendCheckpointToRootchain(eventBytes string, blockHeight int64) error {
 	cp.Logger.Info("Received sendCheckpointToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
@@ -257,7 +257,7 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 		return err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var log = types.Log{}
 	if err = json.Unmarshal([]byte(checkpointAckStr), &log); err != nil {
@@ -568,7 +568,7 @@ func (cp *CheckpointProcessor) fetchDividendAccountRoot() (accountroothash hmTyp
 
 	cp.Logger.Info("Divident account root fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &accountroothash); err != nil {
 		cp.Logger.Error("Error unmarshalling accountroothash received from Heimdall Server", "error", err)
 		return accountroothash, err
@@ -612,7 +612,7 @@ func (cp *CheckpointProcessor) getLastNoAckTime() uint64 {
 		return 0
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var noackObject Result
 	if err := json.Unmarshal(response.Result, &noackObject); err != nil {
 		cp.Logger.Error("Error unmarshalling no-ack data ", "error", err)

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -613,13 +613,14 @@ func (cp *CheckpointProcessor) getLastNoAckTime() uint64 {
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	var noackObject Result
-	if err := json.Unmarshal(response.Result, &noackObject); err != nil {
+
+	var noAckObject Result
+	if err := json.Unmarshal(response.Result, &noAckObject); err != nil {
 		cp.Logger.Error("Error unmarshalling no-ack data ", "error", err)
 		return 0
 	}
 
-	return noackObject.Result
+	return noAckObject.Result
 }
 
 // checkIfNoAckIsRequired - check if NoAck has to be sent or not

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -183,10 +183,8 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 func (cp *CheckpointProcessor) sendCheckpointToRootchain(eventBytes string, blockHeight int64) error {
 	cp.Logger.Info("Received sendCheckpointToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var event sdk.StringEvent
-	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(eventBytes), &event); err != nil {
 		cp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
 		return err
 	}
@@ -257,10 +255,8 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 		return err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var log = types.Log{}
-	if err = json.Unmarshal([]byte(checkpointAckStr), &log); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal([]byte(checkpointAckStr), &log); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}
@@ -568,8 +564,7 @@ func (cp *CheckpointProcessor) fetchDividendAccountRoot() (accountroothash hmTyp
 
 	cp.Logger.Info("Divident account root fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(response.Result, &accountroothash); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &accountroothash); err != nil {
 		cp.Logger.Error("Error unmarshalling accountroothash received from Heimdall Server", "error", err)
 		return accountroothash, err
 	}
@@ -612,10 +607,8 @@ func (cp *CheckpointProcessor) getLastNoAckTime() uint64 {
 		return 0
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var noAckObject Result
-	if err := json.Unmarshal(response.Result, &noAckObject); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(response.Result, &noAckObject); err != nil {
 		cp.Logger.Error("Error unmarshalling no-ack data ", "error", err)
 		return 0
 	}

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"math"
 	"math/big"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/common"
@@ -183,6 +183,7 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 func (cp *CheckpointProcessor) sendCheckpointToRootchain(eventBytes string, blockHeight int64) error {
 	cp.Logger.Info("Received sendCheckpointToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
 		cp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
@@ -255,6 +256,7 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 		return err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var log = types.Log{}
 	if err = json.Unmarshal([]byte(checkpointAckStr), &log); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -564,6 +566,7 @@ func (cp *CheckpointProcessor) fetchDividendAccountRoot() (accountroothash hmTyp
 
 	cp.Logger.Info("Divident account root fetched")
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &accountroothash); err != nil {
 		cp.Logger.Error("Error unmarshalling accountroothash received from Heimdall Server", "error", err)
 		return accountroothash, err
@@ -607,6 +610,7 @@ func (cp *CheckpointProcessor) getLastNoAckTime() uint64 {
 		return 0
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var noackObject Result
 	if err := json.Unmarshal(response.Result, &noackObject); err != nil {
 		cp.Logger.Error("Error unmarshalling no-ack data ", "error", err)

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -183,7 +183,8 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 func (cp *CheckpointProcessor) sendCheckpointToRootchain(eventBytes string, blockHeight int64) error {
 	cp.Logger.Info("Received sendCheckpointToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
 		cp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
@@ -256,7 +257,8 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 		return err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var log = types.Log{}
 	if err = json.Unmarshal([]byte(checkpointAckStr), &log); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -566,7 +568,7 @@ func (cp *CheckpointProcessor) fetchDividendAccountRoot() (accountroothash hmTyp
 
 	cp.Logger.Info("Divident account root fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &accountroothash); err != nil {
 		cp.Logger.Error("Error unmarshalling accountroothash received from Heimdall Server", "error", err)
 		return accountroothash, err
@@ -610,7 +612,7 @@ func (cp *CheckpointProcessor) getLastNoAckTime() uint64 {
 		return 0
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var noackObject Result
 	if err := json.Unmarshal(response.Result, &noackObject); err != nil {
 		cp.Logger.Error("Error unmarshalling no-ack data ", "error", err)

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -56,7 +56,7 @@ func (cp *ClerkProcessor) RegisterTasks() {
 func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes string) error {
 	start := time.Now()
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -56,7 +56,7 @@ func (cp *ClerkProcessor) RegisterTasks() {
 func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes string) error {
 	start := time.Now()
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -56,10 +56,8 @@ func (cp *ClerkProcessor) RegisterTasks() {
 func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes string) error {
 	start := time.Now()
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -57,6 +57,7 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 	start := time.Now()
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -2,10 +2,11 @@ package processor
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
@@ -55,6 +56,7 @@ func (cp *ClerkProcessor) RegisterTasks() {
 func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes string) error {
 	start := time.Now()
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		cp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/clerk_test.go
+++ b/bridge/setu/processor/clerk_test.go
@@ -3,7 +3,6 @@ package processor
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/json"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -13,6 +12,9 @@ import (
 	"github.com/RichardKnop/machinery/v1"
 	"github.com/RichardKnop/machinery/v1/config"
 	"github.com/golang/mock/gomock"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/spf13/viper"
+
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/bor/core/types"
 	"github.com/maticnetwork/heimdall/app"
@@ -24,7 +26,6 @@ import (
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/helper"
 	helperMocks "github.com/maticnetwork/heimdall/helper/mocks"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -614,6 +615,7 @@ func prepareDummyLogBytes() (*bytes.Buffer, error) {
 		Removed:     false,
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	reqBodyBytes := new(bytes.Buffer)
 	if err := json.NewEncoder(reqBodyBytes).Encode(log); err != nil {
 		return nil, err

--- a/bridge/setu/processor/clerk_test.go
+++ b/bridge/setu/processor/clerk_test.go
@@ -615,10 +615,8 @@ func prepareDummyLogBytes() (*bytes.Buffer, error) {
 		Removed:     false,
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	reqBodyBytes := new(bytes.Buffer)
-	if err := json.NewEncoder(reqBodyBytes).Encode(log); err != nil {
+	if err := jsoniter.ConfigFastest.NewEncoder(reqBodyBytes).Encode(log); err != nil {
 		return nil, err
 	}
 

--- a/bridge/setu/processor/clerk_test.go
+++ b/bridge/setu/processor/clerk_test.go
@@ -615,7 +615,7 @@ func prepareDummyLogBytes() (*bytes.Buffer, error) {
 		Removed:     false,
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	reqBodyBytes := new(bytes.Buffer)
 	if err := json.NewEncoder(reqBodyBytes).Encode(log); err != nil {

--- a/bridge/setu/processor/clerk_test.go
+++ b/bridge/setu/processor/clerk_test.go
@@ -615,7 +615,7 @@ func prepareDummyLogBytes() (*bytes.Buffer, error) {
 		Removed:     false,
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	reqBodyBytes := new(bytes.Buffer)
 	if err := json.NewEncoder(reqBodyBytes).Encode(log); err != nil {

--- a/bridge/setu/processor/clerk_test.go
+++ b/bridge/setu/processor/clerk_test.go
@@ -615,7 +615,8 @@ func prepareDummyLogBytes() (*bytes.Buffer, error) {
 		Removed:     false,
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	reqBodyBytes := new(bytes.Buffer)
 	if err := json.NewEncoder(reqBodyBytes).Encode(log); err != nil {
 		return nil, err

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -1,7 +1,8 @@
 package processor
 
 import (
-	"encoding/json"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
@@ -10,8 +11,6 @@ import (
 	"github.com/maticnetwork/heimdall/helper"
 	topupTypes "github.com/maticnetwork/heimdall/topup/types"
 	hmTypes "github.com/maticnetwork/heimdall/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // FeeProcessor - process fee related events
@@ -44,6 +43,7 @@ func (fp *FeeProcessor) RegisterTasks() {
 
 // processTopupFeeEvent - processes topup fee event
 func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		fp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -43,7 +43,7 @@ func (fp *FeeProcessor) RegisterTasks() {
 
 // processTopupFeeEvent - processes topup fee event
 func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		fp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -43,10 +43,8 @@ func (fp *FeeProcessor) RegisterTasks() {
 
 // processTopupFeeEvent - processes topup fee event
 func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		fp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -44,6 +44,7 @@ func (fp *FeeProcessor) RegisterTasks() {
 // processTopupFeeEvent - processes topup fee event
 func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		fp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/fee.go
+++ b/bridge/setu/processor/fee.go
@@ -43,7 +43,7 @@ func (fp *FeeProcessor) RegisterTasks() {
 
 // processTopupFeeEvent - processes topup fee event
 func (fp *FeeProcessor) sendTopUpFeeToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		fp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/json_test.go
+++ b/bridge/setu/processor/json_test.go
@@ -227,7 +227,27 @@ func BenchmarkJsonStandardLibrary(b *testing.B) {
 	}
 }
 
-func BenchmarkJsoniterLibrary(b *testing.B) {
+func BenchmarkJsoniterLibraryWithDefaultConfig(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StopTimer()
+
+	for i := 0; i < b.N; i++ {
+		validatorSet := types.ValidatorSet{}
+
+		b.StartTimer()
+
+		err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(validatorSetData), &validatorSet)
+		require.NoError(b, err)
+
+		_, err = jsoniter.ConfigFastest.Marshal(validatorSet)
+		require.NoError(b, err)
+
+		b.StopTimer()
+	}
+}
+
+func BenchmarkJsoniterLibraryWithFastestConfig(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.StopTimer()

--- a/bridge/setu/processor/json_test.go
+++ b/bridge/setu/processor/json_test.go
@@ -1,0 +1,237 @@
+package processor
+
+import (
+	"encoding/json"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/maticnetwork/heimdall/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const validatorSetData = `
+{
+	"validators": [{
+			"ID": 23,
+			"startEpoch": 72797,
+			"endEpoch": 0,
+			"nonce": 52,
+			"power": 2386,
+			"pubKey": "0x04b0a83d83b01c11ec491e18d264468d5fec83b3d89a3dc274c1090c6941318884aa6fe8018db897c588651df0e6e5773a0a55e7f6147e39a57f565e6196c1a0bb",
+			"signer": "0x0288a9ddca69a4784b3ecab3d8403ddfaaca8ba4",
+			"last_updated": "701494100012",
+			"jailed": false,
+			"accum": -60050137
+		},
+		{
+			"ID": 16,
+			"startEpoch": 60315,
+			"endEpoch": 0,
+			"nonce": 925,
+			"power": 1175,
+			"pubKey": "0x046e3874eef1f03eee0a1933489f4a1e349257be057fe9f180b2e21c29aa05a69d483ca73afe63b3b61c506fede81a30e2c16d75b8d42d91a7d2ec5454041d1ede",
+			"signer": "0x0651e9a1b5805fb67ac8cf82dfa4319e5be4d82c",
+			"last_updated": "702097300006",
+			"jailed": false,
+			"accum": 46469323
+		},
+		{
+			"ID": 19,
+			"startEpoch": 65978,
+			"endEpoch": 0,
+			"nonce": 798,
+			"power": 1529,
+			"pubKey": "0x0451048d2384c1b3b5f2ba9db1c1cd813aaf10e69bb0a4c7147b164b1b7e241bfe16f17e99cdf9b3cf476164fb670f81a40b26ea06d7d59ff254b544b6ca7851ee",
+			"signer": "0x12d8184f0747e33e68ab2d470dc6e870f242ea7a",
+			"last_updated": "701529500051",
+			"jailed": false,
+			"accum": -169957608
+		},
+		{
+			"ID": 9,
+			"startEpoch": 17380,
+			"endEpoch": 0,
+			"nonce": 65065,
+			"power": 54016735,
+			"pubKey": "0x045b89dc4610f6bc13b15dc628fb8094a8e1cb23c9e72644ec41417688665f9a123047f434356cd56974acf4a637cb95c8779a36982fd28ff758baf6e0b69bbf52",
+			"signer": "0x3a22c8bc68e98b0faf40f349dd2b2890fae01484",
+			"last_updated": "703823500014",
+			"jailed": false,
+			"accum": 91342318
+		},
+		{
+			"ID": 22,
+			"startEpoch": 72568,
+			"endEpoch": 0,
+			"nonce": 1,
+			"power": 100,
+			"pubKey": "0x040053708297eb4aad4b20d7dc906b880692526c3ff3416eb845ba4024f2b2a18080e30724aab820d5e715976f826325bcdd825935aab6c3613d756944538926db",
+			"signer": "0x5082f249cdb2f2c1ee035e4f423c46ea2dab3ab1",
+			"last_updated": "667330300051",
+			"jailed": false,
+			"accum": -10683298
+		},
+		{
+			"ID": 21,
+			"startEpoch": 71794,
+			"endEpoch": 0,
+			"nonce": 106,
+			"power": 1204,
+			"pubKey": "0x041a98df71f1cddbc00530f39c6364a8fc250850e514c1f5ab6d4df47f9974842936b9805adc441d5526148613a2c3bc189a68957a633851dbf2730da29f05241f",
+			"signer": "0x518d0f73e34b46b435b485283ef6255fe8436ed5",
+			"last_updated": "706193800008",
+			"jailed": false,
+			"accum": 39839283
+		},
+		{
+			"ID": 20,
+			"startEpoch": 65980,
+			"endEpoch": 0,
+			"nonce": 845,
+			"power": 734,
+			"pubKey": "0x045ef9aabe6b3b4b9c57c319299f7c7bf483baf6f0381eb4f2031b30c2984166cd18f407faac255d8c86be734c566ec0666f9c6eaff52fc660414adece69607aec",
+			"signer": "0x5a1715e478859da38e8749d4c55fef5b7a65387a",
+			"last_updated": "701480800023",
+			"jailed": false,
+			"accum": 44109244
+		},
+		{
+			"ID": 18,
+			"startEpoch": 65872,
+			"endEpoch": 0,
+			"nonce": 643,
+			"power": 14951,
+			"pubKey": "0x049b61f7033294a17c2657fbf55ead9c0c84f42c573c90eeea4f256ae1cd4f0113e71a280458ccd3680761ca27548ccd9b36d7704fb413ce1e208e34e820721fff",
+			"signer": "0x6fd70512f0e9e30e75e104f00402a49ac9eb277a",
+			"last_updated": "699680700008",
+			"jailed": false,
+			"accum": 66266480
+		},
+		{
+			"ID": 10,
+			"startEpoch": 29689,
+			"endEpoch": 0,
+			"nonce": 237,
+			"power": 37896,
+			"pubKey": "0x041f2c0ff8f11c0584bad20b3d275a025f567deda7b8ec97600509398cceba1f3649fc8b424b4754032980770a4c495706d5191d051e6423d5b8e63cd7792aa3d5",
+			"signer": "0x92da9f8f3ee16a276896fc7b2550b2151aae0332",
+			"last_updated": "699239100021",
+			"jailed": false,
+			"accum": 50174785
+		},
+		{
+			"ID": 2,
+			"startEpoch": 0,
+			"endEpoch": 0,
+			"nonce": 78958,
+			"power": 55387659,
+			"pubKey": "0x04888a737a003f4e522ccf23bd9980fdbe7ef2b54365249deba0f9acd45279d66355b1864173b2cf9e75a1cbfb45e65a1a72b9ea76e47aa4bd50d79772ef301769",
+			"signer": "0xbe188d6641e8b680743a4815dfa0f6208038960f",
+			"last_updated": "696958900017",
+			"jailed": false,
+			"accum": 48512227
+		},
+		{
+			"ID": 1,
+			"startEpoch": 0,
+			"endEpoch": 0,
+			"nonce": 158281,
+			"power": 56349433,
+			"pubKey": "0x040bec8102c221c7cfff3e250bb6cc01c3b9a3964fb1bf4d53e91905320eef09595acb09ee0950e7374ec19488ff2523f186f6b1a9164c78dba8602e4e3c4eb013",
+			"signer": "0xc26880a0af2ea0c7e8130e6ec47af756465452e8",
+			"last_updated": "706221600090",
+			"jailed": false,
+			"accum": 65277101
+		},
+		{
+			"ID": 3,
+			"startEpoch": 0,
+			"endEpoch": 0,
+			"nonce": 65654,
+			"power": 46071442,
+			"pubKey": "0x04f3f18a027c929380417d2bd7d2a489cb662d4977e9daff335bc51f23c1c5f5f468aa19c6c8e937a745462ef2550bce42e4f38608dffb5a06e7b9d27d964cffee",
+			"signer": "0xc275dc8be39f50d12f66b6a63629c39da5bae5bd",
+			"last_updated": "701533000056",
+			"jailed": false,
+			"accum": 51535588
+		},
+		{
+			"ID": 14,
+			"startEpoch": 42535,
+			"endEpoch": 0,
+			"nonce": 84,
+			"power": 7113,
+			"pubKey": "0x046e58afa78fade1229ce3bebe3ed5435d895cfdc399323d4f20752935ff04dc514e8f3320a8d5434a13acc9209b9657ebbdf154ae715830135997f6c2ae028258",
+			"signer": "0xc443279a66280fa9bb2916999c5c2d2facab0579",
+			"last_updated": "705224200008",
+			"jailed": false,
+			"accum": -154620784
+		},
+		{
+			"ID": 11,
+			"startEpoch": 35313,
+			"endEpoch": 0,
+			"nonce": 169,
+			"power": 1274,
+			"pubKey": "0x04161cf579b40ea1a68f166da216c50e88f1323213cd22a8ffa6acabc45893a80250b5aafa6dea6e4a0289ebabe8b2996ae806098b7d88d2eee8634ec73fe2edfd",
+			"signer": "0xc4acf8fbe2829cb0c209dff15a98b3dc13f12b1f",
+			"last_updated": "695091100099",
+			"jailed": false,
+			"accum": 54747128
+		},
+		{
+			"ID": 4,
+			"startEpoch": 0,
+			"endEpoch": 0,
+			"nonce": 158405,
+			"power": 45333182,
+			"pubKey": "0x04dcd2883416e7b8663caafbfc885e757b0ea809657df8d6f322f01a0c5a11fd033bf13d3e0d5e88feff92ba415d32d626e3f7d9dd7b5ec7c2fef8ded83d660ac2",
+			"signer": "0xf903ba9e006193c1527bfbe65fe2123704ea3f99",
+			"last_updated": "706173600012",
+			"jailed": false,
+			"accum": -162961648
+		}
+	],
+	"proposer": {
+		"ID": 4,
+		"startEpoch": 0,
+		"endEpoch": 0,
+		"nonce": 158405,
+		"power": 45333182,
+		"pubKey": "0x04dcd2883416e7b8663caafbfc885e757b0ea809657df8d6f322f01a0c5a11fd033bf13d3e0d5e88feff92ba415d32d626e3f7d9dd7b5ec7c2fef8ded83d660ac2",
+		"signer": "0xf903ba9e006193c1527bfbe65fe2123704ea3f99",
+		"last_updated": "706173600012",
+		"jailed": false,
+		"accum": -162961648
+	}
+}`
+
+func BenchmarkJsonStandardLibrary(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StopTimer()
+
+	for i := 0; i < b.N; i++ {
+		validatorSet := types.ValidatorSet{}
+		b.StartTimer()
+		err := json.Unmarshal([]byte(validatorSetData), &validatorSet)
+		_, err = json.Marshal(validatorSet)
+		b.StopTimer()
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkJsoniterLibrary(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StopTimer()
+
+	for i := 0; i < b.N; i++ {
+		validatorSet := types.ValidatorSet{}
+		jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
+		b.StartTimer()
+		err := jsonLib.Unmarshal([]byte(validatorSetData), &validatorSet)
+		_, err = jsonLib.Marshal(validatorSet)
+		b.StopTimer()
+		require.NoError(b, err)
+	}
+}

--- a/bridge/setu/processor/json_test.go
+++ b/bridge/setu/processor/json_test.go
@@ -234,14 +234,13 @@ func BenchmarkJsoniterLibrary(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		validatorSet := types.ValidatorSet{}
-		jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		b.StartTimer()
 
-		err := jsonLib.Unmarshal([]byte(validatorSetData), &validatorSet)
+		err := jsoniter.ConfigFastest.Unmarshal([]byte(validatorSetData), &validatorSet)
 		require.NoError(b, err)
 
-		_, err = jsonLib.Marshal(validatorSet)
+		_, err = jsoniter.ConfigFastest.Marshal(validatorSet)
 		require.NoError(b, err)
 
 		b.StopTimer()

--- a/bridge/setu/processor/json_test.go
+++ b/bridge/setu/processor/json_test.go
@@ -2,10 +2,12 @@ package processor
 
 import (
 	"encoding/json"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/maticnetwork/heimdall/types"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/maticnetwork/heimdall/types"
 )
 
 const validatorSetData = `
@@ -212,11 +214,16 @@ func BenchmarkJsonStandardLibrary(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		validatorSet := types.ValidatorSet{}
+
 		b.StartTimer()
+
 		err := json.Unmarshal([]byte(validatorSetData), &validatorSet)
-		_, err = json.Marshal(validatorSet)
-		b.StopTimer()
 		require.NoError(b, err)
+
+		_, err = json.Marshal(validatorSet)
+		require.NoError(b, err)
+
+		b.StopTimer()
 	}
 }
 
@@ -228,10 +235,15 @@ func BenchmarkJsoniterLibrary(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		validatorSet := types.ValidatorSet{}
 		jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
+
 		b.StartTimer()
+
 		err := jsonLib.Unmarshal([]byte(validatorSetData), &validatorSet)
-		_, err = jsonLib.Marshal(validatorSet)
-		b.StopTimer()
 		require.NoError(b, err)
+
+		_, err = jsonLib.Marshal(validatorSet)
+		require.NoError(b, err)
+
+		b.StopTimer()
 	}
 }

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -70,7 +70,7 @@ func (sp *SlashingProcessor) RegisterTasks() {
 func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight int64) error {
 	sp.Logger.Info("Recevied sendTickToHeimdall request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
@@ -126,7 +126,7 @@ func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight i
 func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight int64) (err error) {
 	sp.Logger.Info("Recevied sendTickToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var event sdk.StringEvent
 	if err = json.Unmarshal([]byte(eventBytes), &event); err != nil {
@@ -195,7 +195,7 @@ func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight 
 sendTickAckToHeimdall - sends tick ack msg to heimdall
 */
 func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -247,7 +247,7 @@ func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes st
 sendUnjailToHeimdall - sends unjail msg to heimdall
 */
 func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -377,7 +377,7 @@ func (sp *SlashingProcessor) fetchLatestSlashInoBytes() (slashInfoBytes hmTypes.
 
 	sp.Logger.Info("Latest slashInfoBytes fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &slashInfoBytes); err != nil {
 		sp.Logger.Error("Error unmarshalling latest slashInfoBytes received from Heimdall Server", "error", err)
 		return slashInfoBytes, err
@@ -396,7 +396,7 @@ func (sp *SlashingProcessor) fetchTickCount() (tickCount uint64, err error) {
 		return tickCount, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &tickCount); err != nil {
 		sp.Logger.Error("Error unmarshalling tick count data ", "error", err)
 		return tickCount, err
@@ -417,7 +417,7 @@ func (sp *SlashingProcessor) fetchTickSlashInfoList() (slashInfoList []*hmTypes.
 
 	sp.Logger.Info("Tick SlashInfo List fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &slashInfoList); err != nil {
 		sp.Logger.Error("Error unmarshalling tick slashinfo list received from Heimdall Server", "error", err)
 		return slashInfoList, err

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -70,7 +70,8 @@ func (sp *SlashingProcessor) RegisterTasks() {
 func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight int64) error {
 	sp.Logger.Info("Recevied sendTickToHeimdall request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
 		sp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
@@ -125,7 +126,8 @@ func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight i
 func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight int64) (err error) {
 	sp.Logger.Info("Recevied sendTickToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var event sdk.StringEvent
 	if err = json.Unmarshal([]byte(eventBytes), &event); err != nil {
 		sp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
@@ -193,7 +195,7 @@ func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight 
 sendTickAckToHeimdall - sends tick ack msg to heimdall
 */
 func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -245,7 +247,7 @@ func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes st
 sendUnjailToHeimdall - sends unjail msg to heimdall
 */
 func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -375,7 +377,7 @@ func (sp *SlashingProcessor) fetchLatestSlashInoBytes() (slashInfoBytes hmTypes.
 
 	sp.Logger.Info("Latest slashInfoBytes fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &slashInfoBytes); err != nil {
 		sp.Logger.Error("Error unmarshalling latest slashInfoBytes received from Heimdall Server", "error", err)
 		return slashInfoBytes, err
@@ -394,7 +396,7 @@ func (sp *SlashingProcessor) fetchTickCount() (tickCount uint64, err error) {
 		return tickCount, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &tickCount); err != nil {
 		sp.Logger.Error("Error unmarshalling tick count data ", "error", err)
 		return tickCount, err
@@ -415,7 +417,7 @@ func (sp *SlashingProcessor) fetchTickSlashInfoList() (slashInfoList []*hmTypes.
 
 	sp.Logger.Info("Tick SlashInfo List fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &slashInfoList); err != nil {
 		sp.Logger.Error("Error unmarshalling tick slashinfo list received from Heimdall Server", "error", err)
 		return slashInfoList, err

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -70,7 +70,7 @@ func (sp *SlashingProcessor) RegisterTasks() {
 func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight int64) error {
 	sp.Logger.Info("Recevied sendTickToHeimdall request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
@@ -126,7 +126,7 @@ func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight i
 func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight int64) (err error) {
 	sp.Logger.Info("Recevied sendTickToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var event sdk.StringEvent
 	if err = json.Unmarshal([]byte(eventBytes), &event); err != nil {
@@ -195,7 +195,7 @@ func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight 
 sendTickAckToHeimdall - sends tick ack msg to heimdall
 */
 func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -247,7 +247,7 @@ func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes st
 sendUnjailToHeimdall - sends unjail msg to heimdall
 */
 func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -377,7 +377,7 @@ func (sp *SlashingProcessor) fetchLatestSlashInoBytes() (slashInfoBytes hmTypes.
 
 	sp.Logger.Info("Latest slashInfoBytes fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &slashInfoBytes); err != nil {
 		sp.Logger.Error("Error unmarshalling latest slashInfoBytes received from Heimdall Server", "error", err)
 		return slashInfoBytes, err
@@ -396,7 +396,7 @@ func (sp *SlashingProcessor) fetchTickCount() (tickCount uint64, err error) {
 		return tickCount, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &tickCount); err != nil {
 		sp.Logger.Error("Error unmarshalling tick count data ", "error", err)
 		return tickCount, err
@@ -417,7 +417,7 @@ func (sp *SlashingProcessor) fetchTickSlashInfoList() (slashInfoList []*hmTypes.
 
 	sp.Logger.Info("Tick SlashInfo List fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &slashInfoList); err != nil {
 		sp.Logger.Error("Error unmarshalling tick slashinfo list received from Heimdall Server", "error", err)
 		return slashInfoList, err

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -196,6 +196,7 @@ sendTickAckToHeimdall - sends tick ack msg to heimdall
 */
 func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes string) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -248,6 +249,7 @@ sendUnjailToHeimdall - sends unjail msg to heimdall
 */
 func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes string) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -3,10 +3,11 @@ package processor
 import (
 	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/bor/core/types"
@@ -69,6 +70,7 @@ func (sp *SlashingProcessor) RegisterTasks() {
 func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight int64) error {
 	sp.Logger.Info("Recevied sendTickToHeimdall request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var event sdk.StringEvent
 	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
 		sp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
@@ -123,6 +125,7 @@ func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight i
 func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight int64) (err error) {
 	sp.Logger.Info("Recevied sendTickToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var event sdk.StringEvent
 	if err = json.Unmarshal([]byte(eventBytes), &event); err != nil {
 		sp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
@@ -190,6 +193,7 @@ func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight 
 sendTickAckToHeimdall - sends tick ack msg to heimdall
 */
 func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes string) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -241,6 +245,7 @@ func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes st
 sendUnjailToHeimdall - sends unjail msg to heimdall
 */
 func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes string) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -370,6 +375,7 @@ func (sp *SlashingProcessor) fetchLatestSlashInoBytes() (slashInfoBytes hmTypes.
 
 	sp.Logger.Info("Latest slashInfoBytes fetched")
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &slashInfoBytes); err != nil {
 		sp.Logger.Error("Error unmarshalling latest slashInfoBytes received from Heimdall Server", "error", err)
 		return slashInfoBytes, err
@@ -388,6 +394,7 @@ func (sp *SlashingProcessor) fetchTickCount() (tickCount uint64, err error) {
 		return tickCount, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &tickCount); err != nil {
 		sp.Logger.Error("Error unmarshalling tick count data ", "error", err)
 		return tickCount, err
@@ -408,6 +415,7 @@ func (sp *SlashingProcessor) fetchTickSlashInfoList() (slashInfoList []*hmTypes.
 
 	sp.Logger.Info("Tick SlashInfo List fetched")
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &slashInfoList); err != nil {
 		sp.Logger.Error("Error unmarshalling tick slashinfo list received from Heimdall Server", "error", err)
 		return slashInfoList, err

--- a/bridge/setu/processor/slashing.go
+++ b/bridge/setu/processor/slashing.go
@@ -70,10 +70,8 @@ func (sp *SlashingProcessor) RegisterTasks() {
 func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight int64) error {
 	sp.Logger.Info("Recevied sendTickToHeimdall request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var event sdk.StringEvent
-	if err := json.Unmarshal([]byte(eventBytes), &event); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(eventBytes), &event); err != nil {
 		sp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
 		return err
 	}
@@ -126,10 +124,8 @@ func (sp *SlashingProcessor) sendTickToHeimdall(eventBytes string, blockHeight i
 func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight int64) (err error) {
 	sp.Logger.Info("Recevied sendTickToRootchain request", "eventBytes", eventBytes, "blockHeight", blockHeight)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var event sdk.StringEvent
-	if err = json.Unmarshal([]byte(eventBytes), &event); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal([]byte(eventBytes), &event); err != nil {
 		sp.Logger.Error("Error unmarshalling event from heimdall", "error", err)
 		return err
 	}
@@ -195,10 +191,8 @@ func (sp *SlashingProcessor) sendTickToRootchain(eventBytes string, blockHeight 
 sendTickAckToHeimdall - sends tick ack msg to heimdall
 */
 func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}
@@ -248,10 +242,8 @@ func (sp *SlashingProcessor) sendTickAckToHeimdall(eventName string, logBytes st
 sendUnjailToHeimdall - sends unjail msg to heimdall
 */
 func (sp *SlashingProcessor) sendUnjailToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}
@@ -379,8 +371,7 @@ func (sp *SlashingProcessor) fetchLatestSlashInoBytes() (slashInfoBytes hmTypes.
 
 	sp.Logger.Info("Latest slashInfoBytes fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err := json.Unmarshal(response.Result, &slashInfoBytes); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(response.Result, &slashInfoBytes); err != nil {
 		sp.Logger.Error("Error unmarshalling latest slashInfoBytes received from Heimdall Server", "error", err)
 		return slashInfoBytes, err
 	}
@@ -398,8 +389,7 @@ func (sp *SlashingProcessor) fetchTickCount() (tickCount uint64, err error) {
 		return tickCount, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(response.Result, &tickCount); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &tickCount); err != nil {
 		sp.Logger.Error("Error unmarshalling tick count data ", "error", err)
 		return tickCount, err
 	}
@@ -419,8 +409,7 @@ func (sp *SlashingProcessor) fetchTickSlashInfoList() (slashInfoList []*hmTypes.
 
 	sp.Logger.Info("Tick SlashInfo List fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(response.Result, &slashInfoList); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &slashInfoList); err != nil {
 		sp.Logger.Error("Error unmarshalling tick slashinfo list received from Heimdall Server", "error", err)
 		return slashInfoList, err
 	}

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -137,10 +137,8 @@ func (sp *SpanProcessor) getLastSpan() (*types.Span, error) {
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var lastSpan types.Span
-	if err = json.Unmarshal(result.Result, &lastSpan); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(result.Result, &lastSpan); err != nil {
 		sp.Logger.Error("Error unmarshalling span", "error", err)
 		return nil, err
 	}
@@ -198,10 +196,8 @@ func (sp *SpanProcessor) fetchNextSpanDetails(id uint64, start uint64) (*types.S
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var msg types.Span
-	if err = json.Unmarshal(result.Result, &msg); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(result.Result, &msg); err != nil {
 		sp.Logger.Error("Error unmarshalling propose tx msg ", "error", err)
 		return nil, err
 	}
@@ -223,8 +219,7 @@ func (sp *SpanProcessor) fetchNextSpanSeed() (nextSpanSeed common.Hash, err erro
 
 	sp.Logger.Info("Next span seed fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(response.Result, &nextSpanSeed); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &nextSpanSeed); err != nil {
 		sp.Logger.Error("Error unmarshalling nextSpanSeed received from Heimdall Server", "error", err)
 		return nextSpanSeed, err
 	}

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -137,7 +137,8 @@ func (sp *SpanProcessor) getLastSpan() (*types.Span, error) {
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var lastSpan types.Span
 	if err = json.Unmarshal(result.Result, &lastSpan); err != nil {
 		sp.Logger.Error("Error unmarshalling span", "error", err)
@@ -197,7 +198,7 @@ func (sp *SpanProcessor) fetchNextSpanDetails(id uint64, start uint64) (*types.S
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var msg types.Span
 	if err = json.Unmarshal(result.Result, &msg); err != nil {
 		sp.Logger.Error("Error unmarshalling propose tx msg ", "error", err)
@@ -221,7 +222,7 @@ func (sp *SpanProcessor) fetchNextSpanSeed() (nextSpanSeed common.Hash, err erro
 
 	sp.Logger.Info("Next span seed fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &nextSpanSeed); err != nil {
 		sp.Logger.Error("Error unmarshalling nextSpanSeed received from Heimdall Server", "error", err)
 		return nextSpanSeed, err

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -137,7 +137,7 @@ func (sp *SpanProcessor) getLastSpan() (*types.Span, error) {
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var lastSpan types.Span
 	if err = json.Unmarshal(result.Result, &lastSpan); err != nil {
@@ -198,7 +198,7 @@ func (sp *SpanProcessor) fetchNextSpanDetails(id uint64, start uint64) (*types.S
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var msg types.Span
 	if err = json.Unmarshal(result.Result, &msg); err != nil {
 		sp.Logger.Error("Error unmarshalling propose tx msg ", "error", err)
@@ -222,7 +222,7 @@ func (sp *SpanProcessor) fetchNextSpanSeed() (nextSpanSeed common.Hash, err erro
 
 	sp.Logger.Info("Next span seed fetched")
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &nextSpanSeed); err != nil {
 		sp.Logger.Error("Error unmarshalling nextSpanSeed received from Heimdall Server", "error", err)
 		return nextSpanSeed, err

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -3,17 +3,16 @@ package processor
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/maticnetwork/bor/common"
+	borTypes "github.com/maticnetwork/heimdall/bor/types"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	"github.com/maticnetwork/heimdall/helper"
-
-	borTypes "github.com/maticnetwork/heimdall/bor/types"
-
 	"github.com/maticnetwork/heimdall/types"
 )
 
@@ -138,6 +137,7 @@ func (sp *SpanProcessor) getLastSpan() (*types.Span, error) {
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var lastSpan types.Span
 	if err = json.Unmarshal(result.Result, &lastSpan); err != nil {
 		sp.Logger.Error("Error unmarshalling span", "error", err)
@@ -197,6 +197,7 @@ func (sp *SpanProcessor) fetchNextSpanDetails(id uint64, start uint64) (*types.S
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var msg types.Span
 	if err = json.Unmarshal(result.Result, &msg); err != nil {
 		sp.Logger.Error("Error unmarshalling propose tx msg ", "error", err)
@@ -220,6 +221,7 @@ func (sp *SpanProcessor) fetchNextSpanSeed() (nextSpanSeed common.Hash, err erro
 
 	sp.Logger.Info("Next span seed fetched")
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &nextSpanSeed); err != nil {
 		sp.Logger.Error("Error unmarshalling nextSpanSeed received from Heimdall Server", "error", err)
 		return nextSpanSeed, err

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -199,6 +199,7 @@ func (sp *SpanProcessor) fetchNextSpanDetails(id uint64, start uint64) (*types.S
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var msg types.Span
 	if err = json.Unmarshal(result.Result, &msg); err != nil {
 		sp.Logger.Error("Error unmarshalling propose tx msg ", "error", err)

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -137,7 +137,7 @@ func (sp *SpanProcessor) getLastSpan() (*types.Span, error) {
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var lastSpan types.Span
 	if err = json.Unmarshal(result.Result, &lastSpan); err != nil {
@@ -198,7 +198,7 @@ func (sp *SpanProcessor) fetchNextSpanDetails(id uint64, start uint64) (*types.S
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var msg types.Span
 	if err = json.Unmarshal(result.Result, &msg); err != nil {
 		sp.Logger.Error("Error unmarshalling propose tx msg ", "error", err)
@@ -222,7 +222,7 @@ func (sp *SpanProcessor) fetchNextSpanSeed() (nextSpanSeed common.Hash, err erro
 
 	sp.Logger.Info("Next span seed fetched")
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(response.Result, &nextSpanSeed); err != nil {
 		sp.Logger.Error("Error unmarshalling nextSpanSeed received from Heimdall Server", "error", err)
 		return nextSpanSeed, err

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -63,10 +63,8 @@ func (sp *StakingProcessor) RegisterTasks() {
 }
 
 func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}
@@ -143,10 +141,8 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 }
 
 func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}
@@ -216,10 +212,8 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}
@@ -285,10 +279,8 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var vLog = types.Log{}
-	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
 		return err
 	}

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -64,6 +64,7 @@ func (sp *StakingProcessor) RegisterTasks() {
 
 func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logBytes string) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -143,6 +144,7 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 
 func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes string) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -215,6 +217,7 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 
 func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes string) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -283,6 +286,7 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 
 func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logBytes string) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -63,7 +63,7 @@ func (sp *StakingProcessor) RegisterTasks() {
 }
 
 func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -142,7 +142,7 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 }
 
 func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -214,7 +214,7 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -282,7 +282,7 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logBytes string) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -63,7 +63,7 @@ func (sp *StakingProcessor) RegisterTasks() {
 }
 
 func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -142,7 +142,7 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 }
 
 func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -214,7 +214,7 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -282,7 +282,7 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logBytes string) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -1,13 +1,14 @@
 package processor
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/maticnetwork/bor/accounts/abi"
 	"github.com/maticnetwork/bor/core/types"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
@@ -62,6 +63,7 @@ func (sp *StakingProcessor) RegisterTasks() {
 }
 
 func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logBytes string) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -140,6 +142,7 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 }
 
 func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes string) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -211,6 +214,7 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes string) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)
@@ -278,6 +282,7 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 }
 
 func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logBytes string) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var vLog = types.Log{}
 	if err := json.Unmarshal([]byte(logBytes), &vLog); err != nil {
 		sp.Logger.Error("Error while unmarshalling event from rootchain", "error", err)

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -127,6 +127,7 @@ func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	err = json.Unmarshal(result.Result, &proposers)
 	if err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
@@ -359,8 +360,8 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainManagerTypes.Par
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	var params chainManagerTypes.Params
 
+	var params chainManagerTypes.Params
 	if err = json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling chainmanager params", "url", ChainManagerParamsURL, "err", err)
 		return nil, err
@@ -382,6 +383,7 @@ func GetCheckpointParams(cliCtx cliContext.CLIContext) (*checkpointTypes.Params,
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var params checkpointTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling Checkpoint params", "url", CheckpointParamsURL)
@@ -404,6 +406,7 @@ func GetBufferedCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, e
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var checkpoint hmtypes.Checkpoint
 	if err := json.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling buffered checkpoint", "url", BufferedCheckpointURL, "err", err)
@@ -547,6 +550,7 @@ func GetUnconfirmedTxnCount(event interface{}) int {
 	var response TendermintUnconfirmedTxs
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -126,7 +126,7 @@ func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(result.Result, &proposers)
 	if err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
@@ -156,7 +156,7 @@ func IsInProposerList(cliCtx cliContext.CLIContext, count uint64) (bool, error) 
 	// unmarshall data from buffer
 	var proposers []hmtypes.Validator
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &proposers); err != nil {
 		logger.Error("Error unmarshalling validator data ", "error", err)
 		return false, err
@@ -224,7 +224,7 @@ func IsCurrentProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &proposer); err != nil {
 		logger.Error("error unmarshalling validator", "error", err)
 		return false, err
@@ -253,7 +253,7 @@ func IsEventSender(cliCtx cliContext.CLIContext, validatorID uint64) bool {
 		return false
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
 		return false
@@ -358,8 +358,9 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainManagerTypes.Par
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var params chainManagerTypes.Params
+
 	if err = json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling chainmanager params", "url", ChainManagerParamsURL, "err", err)
 		return nil, err
@@ -380,7 +381,7 @@ func GetCheckpointParams(cliCtx cliContext.CLIContext) (*checkpointTypes.Params,
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var params checkpointTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling Checkpoint params", "url", CheckpointParamsURL)
@@ -402,7 +403,7 @@ func GetBufferedCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, e
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var checkpoint hmtypes.Checkpoint
 	if err := json.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling buffered checkpoint", "url", BufferedCheckpointURL, "err", err)
@@ -424,7 +425,8 @@ func GetLatestCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, err
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var checkpoint hmtypes.Checkpoint
 	if err = json.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling latest checkpoint", "url", LatestCheckpointURL, "err", err)
@@ -458,7 +460,7 @@ func GetValidatorNonce(cliCtx cliContext.CLIContext, validatorID uint64) (uint64
 		return 0, 0, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling validator data", "error", err)
 		return 0, 0, err
@@ -477,7 +479,8 @@ func GetValidatorSet(cliCtx cliContext.CLIContext) (*hmtypes.ValidatorSet, error
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var validatorSet hmtypes.ValidatorSet
 	if err = json.Unmarshal(response.Result, &validatorSet); err != nil {
 		logger.Error("Error unmarshalling current validatorset data ", "error", err)
@@ -512,7 +515,8 @@ func GetClerkEventRecord(cliCtx cliContext.CLIContext, stateId int64) (*clerktyp
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var eventRecord clerktypes.EventRecord
 	if err = json.Unmarshal(response.Result, &eventRecord); err != nil {
 		logger.Error("Error unmarshalling event record", "error", err)
@@ -542,7 +546,7 @@ func GetUnconfirmedTxnCount(event interface{}) int {
 	// a minimal response of the unconfirmed txs
 	var response TendermintUnconfirmedTxs
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -126,7 +126,7 @@ func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(result.Result, &proposers)
 	if err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
@@ -156,7 +156,7 @@ func IsInProposerList(cliCtx cliContext.CLIContext, count uint64) (bool, error) 
 	// unmarshall data from buffer
 	var proposers []hmtypes.Validator
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &proposers); err != nil {
 		logger.Error("Error unmarshalling validator data ", "error", err)
 		return false, err
@@ -224,7 +224,7 @@ func IsCurrentProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &proposer); err != nil {
 		logger.Error("error unmarshalling validator", "error", err)
 		return false, err
@@ -253,7 +253,7 @@ func IsEventSender(cliCtx cliContext.CLIContext, validatorID uint64) bool {
 		return false
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
 		return false
@@ -358,7 +358,7 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainManagerTypes.Par
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var params chainManagerTypes.Params
 
 	if err = json.Unmarshal(response.Result, &params); err != nil {
@@ -381,7 +381,7 @@ func GetCheckpointParams(cliCtx cliContext.CLIContext) (*checkpointTypes.Params,
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var params checkpointTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling Checkpoint params", "url", CheckpointParamsURL)
@@ -403,7 +403,7 @@ func GetBufferedCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, e
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var checkpoint hmtypes.Checkpoint
 	if err := json.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling buffered checkpoint", "url", BufferedCheckpointURL, "err", err)
@@ -425,7 +425,7 @@ func GetLatestCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, err
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var checkpoint hmtypes.Checkpoint
 	if err = json.Unmarshal(response.Result, &checkpoint); err != nil {
@@ -460,7 +460,7 @@ func GetValidatorNonce(cliCtx cliContext.CLIContext, validatorID uint64) (uint64
 		return 0, 0, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling validator data", "error", err)
 		return 0, 0, err
@@ -479,7 +479,7 @@ func GetValidatorSet(cliCtx cliContext.CLIContext) (*hmtypes.ValidatorSet, error
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var validatorSet hmtypes.ValidatorSet
 	if err = json.Unmarshal(response.Result, &validatorSet); err != nil {
@@ -515,7 +515,7 @@ func GetClerkEventRecord(cliCtx cliContext.CLIContext, stateId int64) (*clerktyp
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var eventRecord clerktypes.EventRecord
 	if err = json.Unmarshal(response.Result, &eventRecord); err != nil {
@@ -546,7 +546,7 @@ func GetUnconfirmedTxnCount(event interface{}) int {
 	// a minimal response of the unconfirmed txs
 	var response TendermintUnconfirmedTxs
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -126,9 +126,7 @@ func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	err = json.Unmarshal(result.Result, &proposers)
+	err = jsoniter.ConfigFastest.Unmarshal(result.Result, &proposers)
 	if err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
 		return false, err
@@ -156,9 +154,7 @@ func IsInProposerList(cliCtx cliContext.CLIContext, count uint64) (bool, error) 
 
 	// unmarshall data from buffer
 	var proposers []hmtypes.Validator
-
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err := json.Unmarshal(response.Result, &proposers); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(response.Result, &proposers); err != nil {
 		logger.Error("Error unmarshalling validator data ", "error", err)
 		return false, err
 	}
@@ -225,8 +221,7 @@ func IsCurrentProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(result.Result, &proposer); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(result.Result, &proposer); err != nil {
 		logger.Error("error unmarshalling validator", "error", err)
 		return false, err
 	}
@@ -254,8 +249,7 @@ func IsEventSender(cliCtx cliContext.CLIContext, validatorID uint64) bool {
 		return false
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(result.Result, &validator); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
 		return false
 	}
@@ -359,10 +353,8 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainManagerTypes.Par
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var params chainManagerTypes.Params
-	if err = json.Unmarshal(response.Result, &params); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling chainmanager params", "url", ChainManagerParamsURL, "err", err)
 		return nil, err
 	}
@@ -382,10 +374,8 @@ func GetCheckpointParams(cliCtx cliContext.CLIContext) (*checkpointTypes.Params,
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var params checkpointTypes.Params
-	if err := json.Unmarshal(response.Result, &params); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling Checkpoint params", "url", CheckpointParamsURL)
 		return nil, err
 	}
@@ -405,10 +395,8 @@ func GetBufferedCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, e
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var checkpoint hmtypes.Checkpoint
-	if err := json.Unmarshal(response.Result, &checkpoint); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling buffered checkpoint", "url", BufferedCheckpointURL, "err", err)
 		return nil, err
 	}
@@ -428,10 +416,8 @@ func GetLatestCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, err
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var checkpoint hmtypes.Checkpoint
-	if err = json.Unmarshal(response.Result, &checkpoint); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling latest checkpoint", "url", LatestCheckpointURL, "err", err)
 		return nil, err
 	}
@@ -463,8 +449,7 @@ func GetValidatorNonce(cliCtx cliContext.CLIContext, validatorID uint64) (uint64
 		return 0, 0, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	if err = json.Unmarshal(result.Result, &validator); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling validator data", "error", err)
 		return 0, 0, err
 	}
@@ -482,10 +467,8 @@ func GetValidatorSet(cliCtx cliContext.CLIContext) (*hmtypes.ValidatorSet, error
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var validatorSet hmtypes.ValidatorSet
-	if err = json.Unmarshal(response.Result, &validatorSet); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &validatorSet); err != nil {
 		logger.Error("Error unmarshalling current validatorset data ", "error", err)
 		return nil, err
 	}
@@ -518,10 +501,8 @@ func GetClerkEventRecord(cliCtx cliContext.CLIContext, stateId int64) (*clerktyp
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var eventRecord clerktypes.EventRecord
-	if err = json.Unmarshal(response.Result, &eventRecord); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(response.Result, &eventRecord); err != nil {
 		logger.Error("Error unmarshalling event record", "error", err)
 		return nil, err
 	}
@@ -548,10 +529,7 @@ func GetUnconfirmedTxnCount(event interface{}) int {
 
 	// a minimal response of the unconfirmed txs
 	var response TendermintUnconfirmedTxs
-
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	err = json.Unmarshal(body, &response)
+	err = jsoniter.ConfigFastest.Unmarshal(body, &response)
 	if err != nil {
 		logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)
 		return 0

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -529,6 +529,7 @@ func GetUnconfirmedTxnCount(event interface{}) int {
 
 	// a minimal response of the unconfirmed txs
 	var response TendermintUnconfirmedTxs
+
 	err = jsoniter.ConfigFastest.Unmarshal(body, &response)
 	if err != nil {
 		logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -126,7 +126,7 @@ func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(result.Result, &proposers)
 	if err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
@@ -156,7 +156,7 @@ func IsInProposerList(cliCtx cliContext.CLIContext, count uint64) (bool, error) 
 	// unmarshall data from buffer
 	var proposers []hmtypes.Validator
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &proposers); err != nil {
 		logger.Error("Error unmarshalling validator data ", "error", err)
 		return false, err
@@ -224,7 +224,7 @@ func IsCurrentProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &proposer); err != nil {
 		logger.Error("error unmarshalling validator", "error", err)
 		return false, err
@@ -253,7 +253,7 @@ func IsEventSender(cliCtx cliContext.CLIContext, validatorID uint64) bool {
 		return false
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
 		return false
@@ -358,7 +358,7 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainManagerTypes.Par
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var params chainManagerTypes.Params
 
 	if err = json.Unmarshal(response.Result, &params); err != nil {
@@ -381,7 +381,7 @@ func GetCheckpointParams(cliCtx cliContext.CLIContext) (*checkpointTypes.Params,
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var params checkpointTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling Checkpoint params", "url", CheckpointParamsURL)
@@ -403,7 +403,7 @@ func GetBufferedCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, e
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var checkpoint hmtypes.Checkpoint
 	if err := json.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling buffered checkpoint", "url", BufferedCheckpointURL, "err", err)
@@ -425,7 +425,7 @@ func GetLatestCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, err
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var checkpoint hmtypes.Checkpoint
 	if err = json.Unmarshal(response.Result, &checkpoint); err != nil {
@@ -460,7 +460,7 @@ func GetValidatorNonce(cliCtx cliContext.CLIContext, validatorID uint64) (uint64
 		return 0, 0, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling validator data", "error", err)
 		return 0, 0, err
@@ -479,7 +479,7 @@ func GetValidatorSet(cliCtx cliContext.CLIContext) (*hmtypes.ValidatorSet, error
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var validatorSet hmtypes.ValidatorSet
 	if err = json.Unmarshal(response.Result, &validatorSet); err != nil {
@@ -515,7 +515,7 @@ func GetClerkEventRecord(cliCtx cliContext.CLIContext, stateId int64) (*clerktyp
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	var eventRecord clerktypes.EventRecord
 	if err = json.Unmarshal(response.Result, &eventRecord); err != nil {
@@ -546,7 +546,7 @@ func GetUnconfirmedTxnCount(event interface{}) int {
 	// a minimal response of the unconfirmed txs
 	var response TendermintUnconfirmedTxs
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)

--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +15,7 @@ import (
 
 	mLog "github.com/RichardKnop/machinery/v1/log"
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/libs/log"
@@ -126,6 +126,7 @@ func IsProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(result.Result, &proposers)
 	if err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
@@ -155,6 +156,7 @@ func IsInProposerList(cliCtx cliContext.CLIContext, count uint64) (bool, error) 
 	// unmarshall data from buffer
 	var proposers []hmtypes.Validator
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(response.Result, &proposers); err != nil {
 		logger.Error("Error unmarshalling validator data ", "error", err)
 		return false, err
@@ -222,6 +224,7 @@ func IsCurrentProposer(cliCtx cliContext.CLIContext) (bool, error) {
 		return false, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &proposer); err != nil {
 		logger.Error("error unmarshalling validator", "error", err)
 		return false, err
@@ -250,6 +253,7 @@ func IsEventSender(cliCtx cliContext.CLIContext, validatorID uint64) bool {
 		return false
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling proposer slice", "error", err)
 		return false
@@ -354,6 +358,7 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainManagerTypes.Par
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var params chainManagerTypes.Params
 	if err = json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling chainmanager params", "url", ChainManagerParamsURL, "err", err)
@@ -375,6 +380,7 @@ func GetCheckpointParams(cliCtx cliContext.CLIContext) (*checkpointTypes.Params,
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var params checkpointTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		logger.Error("Error unmarshalling Checkpoint params", "url", CheckpointParamsURL)
@@ -396,6 +402,7 @@ func GetBufferedCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, e
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var checkpoint hmtypes.Checkpoint
 	if err := json.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling buffered checkpoint", "url", BufferedCheckpointURL, "err", err)
@@ -417,6 +424,7 @@ func GetLatestCheckpoint(cliCtx cliContext.CLIContext) (*hmtypes.Checkpoint, err
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var checkpoint hmtypes.Checkpoint
 	if err = json.Unmarshal(response.Result, &checkpoint); err != nil {
 		logger.Error("Error unmarshalling latest checkpoint", "url", LatestCheckpointURL, "err", err)
@@ -450,6 +458,7 @@ func GetValidatorNonce(cliCtx cliContext.CLIContext, validatorID uint64) (uint64
 		return 0, 0, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err = json.Unmarshal(result.Result, &validator); err != nil {
 		logger.Error("error unmarshalling validator data", "error", err)
 		return 0, 0, err
@@ -468,6 +477,7 @@ func GetValidatorSet(cliCtx cliContext.CLIContext) (*hmtypes.ValidatorSet, error
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var validatorSet hmtypes.ValidatorSet
 	if err = json.Unmarshal(response.Result, &validatorSet); err != nil {
 		logger.Error("Error unmarshalling current validatorset data ", "error", err)
@@ -502,6 +512,7 @@ func GetClerkEventRecord(cliCtx cliContext.CLIContext, stateId int64) (*clerktyp
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var eventRecord clerktypes.EventRecord
 	if err = json.Unmarshal(response.Result, &eventRecord); err != nil {
 		logger.Error("Error unmarshalling event record", "error", err)
@@ -531,6 +542,7 @@ func GetUnconfirmedTxnCount(event interface{}) int {
 	// a minimal response of the unconfirmed txs
 	var response TendermintUnconfirmedTxs
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		logger.Error("Error unmarshalling response received from Heimdall Server", "error", err)

--- a/chainmanager/client/cli/query.go
+++ b/chainmanager/client/cli/query.go
@@ -56,7 +56,7 @@ $ %s query chainmanager params
 				return err
 			}
 
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
 			if err = json.Unmarshal(bz, &params); err != nil {
 				return err

--- a/chainmanager/client/cli/query.go
+++ b/chainmanager/client/cli/query.go
@@ -56,9 +56,8 @@ $ %s query chainmanager params
 				return err
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
-			if err = json.Unmarshal(bz, &params); err != nil {
+			if err = jsoniter.ConfigFastest.Unmarshal(bz, &params); err != nil {
 				return err
 			}
 			return cliCtx.PrintOutput(params)

--- a/chainmanager/client/cli/query.go
+++ b/chainmanager/client/cli/query.go
@@ -1,13 +1,13 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 
 	"github.com/maticnetwork/heimdall/chainmanager/types"
@@ -56,6 +56,7 @@ $ %s query chainmanager params
 				return err
 			}
 
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
 			if err = json.Unmarshal(bz, &params); err != nil {
 				return err

--- a/chainmanager/client/cli/query.go
+++ b/chainmanager/client/cli/query.go
@@ -56,7 +56,7 @@ $ %s query chainmanager params
 				return err
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
 			if err = json.Unmarshal(bz, &params); err != nil {
 				return err

--- a/chainmanager/querier.go
+++ b/chainmanager/querier.go
@@ -21,7 +21,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/chainmanager/querier.go
+++ b/chainmanager/querier.go
@@ -21,7 +21,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/chainmanager/querier.go
+++ b/chainmanager/querier.go
@@ -1,9 +1,8 @@
 package chainmanager
 
 import (
-	"encoding/json"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/maticnetwork/heimdall/chainmanager/types"
@@ -22,6 +21,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/chainmanager/querier.go
+++ b/chainmanager/querier.go
@@ -22,6 +22,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/chainmanager/querier.go
+++ b/chainmanager/querier.go
@@ -21,9 +21,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(keeper.GetParams(ctx))
+	bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/chainmanager/querier_test.go
+++ b/chainmanager/querier_test.go
@@ -1,18 +1,18 @@
 package chainmanager_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/maticnetwork/heimdall/app"
 	"github.com/maticnetwork/heimdall/chainmanager"
 	"github.com/maticnetwork/heimdall/chainmanager/types"
-	"github.com/stretchr/testify/require"
-
-	"github.com/stretchr/testify/suite"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // QuerierTestSuite integrate test suite context object
@@ -73,6 +73,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &params)
 	require.NoError(t, err)
 

--- a/chainmanager/querier_test.go
+++ b/chainmanager/querier_test.go
@@ -73,7 +73,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &params)
 	require.NoError(t, err)
 

--- a/chainmanager/querier_test.go
+++ b/chainmanager/querier_test.go
@@ -73,8 +73,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := json.Unmarshal(res, &params)
+	err := jsoniter.ConfigFastest.Unmarshal(res, &params)
 	require.NoError(t, err)
 
 	// match response params

--- a/chainmanager/querier_test.go
+++ b/chainmanager/querier_test.go
@@ -73,7 +73,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &params)
 	require.NoError(t, err)
 

--- a/checkpoint/client/cli/query.go
+++ b/checkpoint/client/cli/query.go
@@ -67,7 +67,7 @@ $ %s query checkpoint params
 				return err
 			}
 
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
 			if err := json.Unmarshal(bz, &params); err != nil {
 				return nil
@@ -119,7 +119,7 @@ func GetLastNoACK(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No last-no-ack count found")
 			}
 
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var lastNoAck uint64
 			if err := json.Unmarshal(res, &lastNoAck); err != nil {
 				return err
@@ -185,7 +185,7 @@ func GetCheckpointCount(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No ack count found")
 			}
 
-			var json = jsoniter.ConfigCompatibleWithStandardLibrary
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var ackCount uint64
 			if err := json.Unmarshal(res, &ackCount); err != nil {
 				return err

--- a/checkpoint/client/cli/query.go
+++ b/checkpoint/client/cli/query.go
@@ -67,9 +67,8 @@ $ %s query checkpoint params
 				return err
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
-			if err := json.Unmarshal(bz, &params); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(bz, &params); err != nil {
 				return nil
 			}
 			return cliCtx.PrintOutput(params)
@@ -119,9 +118,8 @@ func GetLastNoACK(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No last-no-ack count found")
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var lastNoAck uint64
-			if err := json.Unmarshal(res, &lastNoAck); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(res, &lastNoAck); err != nil {
 				return err
 			}
 
@@ -185,9 +183,8 @@ func GetCheckpointCount(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No ack count found")
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
 			var ackCount uint64
-			if err := json.Unmarshal(res, &ackCount); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(res, &ackCount); err != nil {
 				return err
 			}
 

--- a/checkpoint/client/cli/query.go
+++ b/checkpoint/client/cli/query.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -67,6 +67,7 @@ $ %s query checkpoint params
 				return err
 			}
 
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
 			if err := json.Unmarshal(bz, &params); err != nil {
 				return nil
@@ -118,6 +119,7 @@ func GetLastNoACK(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No last-no-ack count found")
 			}
 
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var lastNoAck uint64
 			if err := json.Unmarshal(res, &lastNoAck); err != nil {
 				return err
@@ -183,6 +185,7 @@ func GetCheckpointCount(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No ack count found")
 			}
 
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var ackCount uint64
 			if err := json.Unmarshal(res, &ackCount); err != nil {
 				return err

--- a/checkpoint/client/cli/query.go
+++ b/checkpoint/client/cli/query.go
@@ -67,7 +67,7 @@ $ %s query checkpoint params
 				return err
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var params types.Params
 			if err := json.Unmarshal(bz, &params); err != nil {
 				return nil
@@ -119,7 +119,7 @@ func GetLastNoACK(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No last-no-ack count found")
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var lastNoAck uint64
 			if err := json.Unmarshal(res, &lastNoAck); err != nil {
 				return err
@@ -185,7 +185,7 @@ func GetCheckpointCount(cdc *codec.Codec) *cobra.Command {
 				return errors.New("No ack count found")
 			}
 
-			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			var ackCount uint64
 			if err := json.Unmarshal(res, &ackCount); err != nil {
 				return err

--- a/checkpoint/client/cli/tx.go
+++ b/checkpoint/client/cli/tx.go
@@ -161,7 +161,7 @@ func SendCheckpointTx(cdc *codec.Codec) *cobra.Command {
 					return err
 				}
 
-				var json = jsoniter.ConfigCompatibleWithStandardLibrary
+				json := jsoniter.ConfigCompatibleWithStandardLibrary
 				if err := json.Unmarshal(proposerBytes, &checkpointProposer); err != nil {
 					return err
 				}

--- a/checkpoint/client/cli/tx.go
+++ b/checkpoint/client/cli/tx.go
@@ -161,7 +161,7 @@ func SendCheckpointTx(cdc *codec.Codec) *cobra.Command {
 					return err
 				}
 
-				json := jsoniter.ConfigCompatibleWithStandardLibrary
+				var json = jsoniter.ConfigCompatibleWithStandardLibrary
 				if err := json.Unmarshal(proposerBytes, &checkpointProposer); err != nil {
 					return err
 				}

--- a/checkpoint/client/cli/tx.go
+++ b/checkpoint/client/cli/tx.go
@@ -161,8 +161,7 @@ func SendCheckpointTx(cdc *codec.Codec) *cobra.Command {
 					return err
 				}
 
-				json := jsoniter.ConfigCompatibleWithStandardLibrary
-				if err := json.Unmarshal(proposerBytes, &checkpointProposer); err != nil {
+				if err := jsoniter.ConfigFastest.Unmarshal(proposerBytes, &checkpointProposer); err != nil {
 					return err
 				}
 
@@ -185,7 +184,7 @@ func SendCheckpointTx(cdc *codec.Codec) *cobra.Command {
 
 				// unmarsall the checkpoint msg
 				var newCheckpointMsg types.MsgCheckpoint
-				if err := json.Unmarshal(result, &newCheckpointMsg); err != nil {
+				if err := jsoniter.ConfigFastest.Unmarshal(result, &newCheckpointMsg); err != nil {
 					return err
 				}
 

--- a/checkpoint/client/cli/tx.go
+++ b/checkpoint/client/cli/tx.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -11,12 +10,13 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
-	types "github.com/maticnetwork/heimdall/checkpoint/types"
+	"github.com/maticnetwork/heimdall/checkpoint/types"
 	hmClient "github.com/maticnetwork/heimdall/client"
 	"github.com/maticnetwork/heimdall/helper"
 	hmTypes "github.com/maticnetwork/heimdall/types"
@@ -161,6 +161,7 @@ func SendCheckpointTx(cdc *codec.Codec) *cobra.Command {
 					return err
 				}
 
+				var json = jsoniter.ConfigCompatibleWithStandardLibrary
 				if err := json.Unmarshal(proposerBytes, &checkpointProposer); err != nil {
 					return err
 				}

--- a/checkpoint/client/rest/query.go
+++ b/checkpoint/client/rest/query.go
@@ -254,7 +254,7 @@ func checkpointCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var ackCount uint64
 		if err := json.Unmarshal(ackCountBytes, &ackCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -308,7 +308,7 @@ func prepareCheckpointHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			validatorSetBytes []byte
 		)
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		// get start and start
 		if params.Get("start") != "" && params.Get("end") != "" {
@@ -428,7 +428,7 @@ func noackHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var lastAckTime uint64
 		if err := json.Unmarshal(res, &lastAckTime); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -468,7 +468,7 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		//
 		// Ack acount
@@ -575,7 +575,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		//
 		// Get ack count
 		//
@@ -705,7 +705,7 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var checkpointUnmarshal hmTypes.Checkpoint
 		if err = json.Unmarshal(res, &checkpointUnmarshal); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/checkpoint/client/rest/query.go
+++ b/checkpoint/client/rest/query.go
@@ -2,7 +2,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/bor/common"
 	ethcmn "github.com/maticnetwork/bor/common"
@@ -254,6 +254,7 @@ func checkpointCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var ackCount uint64
 		if err := json.Unmarshal(ackCountBytes, &ackCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -306,6 +307,8 @@ func prepareCheckpointHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			height            int64
 			validatorSetBytes []byte
 		)
+
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		// get start and start
 		if params.Get("start") != "" && params.Get("end") != "" {
@@ -425,6 +428,7 @@ func noackHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var lastAckTime uint64
 		if err := json.Unmarshal(res, &lastAckTime); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -463,6 +467,8 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if !ok {
 			return
 		}
+
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		//
 		// Ack acount
@@ -569,6 +575,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		//
 		// Get ack count
 		//
@@ -698,6 +705,7 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var checkpointUnmarshal hmTypes.Checkpoint
 		if err = json.Unmarshal(res, &checkpointUnmarshal); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/checkpoint/client/rest/query.go
+++ b/checkpoint/client/rest/query.go
@@ -254,14 +254,13 @@ func checkpointCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var ackCount uint64
-		if err := json.Unmarshal(ackCountBytes, &ackCount); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(ackCountBytes, &ackCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
-		result, err := json.Marshal(map[string]interface{}{"result": ackCount})
+		result, err := jsoniter.ConfigFastest.Marshal(map[string]interface{}{"result": ackCount})
 		if err != nil {
 			RestLogger.Error("Error while marshalling resposne to Json", "error", err)
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -308,8 +307,6 @@ func prepareCheckpointHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			validatorSetBytes []byte
 		)
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 		// get start and start
 		if params.Get("start") != "" && params.Get("end") != "" {
 			start, err := strconv.ParseUint(params.Get("start"), 10, 64)
@@ -333,7 +330,7 @@ func prepareCheckpointHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			}
 
 			var params types.Params
-			if err = json.Unmarshal(res, &params); err != nil {
+			if err = jsoniter.ConfigFastest.Unmarshal(res, &params); err != nil {
 				RestLogger.Error("Unable to unmarshal params", "Start", start, "End", end, "Error", err)
 				hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 
@@ -365,7 +362,7 @@ func prepareCheckpointHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 			validatorSetBytes, height, err = cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", stakingTypes.QuerierRoute, stakingTypes.QueryCurrentValidatorSet), nil)
 			if err == nil {
-				if err = json.Unmarshal(validatorSetBytes, &validatorSet); err != nil {
+				if err = jsoniter.ConfigFastest.Unmarshal(validatorSetBytes, &validatorSet); err != nil {
 					hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 					RestLogger.Error("Unable to get validator set to form proposer", "Error", err)
 
@@ -381,7 +378,7 @@ func prepareCheckpointHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 				RootHash:   ethcmn.BytesToHash(roothash),
 			}
 
-			result, err = json.Marshal(checkpoint)
+			result, err = jsoniter.ConfigFastest.Marshal(checkpoint)
 			if err != nil {
 				RestLogger.Error("Error while marshalling resposne to Json", "error", err)
 				hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -428,14 +425,13 @@ func noackHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var lastAckTime uint64
-		if err := json.Unmarshal(res, &lastAckTime); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(res, &lastAckTime); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
-		result, err := json.Marshal(map[string]interface{}{"result": lastAckTime})
+		result, err := jsoniter.ConfigFastest.Marshal(map[string]interface{}{"result": lastAckTime})
 		if err != nil {
 			RestLogger.Error("Error while marshalling resposne to Json", "error", err)
 			hmRest.WriteErrorResponse(w, http.StatusNoContent, errors.New("Error while sending last ack time").Error())
@@ -468,8 +464,6 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 		//
 		// Ack acount
 		//
@@ -480,7 +474,7 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if err == nil {
 			// check content
 			if hmRest.ReturnNotFoundIfNoContent(w, ackCountBytes, "No ack count found") {
-				if err = json.Unmarshal(ackCountBytes, &ackCountInt); err != nil {
+				if err = jsoniter.ConfigFastest.Unmarshal(ackCountBytes, &ackCountInt); err != nil {
 					// log and ignore
 					RestLogger.Error("Error while unmarshing no-ack count", "error", err)
 				}
@@ -497,7 +491,7 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if err == nil {
 			if len(checkpointBufferBytes) != 0 {
 				_checkpoint = new(hmTypes.Checkpoint)
-				if err = json.Unmarshal(checkpointBufferBytes, _checkpoint); err != nil {
+				if err = jsoniter.ConfigFastest.Unmarshal(checkpointBufferBytes, _checkpoint); err != nil {
 					// log and ignore
 					RestLogger.Error("Error while unmarshing checkpoint header", "error", err)
 				}
@@ -512,7 +506,7 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 		validatorSetBytes, _, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", stakingTypes.QuerierRoute, stakingTypes.QueryCurrentValidatorSet), nil)
 		if err == nil {
-			if err := json.Unmarshal(validatorSetBytes, &validatorSet); err != nil {
+			if err := jsoniter.ConfigFastest.Unmarshal(validatorSetBytes, &validatorSet); err != nil {
 				// log and ignore
 				RestLogger.Error("Error while unmarshing validator set", "error", err)
 			}
@@ -532,7 +526,7 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		if err == nil {
 			// check content
 			if hmRest.ReturnNotFoundIfNoContent(w, lastNoACKBytes, "No last-no-ack count found") {
-				if err = json.Unmarshal(lastNoACKBytes, &lastNoACKTime); err != nil {
+				if err = jsoniter.ConfigFastest.Unmarshal(lastNoACKBytes, &lastNoACKTime); err != nil {
 					// log and ignore
 					RestLogger.Error("Error while unmarshing last no-ack time", "error", err)
 				}
@@ -551,7 +545,7 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			LastNoACK:        time.Unix(int64(lastNoACKTime), 0),
 		}
 
-		result, err := json.Marshal(state)
+		result, err := jsoniter.ConfigFastest.Marshal(state)
 		if err != nil {
 			RestLogger.Error("Error while marshalling resposne to Json", "error", err)
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -575,7 +569,6 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		//
 		// Get ack count
 		//
@@ -592,7 +585,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		var ackCount uint64
-		if err := json.Unmarshal(ackcountBytes, &ackCount); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(ackcountBytes, &ackCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -622,7 +615,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		var checkpointUnmarshal hmTypes.Checkpoint
-		if err = json.Unmarshal(res, &checkpointUnmarshal); err != nil {
+		if err = jsoniter.ConfigFastest.Unmarshal(res, &checkpointUnmarshal); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -637,7 +630,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			TimeStamp:  checkpointUnmarshal.TimeStamp,
 		}
 
-		resWithID, err := json.Marshal(checkpointWithID)
+		resWithID, err := jsoniter.ConfigFastest.Marshal(checkpointWithID)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 		}
@@ -705,9 +698,8 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var checkpointUnmarshal hmTypes.Checkpoint
-		if err = json.Unmarshal(res, &checkpointUnmarshal); err != nil {
+		if err = jsoniter.ConfigFastest.Unmarshal(res, &checkpointUnmarshal); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -722,7 +714,7 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			TimeStamp:  checkpointUnmarshal.TimeStamp,
 		}
 
-		resWithID, err := json.Marshal(checkpointWithID)
+		resWithID, err := jsoniter.ConfigFastest.Marshal(checkpointWithID)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 		}

--- a/checkpoint/client/rest/query.go
+++ b/checkpoint/client/rest/query.go
@@ -254,7 +254,7 @@ func checkpointCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var ackCount uint64
 		if err := json.Unmarshal(ackCountBytes, &ackCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -308,7 +308,7 @@ func prepareCheckpointHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			validatorSetBytes []byte
 		)
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		// get start and start
 		if params.Get("start") != "" && params.Get("end") != "" {
@@ -428,7 +428,7 @@ func noackHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var lastAckTime uint64
 		if err := json.Unmarshal(res, &lastAckTime); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -468,7 +468,7 @@ func overviewHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		//
 		// Ack acount
@@ -575,7 +575,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		//
 		// Get ack count
 		//
@@ -705,7 +705,7 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var checkpointUnmarshal hmTypes.Checkpoint
 		if err = json.Unmarshal(res, &checkpointUnmarshal); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/checkpoint/querier.go
+++ b/checkpoint/querier.go
@@ -40,7 +40,7 @@ func NewQuerier(keeper Keeper, stakingKeeper staking.Keeper, topupKeeper topup.K
 }
 
 func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -50,7 +50,7 @@ func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 }
 
 func handleQueryAckCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetACKCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -70,7 +70,7 @@ func handleQueryCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint by index %v", params.Number), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -89,7 +89,7 @@ func handleQueryCheckpointBuffer(ctx sdk.Context, req abci.RequestQuery, keeper 
 		return nil, common.ErrNoCheckpointBufferFound(keeper.Codespace())
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -103,7 +103,7 @@ func handleQueryLastNoAck(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	res := keeper.GetLastNoAck(ctx)
 
 	// send result
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -123,7 +123,7 @@ func handleQueryCheckpointList(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -180,7 +180,7 @@ func handleQueryNextCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		queryParams.BorChainID,
 	)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(checkpointMsg)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not marshall checkpoint msg. Error:%v", err), err.Error()))

--- a/checkpoint/querier.go
+++ b/checkpoint/querier.go
@@ -40,9 +40,7 @@ func NewQuerier(keeper Keeper, stakingKeeper staking.Keeper, topupKeeper topup.K
 }
 
 func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(keeper.GetParams(ctx))
+	bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -51,9 +49,7 @@ func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 }
 
 func handleQueryAckCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(keeper.GetACKCount(ctx))
+	bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetACKCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -72,9 +68,7 @@ func handleQueryCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint by index %v", params.Number), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(res)
+	bz, err := jsoniter.ConfigFastest.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -92,9 +86,7 @@ func handleQueryCheckpointBuffer(ctx sdk.Context, req abci.RequestQuery, keeper 
 		return nil, common.ErrNoCheckpointBufferFound(keeper.Codespace())
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(res)
+	bz, err := jsoniter.ConfigFastest.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -107,9 +99,7 @@ func handleQueryLastNoAck(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	res := keeper.GetLastNoAck(ctx)
 
 	// send result
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(res)
+	bz, err := jsoniter.ConfigFastest.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -128,9 +118,7 @@ func handleQueryCheckpointList(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(res)
+	bz, err := jsoniter.ConfigFastest.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -186,9 +174,7 @@ func handleQueryNextCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		queryParams.BorChainID,
 	)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(checkpointMsg)
+	bz, err := jsoniter.ConfigFastest.Marshal(checkpointMsg)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not marshall checkpoint msg. Error:%v", err), err.Error()))
 	}

--- a/checkpoint/querier.go
+++ b/checkpoint/querier.go
@@ -40,7 +40,7 @@ func NewQuerier(keeper Keeper, stakingKeeper staking.Keeper, topupKeeper topup.K
 }
 
 func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -50,7 +50,7 @@ func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 }
 
 func handleQueryAckCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetACKCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -70,7 +70,7 @@ func handleQueryCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint by index %v", params.Number), err.Error()))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -89,7 +89,7 @@ func handleQueryCheckpointBuffer(ctx sdk.Context, req abci.RequestQuery, keeper 
 		return nil, common.ErrNoCheckpointBufferFound(keeper.Codespace())
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -103,7 +103,7 @@ func handleQueryLastNoAck(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	res := keeper.GetLastNoAck(ctx)
 
 	// send result
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -123,7 +123,7 @@ func handleQueryCheckpointList(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -180,7 +180,7 @@ func handleQueryNextCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		queryParams.BorChainID,
 	)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(checkpointMsg)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not marshall checkpoint msg. Error:%v", err), err.Error()))

--- a/checkpoint/querier.go
+++ b/checkpoint/querier.go
@@ -1,17 +1,18 @@
 package checkpoint
 
 import (
-	"encoding/json"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/maticnetwork/heimdall/checkpoint/types"
 	"github.com/maticnetwork/heimdall/common"
 	"github.com/maticnetwork/heimdall/helper"
 	"github.com/maticnetwork/heimdall/staking"
 	"github.com/maticnetwork/heimdall/topup"
 	hmTypes "github.com/maticnetwork/heimdall/types"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // NewQuerier creates a querier for auth REST endpoints
@@ -39,6 +40,7 @@ func NewQuerier(keeper Keeper, stakingKeeper staking.Keeper, topupKeeper topup.K
 }
 
 func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -48,6 +50,7 @@ func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 }
 
 func handleQueryAckCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetACKCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -67,6 +70,7 @@ func handleQueryCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint by index %v", params.Number), err.Error()))
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -85,6 +89,7 @@ func handleQueryCheckpointBuffer(ctx sdk.Context, req abci.RequestQuery, keeper 
 		return nil, common.ErrNoCheckpointBufferFound(keeper.Codespace())
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -97,7 +102,8 @@ func handleQueryLastNoAck(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	// get last no ack
 	res := keeper.GetLastNoAck(ctx)
 
-	// sed result
+	// send result
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -117,6 +123,7 @@ func handleQueryCheckpointList(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch checkpoint list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -173,6 +180,7 @@ func handleQueryNextCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 		queryParams.BorChainID,
 	)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(checkpointMsg)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not marshall checkpoint msg. Error:%v", err), err.Error()))

--- a/checkpoint/querier.go
+++ b/checkpoint/querier.go
@@ -41,6 +41,7 @@ func NewQuerier(keeper Keeper, stakingKeeper staking.Keeper, topupKeeper topup.K
 
 func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -51,6 +52,7 @@ func handleQueryParams(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 
 func handleQueryAckCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(keeper.GetACKCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -71,6 +73,7 @@ func handleQueryCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -90,6 +93,7 @@ func handleQueryCheckpointBuffer(ctx sdk.Context, req abci.RequestQuery, keeper 
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -104,6 +108,7 @@ func handleQueryLastNoAck(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 
 	// send result
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -124,6 +129,7 @@ func handleQueryCheckpointList(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -181,6 +187,7 @@ func handleQueryNextCheckpoint(ctx sdk.Context, req abci.RequestQuery, keeper Ke
 	)
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(checkpointMsg)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not marshall checkpoint msg. Error:%v", err), err.Error()))

--- a/checkpoint/querier_test.go
+++ b/checkpoint/querier_test.go
@@ -82,7 +82,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &params)
 	require.NoError(t, err)
 	require.NotNil(t, params)
@@ -147,7 +147,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpoint() {
 
 	var checkpoint hmTypes.Checkpoint
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -188,7 +188,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpointBuffer() {
 
 	var checkpoint hmTypes.Checkpoint
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -264,7 +264,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpointList() {
 
 	var actualRes []hmTypes.Checkpoint
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpoints, actualRes)
@@ -315,7 +315,7 @@ func (suite *QuerierTestSuite) TestQueryNextCheckpoint() {
 
 	var actualRes types.MsgCheckpoint
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpointBlock.StartBlock, actualRes.StartBlock)

--- a/checkpoint/querier_test.go
+++ b/checkpoint/querier_test.go
@@ -1,7 +1,6 @@
 package checkpoint_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -10,7 +9,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	hmTypes "github.com/maticnetwork/heimdall/types"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -20,6 +19,7 @@ import (
 	chSim "github.com/maticnetwork/heimdall/checkpoint/simulation"
 	"github.com/maticnetwork/heimdall/checkpoint/types"
 	"github.com/maticnetwork/heimdall/helper/mocks"
+	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
 // QuerierTestSuite integrate test suite context object
@@ -82,6 +82,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &params)
 	require.NoError(t, err)
 	require.NotNil(t, params)
@@ -145,6 +146,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpoint() {
 	require.NotNil(t, res)
 
 	var checkpoint hmTypes.Checkpoint
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -184,6 +186,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpointBuffer() {
 	require.NotNil(t, res)
 
 	var checkpoint hmTypes.Checkpoint
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -258,6 +261,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpointList() {
 	require.NotNil(t, res)
 
 	var actualRes []hmTypes.Checkpoint
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpoints, actualRes)
@@ -307,6 +311,7 @@ func (suite *QuerierTestSuite) TestQueryNextCheckpoint() {
 	require.NotNil(t, res)
 
 	var actualRes types.MsgCheckpoint
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpointBlock.StartBlock, actualRes.StartBlock)

--- a/checkpoint/querier_test.go
+++ b/checkpoint/querier_test.go
@@ -82,7 +82,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &params)
 	require.NoError(t, err)
 	require.NotNil(t, params)
@@ -147,7 +147,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpoint() {
 
 	var checkpoint hmTypes.Checkpoint
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -188,7 +188,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpointBuffer() {
 
 	var checkpoint hmTypes.Checkpoint
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -264,7 +264,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpointList() {
 
 	var actualRes []hmTypes.Checkpoint
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpoints, actualRes)
@@ -315,7 +315,7 @@ func (suite *QuerierTestSuite) TestQueryNextCheckpoint() {
 
 	var actualRes types.MsgCheckpoint
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpointBlock.StartBlock, actualRes.StartBlock)

--- a/checkpoint/querier_test.go
+++ b/checkpoint/querier_test.go
@@ -82,7 +82,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &params)
 	require.NoError(t, err)
 	require.NotNil(t, params)
@@ -146,7 +146,8 @@ func (suite *QuerierTestSuite) TestQueryCheckpoint() {
 	require.NotNil(t, res)
 
 	var checkpoint hmTypes.Checkpoint
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -186,7 +187,8 @@ func (suite *QuerierTestSuite) TestQueryCheckpointBuffer() {
 	require.NotNil(t, res)
 
 	var checkpoint hmTypes.Checkpoint
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
@@ -261,7 +263,8 @@ func (suite *QuerierTestSuite) TestQueryCheckpointList() {
 	require.NotNil(t, res)
 
 	var actualRes []hmTypes.Checkpoint
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpoints, actualRes)
@@ -311,7 +314,8 @@ func (suite *QuerierTestSuite) TestQueryNextCheckpoint() {
 	require.NotNil(t, res)
 
 	var actualRes types.MsgCheckpoint
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpointBlock.StartBlock, actualRes.StartBlock)

--- a/checkpoint/querier_test.go
+++ b/checkpoint/querier_test.go
@@ -82,8 +82,7 @@ func (suite *QuerierTestSuite) TestQueryParams() {
 	require.NoError(t, sdkErr)
 	require.NotNil(t, res)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := json.Unmarshal(res, &params)
+	err := jsoniter.ConfigFastest.Unmarshal(res, &params)
 	require.NoError(t, err)
 	require.NotNil(t, params)
 	require.Equal(t, defaultParams.AvgCheckpointLength, params.AvgCheckpointLength)
@@ -147,8 +146,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpoint() {
 
 	var checkpoint hmTypes.Checkpoint
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err = json.Unmarshal(res, &checkpoint)
+	err = jsoniter.ConfigFastest.Unmarshal(res, &checkpoint)
 	require.NoError(t, err)
 	require.Equal(t, checkpoint, checkpointBlock)
 }
@@ -186,12 +184,10 @@ func (suite *QuerierTestSuite) TestQueryCheckpointBuffer() {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	var checkpoint hmTypes.Checkpoint
-
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err = json.Unmarshal(res, &checkpoint)
+	var cp hmTypes.Checkpoint
+	err = jsoniter.ConfigFastest.Unmarshal(res, &cp)
 	require.NoError(t, err)
-	require.Equal(t, checkpoint, checkpointBlock)
+	require.Equal(t, cp, checkpointBlock)
 }
 
 func (suite *QuerierTestSuite) TestQueryLastNoAck() {
@@ -264,8 +260,7 @@ func (suite *QuerierTestSuite) TestQueryCheckpointList() {
 
 	var actualRes []hmTypes.Checkpoint
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err := json.Unmarshal(res, &actualRes)
+	err := jsoniter.ConfigFastest.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpoints, actualRes)
 }
@@ -315,8 +310,7 @@ func (suite *QuerierTestSuite) TestQueryNextCheckpoint() {
 
 	var actualRes types.MsgCheckpoint
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err = json.Unmarshal(res, &actualRes)
+	err = jsoniter.ConfigFastest.Unmarshal(res, &actualRes)
 	require.NoError(t, err)
 	require.Equal(t, checkpointBlock.StartBlock, actualRes.StartBlock)
 	require.Equal(t, checkpointBlock.EndBlock, actualRes.EndBlock)

--- a/clerk/client/rest/query.go
+++ b/clerk/client/rest/query.go
@@ -353,7 +353,7 @@ func rangeQuery(cliCtx context.CLIContext, page uint64, limit uint64) ([]byte, e
 
 func tillTimeRangeQuery(cliCtx context.CLIContext, fromID uint64, toTime int64, limit uint64) ([]byte, error) {
 	result := make([]*types.EventRecord, 0, limit)
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	// if from id not found, return empty result
 	fromData, err := recordQuery(cliCtx, fromID)

--- a/clerk/client/rest/query.go
+++ b/clerk/client/rest/query.go
@@ -2,7 +2,6 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/heimdall/clerk/types"
 	hmTypes "github.com/maticnetwork/heimdall/types"
@@ -353,6 +353,7 @@ func rangeQuery(cliCtx context.CLIContext, page uint64, limit uint64) ([]byte, e
 
 func tillTimeRangeQuery(cliCtx context.CLIContext, fromID uint64, toTime int64, limit uint64) ([]byte, error) {
 	result := make([]*types.EventRecord, 0, limit)
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	// if from id not found, return empty result
 	fromData, err := recordQuery(cliCtx, fromID)

--- a/clerk/client/rest/query.go
+++ b/clerk/client/rest/query.go
@@ -353,7 +353,7 @@ func rangeQuery(cliCtx context.CLIContext, page uint64, limit uint64) ([]byte, e
 
 func tillTimeRangeQuery(cliCtx context.CLIContext, fromID uint64, toTime int64, limit uint64) ([]byte, error) {
 	result := make([]*types.EventRecord, 0, limit)
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	// if from id not found, return empty result
 	fromData, err := recordQuery(cliCtx, fromID)

--- a/clerk/client/rest/query.go
+++ b/clerk/client/rest/query.go
@@ -353,16 +353,15 @@ func rangeQuery(cliCtx context.CLIContext, page uint64, limit uint64) ([]byte, e
 
 func tillTimeRangeQuery(cliCtx context.CLIContext, fromID uint64, toTime int64, limit uint64) ([]byte, error) {
 	result := make([]*types.EventRecord, 0, limit)
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	// if from id not found, return empty result
 	fromData, err := recordQuery(cliCtx, fromID)
 	if err != nil {
-		return json.Marshal(result)
+		return jsoniter.ConfigFastest.Marshal(result)
 	}
 
 	var fromRecord types.EventRecord
-	if err = json.Unmarshal(fromData, &fromRecord); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(fromData, &fromRecord); err != nil {
 		return nil, err
 	}
 
@@ -374,7 +373,7 @@ func tillTimeRangeQuery(cliCtx context.CLIContext, fromID uint64, toTime int64, 
 	}
 
 	rangeRecords := make([]*types.EventRecord, 0)
-	if err = json.Unmarshal(rangeData, &rangeRecords); err != nil {
+	if err = jsoniter.ConfigFastest.Unmarshal(rangeData, &rangeRecords); err != nil {
 		return nil, err
 	}
 
@@ -397,7 +396,7 @@ func tillTimeRangeQuery(cliCtx context.CLIContext, fromID uint64, toTime int64, 
 			}
 
 			var record types.EventRecord
-			err = json.Unmarshal(recordData, &record)
+			err = jsoniter.ConfigFastest.Unmarshal(recordData, &record)
 			if err != nil {
 				return nil, err
 			}
@@ -415,7 +414,7 @@ func tillTimeRangeQuery(cliCtx context.CLIContext, fromID uint64, toTime int64, 
 	}
 
 	// return result in json
-	return json.Marshal(result)
+	return jsoniter.ConfigFastest.Marshal(result)
 }
 
 //swagger:parameters clerkIsOldTx clerkEventList clerkEventById

--- a/clerk/querier.go
+++ b/clerk/querier.go
@@ -45,7 +45,7 @@ func handleQueryRecord(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(record)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -65,7 +65,7 @@ func handleQueryRecordList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -85,7 +85,7 @@ func handleQueryRecordListWithTime(ctx sdk.Context, req abci.RequestQuery, keepe
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with fromTime %v and toTime %v", params.FromTime, params.ToTime), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/clerk/querier.go
+++ b/clerk/querier.go
@@ -45,7 +45,7 @@ func handleQueryRecord(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(record)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -65,7 +65,7 @@ func handleQueryRecordList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -85,7 +85,7 @@ func handleQueryRecordListWithTime(ctx sdk.Context, req abci.RequestQuery, keepe
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with fromTime %v and toTime %v", params.FromTime, params.ToTime), err.Error()))
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/clerk/querier.go
+++ b/clerk/querier.go
@@ -1,12 +1,12 @@
 package clerk
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/maticnetwork/heimdall/clerk/types"
@@ -45,6 +45,7 @@ func handleQueryRecord(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(record)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -64,6 +65,7 @@ func handleQueryRecordList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -83,6 +85,7 @@ func handleQueryRecordListWithTime(ctx sdk.Context, req abci.RequestQuery, keepe
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with fromTime %v and toTime %v", params.FromTime, params.ToTime), err.Error()))
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/clerk/querier.go
+++ b/clerk/querier.go
@@ -45,9 +45,7 @@ func handleQueryRecord(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(record)
+	bz, err := jsoniter.ConfigFastest.Marshal(record)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -66,9 +64,7 @@ func handleQueryRecordList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with page %v and limit %v", params.Page, params.Limit), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(res)
+	bz, err := jsoniter.ConfigFastest.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -87,9 +83,7 @@ func handleQueryRecordListWithTime(ctx sdk.Context, req abci.RequestQuery, keepe
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr(fmt.Sprintf("could not fetch record list with fromTime %v and toTime %v", params.FromTime, params.ToTime), err.Error()))
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(res)
+	bz, err := jsoniter.ConfigFastest.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/clerk/querier.go
+++ b/clerk/querier.go
@@ -46,6 +46,7 @@ func handleQueryRecord(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(record)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -66,6 +67,7 @@ func handleQueryRecordList(ctx sdk.Context, req abci.RequestQuery, keeper Keeper
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -86,6 +88,7 @@ func handleQueryRecordListWithTime(ctx sdk.Context, req abci.RequestQuery, keepe
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(res)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/cmd/heimdallcli/stake.go
+++ b/cmd/heimdallcli/stake.go
@@ -148,6 +148,7 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainmanagerTypes.Par
 	}
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var params chainmanagerTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		return nil, err

--- a/cmd/heimdallcli/stake.go
+++ b/cmd/heimdallcli/stake.go
@@ -147,7 +147,7 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainmanagerTypes.Par
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var params chainmanagerTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		return nil, err

--- a/cmd/heimdallcli/stake.go
+++ b/cmd/heimdallcli/stake.go
@@ -147,7 +147,7 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainmanagerTypes.Par
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var params chainmanagerTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		return nil, err

--- a/cmd/heimdallcli/stake.go
+++ b/cmd/heimdallcli/stake.go
@@ -147,10 +147,8 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainmanagerTypes.Par
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var params chainmanagerTypes.Params
-	if err := json.Unmarshal(response.Result, &params); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(response.Result, &params); err != nil {
 		return nil, err
 	}
 

--- a/cmd/heimdallcli/stake.go
+++ b/cmd/heimdallcli/stake.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"math/big"
 
 	cliContext "github.com/cosmos/cosmos-sdk/client/context"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -147,6 +147,7 @@ func GetChainmanagerParams(cliCtx cliContext.CLIContext) (*chainmanagerTypes.Par
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var params chainmanagerTypes.Params
 	if err := json.Unmarshal(response.Result, &params); err != nil {
 		return nil, err

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -123,7 +123,7 @@ func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdal
 	}
 
 	// app state json
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	appStateJSON, err := json.Marshal(appStateBytes)
 	if err != nil {

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -123,7 +123,8 @@ func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdal
 	}
 
 	// app state json
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	appStateJSON, err := json.Marshal(appStateBytes)
 	if err != nil {
 		return err

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -123,7 +123,7 @@ func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdal
 	}
 
 	// app state json
-	appStateJSON, err := jsoniter.ConfigFastest.Marshal(appStateBytes)
+	appStateJSON, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(appStateBytes)
 	if err != nil {
 		return err
 	}

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -123,9 +123,7 @@ func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdal
 	}
 
 	// app state json
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	appStateJSON, err := json.Marshal(appStateBytes)
+	appStateJSON, err := jsoniter.ConfigFastest.Marshal(appStateBytes)
 	if err != nil {
 		return err
 	}

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -10,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	cfg "github.com/tendermint/tendermint/config"
@@ -123,6 +123,7 @@ func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdal
 	}
 
 	// app state json
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	appStateJSON, err := json.Marshal(appStateBytes)
 	if err != nil {
 		return err

--- a/cmd/heimdalld/init.go
+++ b/cmd/heimdalld/init.go
@@ -123,7 +123,7 @@ func heimdallInit(ctx *server.Context, cdc *codec.Codec, initConfig *initHeimdal
 	}
 
 	// app state json
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	appStateJSON, err := json.Marshal(appStateBytes)
 	if err != nil {

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -409,7 +409,7 @@ func openTraceWriter(traceWriterFile string) (io.Writer, error) {
 }
 
 func showAccountCmd() *cobra.Command {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	return &cobra.Command{
 		Use:   "show-account",
@@ -438,7 +438,7 @@ func showAccountCmd() *cobra.Command {
 }
 
 func showPrivateKeyCmd() *cobra.Command {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return &cobra.Command{
 		Use:   "show-privatekey",
 		Short: "Print the account's private key",
@@ -466,7 +466,7 @@ func showPrivateKeyCmd() *cobra.Command {
 
 // VerifyGenesis verifies the genesis file and brings it in sync with on-chain contract
 func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	cmd := &cobra.Command{
 		Use:   "verify-genesis",
 		Short: "Verify if the genesis matches",

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -409,7 +409,6 @@ func openTraceWriter(traceWriterFile string) (io.Writer, error) {
 }
 
 func showAccountCmd() *cobra.Command {
-	jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	return &cobra.Command{
 		Use:   "show-account",
@@ -426,7 +425,7 @@ func showAccountCmd() *cobra.Command {
 				PubKey:  "0x" + hex.EncodeToString(pubObject[:]),
 			}
 
-			b, err := jsonLib.MarshalIndent(account, "", "    ")
+			b, err := jsoniter.ConfigFastest.MarshalIndent(account, "", "    ")
 			if err != nil {
 				panic(err)
 			}
@@ -438,7 +437,6 @@ func showAccountCmd() *cobra.Command {
 }
 
 func showPrivateKeyCmd() *cobra.Command {
-	jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	return &cobra.Command{
 		Use:   "show-privatekey",
@@ -454,7 +452,7 @@ func showPrivateKeyCmd() *cobra.Command {
 				PrivKey: "0x" + hex.EncodeToString(privObject[:]),
 			}
 
-			b, err := jsonLib.MarshalIndent(account, "", "    ")
+			b, err := jsoniter.ConfigFastest.MarshalIndent(account, "", "    ")
 			if err != nil {
 				panic(err)
 			}
@@ -467,7 +465,6 @@ func showPrivateKeyCmd() *cobra.Command {
 
 // VerifyGenesis verifies the genesis file and brings it in sync with on-chain contract
 func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-	jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
 	cmd := &cobra.Command{
 		Use:   "verify-genesis",
 		Short: "Verify if the genesis matches",
@@ -485,7 +482,7 @@ func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 
 			// get genesis state
 			var genesisState app.GenesisState
-			err = jsonLib.Unmarshal(genDoc.AppState, &genesisState)
+			err = jsoniter.ConfigFastest.Unmarshal(genDoc.AppState, &genesisState)
 			if err != nil {
 				return err
 			}

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -480,7 +480,7 @@ func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 
 			// get genesis state
 			var genesisState app.GenesisState
-			err = jsoniter.ConfigFastest.Unmarshal(genDoc.AppState, &genesisState)
+			err = jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(genDoc.AppState, &genesisState)
 			if err != nil {
 				return err
 			}

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -409,7 +409,7 @@ func openTraceWriter(traceWriterFile string) (io.Writer, error) {
 }
 
 func showAccountCmd() *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	return &cobra.Command{
 		Use:   "show-account",
@@ -438,7 +438,7 @@ func showAccountCmd() *cobra.Command {
 }
 
 func showPrivateKeyCmd() *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return &cobra.Command{
 		Use:   "show-privatekey",
 		Short: "Print the account's private key",
@@ -466,7 +466,7 @@ func showPrivateKeyCmd() *cobra.Command {
 
 // VerifyGenesis verifies the genesis file and brings it in sync with on-chain contract
 func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	cmd := &cobra.Command{
 		Use:   "verify-genesis",
 		Short: "Verify if the genesis matches",

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -409,7 +409,7 @@ func openTraceWriter(traceWriterFile string) (io.Writer, error) {
 }
 
 func showAccountCmd() *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	return &cobra.Command{
 		Use:   "show-account",
@@ -426,7 +426,7 @@ func showAccountCmd() *cobra.Command {
 				PubKey:  "0x" + hex.EncodeToString(pubObject[:]),
 			}
 
-			b, err := json.MarshalIndent(account, "", "    ")
+			b, err := jsonLib.MarshalIndent(account, "", "    ")
 			if err != nil {
 				panic(err)
 			}
@@ -438,7 +438,8 @@ func showAccountCmd() *cobra.Command {
 }
 
 func showPrivateKeyCmd() *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	return &cobra.Command{
 		Use:   "show-privatekey",
 		Short: "Print the account's private key",
@@ -453,7 +454,7 @@ func showPrivateKeyCmd() *cobra.Command {
 				PrivKey: "0x" + hex.EncodeToString(privObject[:]),
 			}
 
-			b, err := json.MarshalIndent(account, "", "    ")
+			b, err := jsonLib.MarshalIndent(account, "", "    ")
 			if err != nil {
 				panic(err)
 			}
@@ -466,7 +467,7 @@ func showPrivateKeyCmd() *cobra.Command {
 
 // VerifyGenesis verifies the genesis file and brings it in sync with on-chain contract
 func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	jsonLib := jsoniter.ConfigCompatibleWithStandardLibrary
 	cmd := &cobra.Command{
 		Use:   "verify-genesis",
 		Short: "Verify if the genesis matches",
@@ -484,7 +485,7 @@ func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 
 			// get genesis state
 			var genesisState app.GenesisState
-			err = json.Unmarshal(genDoc.AppState, &genesisState)
+			err = jsonLib.Unmarshal(genDoc.AppState, &genesisState)
 			if err != nil {
 				return err
 			}

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -409,7 +409,6 @@ func openTraceWriter(traceWriterFile string) (io.Writer, error) {
 }
 
 func showAccountCmd() *cobra.Command {
-
 	return &cobra.Command{
 		Use:   "show-account",
 		Short: "Print the account's address and public key",
@@ -437,7 +436,6 @@ func showAccountCmd() *cobra.Command {
 }
 
 func showPrivateKeyCmd() *cobra.Command {
-
 	return &cobra.Command{
 		Use:   "show-privatekey",
 		Short: "Print the account's private key",

--- a/cmd/heimdalld/main.go
+++ b/cmd/heimdalld/main.go
@@ -20,18 +20,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/cosmos/cosmos-sdk/store"
-	"golang.org/x/sync/errgroup"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	ethCommon "github.com/maticnetwork/bor/common"
-	bridgeCmd "github.com/maticnetwork/heimdall/bridge/cmd"
-	restServer "github.com/maticnetwork/heimdall/server"
-	"github.com/maticnetwork/heimdall/version"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
-
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
@@ -45,12 +39,17 @@ import (
 	tmTypes "github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
 	dbm "github.com/tendermint/tm-db"
+	"golang.org/x/sync/errgroup"
 
+	ethCommon "github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/heimdall/app"
 	authTypes "github.com/maticnetwork/heimdall/auth/types"
+	bridgeCmd "github.com/maticnetwork/heimdall/bridge/cmd"
 	"github.com/maticnetwork/heimdall/helper"
+	restServer "github.com/maticnetwork/heimdall/server"
 	hmTypes "github.com/maticnetwork/heimdall/types"
 	hmModule "github.com/maticnetwork/heimdall/types/module"
+	"github.com/maticnetwork/heimdall/version"
 )
 
 var logger = helper.Logger.With("module", "cmd/heimdalld")
@@ -410,6 +409,8 @@ func openTraceWriter(traceWriterFile string) (io.Writer, error) {
 }
 
 func showAccountCmd() *cobra.Command {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	return &cobra.Command{
 		Use:   "show-account",
 		Short: "Print the account's address and public key",
@@ -437,6 +438,7 @@ func showAccountCmd() *cobra.Command {
 }
 
 func showPrivateKeyCmd() *cobra.Command {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return &cobra.Command{
 		Use:   "show-privatekey",
 		Short: "Print the account's private key",
@@ -464,6 +466,7 @@ func showPrivateKeyCmd() *cobra.Command {
 
 // VerifyGenesis verifies the genesis file and brings it in sync with on-chain contract
 func VerifyGenesis(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	cmd := &cobra.Command{
 		Use:   "verify-genesis",
 		Short: "Verify if the genesis matches",

--- a/cmd/heimdalld/testnet.go
+++ b/cmd/heimdalld/testnet.go
@@ -28,7 +28,7 @@ import (
 
 // TestnetCmd initialises files required to start heimdall testnet
 func testnetCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	cmd := &cobra.Command{
 		Use:   "create-testnet",

--- a/cmd/heimdalld/testnet.go
+++ b/cmd/heimdalld/testnet.go
@@ -28,7 +28,7 @@ import (
 
 // TestnetCmd initialises files required to start heimdall testnet
 func testnetCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 	cmd := &cobra.Command{
 		Use:   "create-testnet",

--- a/cmd/heimdalld/testnet.go
+++ b/cmd/heimdalld/testnet.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tendermint/tendermint/crypto"
@@ -28,6 +28,8 @@ import (
 
 // TestnetCmd initialises files required to start heimdall testnet
 func testnetCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	cmd := &cobra.Command{
 		Use:   "create-testnet",
 		Short: "Initialize files for a Heimdall testnet",

--- a/cmd/heimdalld/testnet.go
+++ b/cmd/heimdalld/testnet.go
@@ -28,7 +28,6 @@ import (
 
 // TestnetCmd initialises files required to start heimdall testnet
 func testnetCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "create-testnet",
 		Short: "Initialize files for a Heimdall testnet",

--- a/cmd/heimdalld/testnet.go
+++ b/cmd/heimdalld/testnet.go
@@ -28,7 +28,6 @@ import (
 
 // TestnetCmd initialises files required to start heimdall testnet
 func testnetCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	cmd := &cobra.Command{
 		Use:   "create-testnet",
@@ -183,7 +182,7 @@ testnet --v 4 --n 8 --output-dir ./output --starting-ip-address 192.168.10.2
 				return err
 			}
 
-			appStateJSON, err := json.Marshal(appStateBytes)
+			appStateJSON, err := jsoniter.ConfigFastest.Marshal(appStateBytes)
 			if err != nil {
 				return err
 			}
@@ -198,7 +197,7 @@ testnet --v 4 --n 8 --output-dir ./output --starting-ip-address 192.168.10.2
 			// TODO move to const string flag
 			dump := viper.GetBool("signer-dump")
 			if dump {
-				signerJSON, err := json.MarshalIndent(signers, "", "  ")
+				signerJSON, err := jsoniter.ConfigFastest.MarshalIndent(signers, "", "  ")
 				if err != nil {
 					return err
 				}

--- a/cmd/heimdalld/testnet.go
+++ b/cmd/heimdalld/testnet.go
@@ -181,7 +181,7 @@ testnet --v 4 --n 8 --output-dir ./output --starting-ip-address 192.168.10.2
 				return err
 			}
 
-			appStateJSON, err := jsoniter.ConfigFastest.Marshal(appStateBytes)
+			appStateJSON, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(appStateBytes)
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -11,21 +11,20 @@ require (
 	github.com/cespare/cp v1.1.1 // indirect
 	github.com/cosmos/cosmos-sdk v0.37.4
 	github.com/deckarep/golang-set v1.7.1 // indirect
-	github.com/docker/docker v1.13.1 // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/elastic/gosigar v0.10.5 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect
-	github.com/go-kit/kit v0.9.0 // indirect
+	github.com/go-kit/kit v0.9.0
 	github.com/gogo/protobuf v1.3.0
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/gorilla/mux v1.7.3
-	github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b // indirect
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/huin/goupnp v1.0.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
+	github.com/json-iterator/go v1.1.12
 	github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 // indirect
 	github.com/maticnetwork/bor v0.1.7-0.20200507151553-e03cd94ed12b
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
@@ -34,12 +33,11 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/prometheus/tsdb v0.10.0 // indirect
-	github.com/prysmaticlabs/prysm v0.0.0-20190507024903-1be950f90cad
 	github.com/rakyll/statik v0.1.6
 	github.com/rcrowley/go-metrics v0.0.0-20190706150252-9beb055b7962 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
-	github.com/spf13/cast v1.4.1
+	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/status-im/keycard-go v0.0.0-20191119114148-6dd40a46baa0 // indirect
@@ -53,7 +51,6 @@ require (
 	github.com/tyler-smith/go-bip39 v1.0.2 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
-	google.golang.org/grpc v1.31.0 // indirect
 	gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -72,7 +72,6 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
 github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
-github.com/apilayer/freegeoip v3.5.0+incompatible h1:z1u2gv0/rsSi/HqMDB436AiUROXXim7st5DOg4Ikl4A=
 github.com/apilayer/freegeoip v3.5.0+incompatible/go.mod h1:CUfFqErhFhXneJendyQ/rRcuA8kH8JxHvYnbOozmlCU=
 github.com/aristanetworks/fsnotify v1.4.2/go.mod h1:D/rtu7LpjYM8tRJphJ0hUBYpjai8SfX+aSNsWDTq/Ks=
 github.com/aristanetworks/glog v0.0.0-20180419172825-c15b03b3054f/go.mod h1:KASm+qXFKs/xjSoWn30NrWBBvdTTQq+UjkhjEJHfSFA=
@@ -147,8 +146,6 @@ github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14y
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
-github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -307,8 +304,6 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
-github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b h1:fRjb9ncV+Aad/w56TstaCM/xGusFsfDfeGhhc+k4IBg=
-github.com/graph-gophers/graphql-go v0.0.0-20200207002730-8334863f2c8b/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -320,7 +315,6 @@ github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/howeyc/fsnotify v0.9.0 h1:0gtV5JmOKH4A8SsFxG2BczSeXWWPvcMT0euZt5gDAxY=
 github.com/howeyc/fsnotify v0.9.0/go.mod h1:41HzSPxBGeFRQKEEwgh49TRw/nKBsYZ2cF1OzPjSJsA=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -331,7 +325,6 @@ github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883 h1:FSeK4fZCo8u40n2JMnyAsd6x7+SbvoOMHvQOU/n10P4=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
@@ -351,13 +344,13 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
@@ -419,11 +412,12 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -448,7 +442,6 @@ github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c/go.mod h1:t+O9It+L
 github.com/openconfig/reference v0.0.0-20190727015836-8dfd928c9696/go.mod h1:ym2A+zigScwkSEb/cVQB0/ZMpU3rqiH6X7WRRsxgOGw=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/oschwald/maxminddb-golang v1.6.0 h1:KAJSjdHQ8Kv45nFIbtoLGrGWqHFajOIm7skTyz/+Dls=
 github.com/oschwald/maxminddb-golang v1.6.0/go.mod h1:DUJFucBg2cvqx42YmDa/+xHvb0elJtOm3o4aFQ/nb/w=
 github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
@@ -500,8 +493,6 @@ github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.10.0 h1:If5rVCMTp6W2SiRAQFlbpJNgVlgMEd+U2GZckwK38ic=
 github.com/prometheus/tsdb v0.10.0/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSgwXEyGCt4=
-github.com/prysmaticlabs/prysm v0.0.0-20190507024903-1be950f90cad h1:xzexCebrDlUgTE5mWBktmD0k0zUjn301GGrX1R6twMs=
-github.com/prysmaticlabs/prysm v0.0.0-20190507024903-1be950f90cad/go.mod h1:kjzJhe13tmXQBdaO5DRLntr1qtMgl1boIocbR4dP3O4=
 github.com/rakyll/statik v0.1.5/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=
 github.com/rakyll/statik v0.1.6 h1:uICcfUXpgqtw2VopbIncslhAmE5hwc4g20TEyEENBNs=
 github.com/rakyll/statik v0.1.6/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=
@@ -717,7 +708,6 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5 h1:wjuX4b5yYQnEQHzd+CBcrcC6OVR2J1CN6mUy0oSxIPo=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -778,8 +768,6 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 h1:5B6i6EAiSYyejWfvc5Rc9BbI3rzIsrrXfAQBWnYfn+w=
-golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -793,8 +781,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d h1:Zu/JngovGLVi6t2J3nmAf3AoTDwuzw85YZ3b9o4yU7s=
-golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c h1:aFV+BgZ4svzjfabn8ERpuB4JI4N6/rdy1iusx77G3oU=
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -802,7 +788,6 @@ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -988,7 +973,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/gov/client/cli/parse.go
+++ b/gov/client/cli/parse.go
@@ -33,7 +33,7 @@ func parseSubmitProposalFlags() (*proposal, error) {
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(contents, proposal)
 	if err != nil {
 		return nil, err

--- a/gov/client/cli/parse.go
+++ b/gov/client/cli/parse.go
@@ -33,8 +33,7 @@ func parseSubmitProposalFlags() (*proposal, error) {
 		return nil, err
 	}
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	err = json.Unmarshal(contents, proposal)
+	err = jsoniter.ConfigFastest.Unmarshal(contents, proposal)
 	if err != nil {
 		return nil, err
 	}

--- a/gov/client/cli/parse.go
+++ b/gov/client/cli/parse.go
@@ -33,7 +33,7 @@ func parseSubmitProposalFlags() (*proposal, error) {
 		return nil, err
 	}
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(contents, proposal)
 	if err != nil {
 		return nil, err

--- a/gov/client/cli/parse.go
+++ b/gov/client/cli/parse.go
@@ -1,10 +1,10 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/viper"
 
 	govutils "github.com/maticnetwork/heimdall/gov/client/utils"
@@ -33,6 +33,7 @@ func parseSubmitProposalFlags() (*proposal, error) {
 		return nil, err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err = json.Unmarshal(contents, proposal)
 	if err != nil {
 		return nil, err

--- a/gov/module.go
+++ b/gov/module.go
@@ -3,15 +3,13 @@ package gov
 import (
 	"encoding/json"
 
-	"github.com/gorilla/mux"
-	"github.com/spf13/cobra"
-
-	abci "github.com/tendermint/tendermint/abci/types"
-
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/maticnetwork/heimdall/gov/client"
 	"github.com/maticnetwork/heimdall/gov/client/cli"

--- a/gov/types/proposal.go
+++ b/gov/types/proposal.go
@@ -140,13 +140,13 @@ func (status *ProposalStatus) Unmarshal(data []byte) error {
 
 // Marshals to JSON using string
 func (status ProposalStatus) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(status.String())
 }
 
 // Unmarshals from JSON assuming Bech32 encoding
 func (status *ProposalStatus) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {

--- a/gov/types/proposal.go
+++ b/gov/types/proposal.go
@@ -140,13 +140,13 @@ func (status *ProposalStatus) Unmarshal(data []byte) error {
 
 // Marshals to JSON using string
 func (status ProposalStatus) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(status.String())
 }
 
 // Unmarshals from JSON assuming Bech32 encoding
 func (status *ProposalStatus) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {

--- a/gov/types/proposal.go
+++ b/gov/types/proposal.go
@@ -1,12 +1,12 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // Proposal defines a struct used by the governance module to allow for voting
@@ -140,11 +140,13 @@ func (status *ProposalStatus) Unmarshal(data []byte) error {
 
 // Marshals to JSON using string
 func (status ProposalStatus) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(status.String())
 }
 
 // Unmarshals from JSON assuming Bech32 encoding
 func (status *ProposalStatus) UnmarshalJSON(data []byte) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {

--- a/gov/types/proposal.go
+++ b/gov/types/proposal.go
@@ -140,15 +140,13 @@ func (status *ProposalStatus) Unmarshal(data []byte) error {
 
 // Marshals to JSON using string
 func (status ProposalStatus) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Marshal(status.String())
+	return jsoniter.ConfigFastest.Marshal(status.String())
 }
 
 // Unmarshals from JSON assuming Bech32 encoding
 func (status *ProposalStatus) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
-	err := json.Unmarshal(data, &s)
+	err := jsoniter.ConfigFastest.Unmarshal(data, &s)
 	if err != nil {
 		return err
 	}

--- a/gov/types/vote.go
+++ b/gov/types/vote.go
@@ -107,15 +107,13 @@ func (vo *VoteOption) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using string.
 func (vo VoteOption) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Marshal(vo.String())
+	return jsoniter.ConfigFastest.Marshal(vo.String())
 }
 
 // UnmarshalJSON decodes from JSON assuming Bech32 encoding.
 func (vo *VoteOption) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
-	err := json.Unmarshal(data, &s)
+	err := jsoniter.ConfigFastest.Unmarshal(data, &s)
 	if err != nil {
 		return err
 	}

--- a/gov/types/vote.go
+++ b/gov/types/vote.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
 
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
@@ -106,11 +107,13 @@ func (vo *VoteOption) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using string.
 func (vo VoteOption) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(vo.String())
 }
 
 // UnmarshalJSON decodes from JSON assuming Bech32 encoding.
 func (vo *VoteOption) UnmarshalJSON(data []byte) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {

--- a/gov/types/vote.go
+++ b/gov/types/vote.go
@@ -107,13 +107,13 @@ func (vo *VoteOption) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using string.
 func (vo VoteOption) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(vo.String())
 }
 
 // UnmarshalJSON decodes from JSON assuming Bech32 encoding.
 func (vo *VoteOption) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {

--- a/gov/types/vote.go
+++ b/gov/types/vote.go
@@ -107,13 +107,13 @@ func (vo *VoteOption) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using string.
 func (vo VoteOption) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(vo.String())
 }
 
 // UnmarshalJSON decodes from JSON assuming Bech32 encoding.
 func (vo *VoteOption) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	err := json.Unmarshal(data, &s)
 	if err != nil {

--- a/helper/call.go
+++ b/helper/call.go
@@ -850,8 +850,8 @@ func populateABIs(contractCallerObj *ContractCaller) error {
 				Logger.Error("Error while getting ABI for contract caller", "name", contractABI, "error", err)
 				return err
 			} else {
+				// init ABI
 				ContractsABIsMap[contractABI] = ccAbi
-				Logger.Debug("ABI initialized", "name", contractABI)
 			}
 		} else {
 			// use cached abi

--- a/helper/heimdall-params.go
+++ b/helper/heimdall-params.go
@@ -1,4 +1,7 @@
 package helper
 
-const NewSelectionAlgoHeight = 375300
-const SpanOverrideBlockHeight = 8664000
+const (
+	NetworkName             = "mumbai"
+	NewSelectionAlgoHeight  = 282500
+	SpanOverrideBlockHeight = 10205000
+)

--- a/helper/heimdall-params.go
+++ b/helper/heimdall-params.go
@@ -1,7 +1,4 @@
 package helper
 
-const (
-	NetworkName             = "mumbai"
-	NewSelectionAlgoHeight  = 282500
-	SpanOverrideBlockHeight = 10205000
-)
+const NewSelectionAlgoHeight = 375300
+const SpanOverrideBlockHeight = 8664000

--- a/simulation/event_stats.go
+++ b/simulation/event_stats.go
@@ -34,7 +34,7 @@ func (es EventStats) Tally(route, op, evResult string) {
 
 // Print the event stats in JSON format.
 func (es EventStats) Print(w io.Writer) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	obj, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)
@@ -45,7 +45,7 @@ func (es EventStats) Print(w io.Writer) {
 
 // ExportJSON saves the event stats as a JSON file on a given path
 func (es EventStats) ExportJSON(path string) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)

--- a/simulation/event_stats.go
+++ b/simulation/event_stats.go
@@ -35,6 +35,7 @@ func (es EventStats) Tally(route, op, evResult string) {
 // Print the event stats in JSON format.
 func (es EventStats) Print(w io.Writer) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	obj, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)
@@ -46,6 +47,7 @@ func (es EventStats) Print(w io.Writer) {
 // ExportJSON saves the event stats as a JSON file on a given path
 func (es EventStats) ExportJSON(path string) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)

--- a/simulation/event_stats.go
+++ b/simulation/event_stats.go
@@ -34,7 +34,7 @@ func (es EventStats) Tally(route, op, evResult string) {
 
 // Print the event stats in JSON format.
 func (es EventStats) Print(w io.Writer) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	obj, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)
@@ -45,7 +45,7 @@ func (es EventStats) Print(w io.Writer) {
 
 // ExportJSON saves the event stats as a JSON file on a given path
 func (es EventStats) ExportJSON(path string) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)

--- a/simulation/event_stats.go
+++ b/simulation/event_stats.go
@@ -34,9 +34,7 @@ func (es EventStats) Tally(route, op, evResult string) {
 
 // Print the event stats in JSON format.
 func (es EventStats) Print(w io.Writer) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	obj, err := json.MarshalIndent(es, "", " ")
+	obj, err := jsoniter.ConfigFastest.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)
 	}
@@ -46,9 +44,7 @@ func (es EventStats) Print(w io.Writer) {
 
 // ExportJSON saves the event stats as a JSON file on a given path
 func (es EventStats) ExportJSON(path string) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.MarshalIndent(es, "", " ")
+	bz, err := jsoniter.ConfigFastest.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)
 	}

--- a/simulation/event_stats.go
+++ b/simulation/event_stats.go
@@ -1,10 +1,11 @@
 package simulation
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 // EventStats defines an object that keeps a tally of each event that has occurred
@@ -33,6 +34,7 @@ func (es EventStats) Tally(route, op, evResult string) {
 
 // Print the event stats in JSON format.
 func (es EventStats) Print(w io.Writer) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	obj, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)
@@ -43,6 +45,7 @@ func (es EventStats) Print(w io.Writer) {
 
 // ExportJSON saves the event stats as a JSON file on a given path
 func (es EventStats) ExportJSON(path string) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.MarshalIndent(es, "", " ")
 	if err != nil {
 		panic(err)

--- a/simulation/operation.go
+++ b/simulation/operation.go
@@ -58,7 +58,7 @@ func QueuedMsgEntry(height int64, opMsg simulation.OperationMsg) OperationEntry 
 
 // MustMarshal marshals the operation entry, panic on error.
 func (oe OperationEntry) MustMarshal() json.RawMessage {
-	out, err := jsoniter.ConfigFastest.Marshal(oe)
+	out, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(oe)
 	if err != nil {
 		panic(err)
 	}

--- a/simulation/operation.go
+++ b/simulation/operation.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"sort"
 
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/maticnetwork/heimdall/types/simulation"
 )
 
@@ -56,7 +58,8 @@ func QueuedMsgEntry(height int64, opMsg simulation.OperationMsg) OperationEntry 
 
 // MustMarshal marshals the operation entry, panic on error.
 func (oe OperationEntry) MustMarshal() json.RawMessage {
-	out, err := json.Marshal(oe)
+	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
+	out, err := jsonLib.Marshal(oe)
 	if err != nil {
 		panic(err)
 	}

--- a/simulation/operation.go
+++ b/simulation/operation.go
@@ -59,6 +59,7 @@ func QueuedMsgEntry(height int64, opMsg simulation.OperationMsg) OperationEntry 
 // MustMarshal marshals the operation entry, panic on error.
 func (oe OperationEntry) MustMarshal() json.RawMessage {
 	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	out, err := jsonLib.Marshal(oe)
 	if err != nil {
 		panic(err)

--- a/simulation/operation.go
+++ b/simulation/operation.go
@@ -58,9 +58,7 @@ func QueuedMsgEntry(height int64, opMsg simulation.OperationMsg) OperationEntry 
 
 // MustMarshal marshals the operation entry, panic on error.
 func (oe OperationEntry) MustMarshal() json.RawMessage {
-	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
-
-	out, err := jsonLib.Marshal(oe)
+	out, err := jsoniter.ConfigFastest.Marshal(oe)
 	if err != nil {
 		panic(err)
 	}

--- a/simulation/util.go
+++ b/simulation/util.go
@@ -50,6 +50,7 @@ func getBlockSize(r *rand.Rand, params Params, lastBlockSizeState, avgBlockSize 
 
 func mustMarshalJSONIndent(o interface{}) []byte {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.MarshalIndent(o, "", "  ")
 	if err != nil {
 		panic(fmt.Sprintf("failed to JSON encode: %s", err))

--- a/simulation/util.go
+++ b/simulation/util.go
@@ -49,7 +49,7 @@ func getBlockSize(r *rand.Rand, params Params, lastBlockSizeState, avgBlockSize 
 }
 
 func mustMarshalJSONIndent(o interface{}) []byte {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.MarshalIndent(o, "", "  ")
 	if err != nil {
 		panic(fmt.Sprintf("failed to JSON encode: %s", err))

--- a/simulation/util.go
+++ b/simulation/util.go
@@ -1,10 +1,11 @@
 package simulation
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 func getTestingMode(tb testing.TB) (testingMode bool, t *testing.T, b *testing.B) {
@@ -48,6 +49,7 @@ func getBlockSize(r *rand.Rand, params Params, lastBlockSizeState, avgBlockSize 
 }
 
 func mustMarshalJSONIndent(o interface{}) []byte {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.MarshalIndent(o, "", "  ")
 	if err != nil {
 		panic(fmt.Sprintf("failed to JSON encode: %s", err))

--- a/simulation/util.go
+++ b/simulation/util.go
@@ -49,9 +49,7 @@ func getBlockSize(r *rand.Rand, params Params, lastBlockSizeState, avgBlockSize 
 }
 
 func mustMarshalJSONIndent(o interface{}) []byte {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.MarshalIndent(o, "", "  ")
+	bz, err := jsoniter.ConfigFastest.MarshalIndent(o, "", "  ")
 	if err != nil {
 		panic(fmt.Sprintf("failed to JSON encode: %s", err))
 	}

--- a/simulation/util.go
+++ b/simulation/util.go
@@ -49,7 +49,7 @@ func getBlockSize(r *rand.Rand, params Params, lastBlockSizeState, avgBlockSize 
 }
 
 func mustMarshalJSONIndent(o interface{}) []byte {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.MarshalIndent(o, "", "  ")
 	if err != nil {
 		panic(fmt.Sprintf("failed to JSON encode: %s", err))

--- a/simulation/util.go
+++ b/simulation/util.go
@@ -49,7 +49,7 @@ func getBlockSize(r *rand.Rand, params Params, lastBlockSizeState, avgBlockSize 
 }
 
 func mustMarshalJSONIndent(o interface{}) []byte {
-	bz, err := jsoniter.ConfigFastest.MarshalIndent(o, "", "  ")
+	bz, err := jsoniter.ConfigCompatibleWithStandardLibrary.MarshalIndent(o, "", "  ")
 	if err != nil {
 		panic(fmt.Sprintf("failed to JSON encode: %s", err))
 	}

--- a/slashing/client/rest/query.go
+++ b/slashing/client/rest/query.go
@@ -2,17 +2,15 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
+	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/heimdall/slashing/types"
-
 	hmTypes "github.com/maticnetwork/heimdall/types"
 	hmRest "github.com/maticnetwork/heimdall/types/rest"
 )
@@ -381,6 +379,7 @@ func latestSlashInfoBytesHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		var slashInfoBytes = hmTypes.BytesToHexBytes(res)
 		RestLogger.Debug("Fetched slashInfoBytes ", "SlashInfoBytes", slashInfoBytes.String())
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		result, err := json.Marshal(&slashInfoBytes)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
@@ -558,6 +557,7 @@ func tickCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var tickCount uint64
 		if err := json.Unmarshal(tickCountBytes, &tickCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/slashing/client/rest/query.go
+++ b/slashing/client/rest/query.go
@@ -379,7 +379,7 @@ func latestSlashInfoBytesHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		var slashInfoBytes = hmTypes.BytesToHexBytes(res)
 		RestLogger.Debug("Fetched slashInfoBytes ", "SlashInfoBytes", slashInfoBytes.String())
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		result, err := json.Marshal(&slashInfoBytes)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
@@ -557,7 +557,7 @@ func tickCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		var tickCount uint64
 		if err := json.Unmarshal(tickCountBytes, &tickCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/slashing/client/rest/query.go
+++ b/slashing/client/rest/query.go
@@ -379,8 +379,7 @@ func latestSlashInfoBytesHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		var slashInfoBytes = hmTypes.BytesToHexBytes(res)
 		RestLogger.Debug("Fetched slashInfoBytes ", "SlashInfoBytes", slashInfoBytes.String())
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-		result, err := json.Marshal(&slashInfoBytes)
+		result, err := jsoniter.ConfigFastest.Marshal(&slashInfoBytes)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -557,14 +556,13 @@ func tickCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var tickCount uint64
-		if err := json.Unmarshal(tickCountBytes, &tickCount); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(tickCountBytes, &tickCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
-		result, err := json.Marshal(&tickCount)
+		result, err := jsoniter.ConfigFastest.Marshal(&tickCount)
 		if err != nil {
 			RestLogger.Error("Error while marshalling resposne to Json", "error", err)
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/slashing/client/rest/query.go
+++ b/slashing/client/rest/query.go
@@ -379,7 +379,7 @@ func latestSlashInfoBytesHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		var slashInfoBytes = hmTypes.BytesToHexBytes(res)
 		RestLogger.Debug("Fetched slashInfoBytes ", "SlashInfoBytes", slashInfoBytes.String())
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		result, err := json.Marshal(&slashInfoBytes)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
@@ -557,7 +557,7 @@ func tickCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		var tickCount uint64
 		if err := json.Unmarshal(tickCountBytes, &tickCount); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/slashing/module.go
+++ b/slashing/module.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	chainmanagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 	"github.com/maticnetwork/heimdall/helper"
 	slashingCli "github.com/maticnetwork/heimdall/slashing/client/cli"
 	"github.com/maticnetwork/heimdall/slashing/client/rest"
@@ -23,8 +24,6 @@ import (
 	hmTypes "github.com/maticnetwork/heimdall/types"
 	hmModule "github.com/maticnetwork/heimdall/types/module"
 	simTypes "github.com/maticnetwork/heimdall/types/simulation"
-
-	chainmanagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 )
 
 var (

--- a/slashing/querier.go
+++ b/slashing/querier.go
@@ -53,8 +53,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	bz, err := json.Marshal(keeper.GetParams(ctx))
+	bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -75,8 +74,7 @@ func querySigningInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	bz, err := json.Marshal(signingInfo)
+	bz, err := jsoniter.ConfigFastest.Marshal(signingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -105,8 +103,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	bz, err := json.Marshal(signingInfos)
+	bz, err := jsoniter.ConfigFastest.Marshal(signingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -114,8 +111,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 }
 
 func handleQueryTickCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	bz, err := json.Marshal(keeper.GetTickCount(ctx))
+	bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetTickCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -136,8 +132,7 @@ func querySlashingInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	bz, err := json.Marshal(slashingInfo)
+	bz, err := jsoniter.ConfigFastest.Marshal(slashingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -166,8 +161,7 @@ func querySlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byt
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	bz, err := json.Marshal(slashingInfos)
+	bz, err := jsoniter.ConfigFastest.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -210,8 +204,7 @@ func queryTickSlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	bz, err := json.Marshal(slashingInfos)
+	bz, err := jsoniter.ConfigFastest.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/slashing/querier.go
+++ b/slashing/querier.go
@@ -53,7 +53,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -75,7 +75,7 @@ func querySigningInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(signingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -105,7 +105,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(signingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -114,7 +114,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 }
 
 func handleQueryTickCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetTickCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -136,7 +136,7 @@ func querySlashingInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -166,7 +166,7 @@ func querySlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byt
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -210,7 +210,7 @@ func queryTickSlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/slashing/querier.go
+++ b/slashing/querier.go
@@ -53,7 +53,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -75,7 +75,7 @@ func querySigningInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(signingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -105,7 +105,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(signingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -114,7 +114,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 }
 
 func handleQueryTickCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetTickCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -136,7 +136,7 @@ func querySlashingInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -166,7 +166,7 @@ func querySlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byt
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -210,7 +210,7 @@ func queryTickSlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/slashing/querier.go
+++ b/slashing/querier.go
@@ -1,15 +1,15 @@
 package slashing
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
-
-	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	"github.com/maticnetwork/heimdall/helper"
 	"github.com/maticnetwork/heimdall/slashing/types"
 	hmTypes "github.com/maticnetwork/heimdall/types"
@@ -53,6 +53,7 @@ func NewQuerier(k Keeper) sdk.Querier {
 }
 
 func queryParams(ctx sdk.Context, keeper Keeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetParams(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -74,6 +75,7 @@ func querySigningInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte,
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(signingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -103,6 +105,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(signingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -111,6 +114,7 @@ func querySigningInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 }
 
 func handleQueryTickCount(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetTickCount(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -132,6 +136,7 @@ func querySlashingInfo(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfo)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -161,6 +166,7 @@ func querySlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byt
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -204,6 +210,7 @@ func queryTickSlashingInfos(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(slashingInfos)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/staking/client/rest/query.go
+++ b/staking/client/rest/query.go
@@ -175,15 +175,13 @@ func getTotalValidatorPower(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 		var totalPower uint64
-		if err := json.Unmarshal(totalPowerBytes, &totalPower); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(totalPowerBytes, &totalPower); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
-		result, err := json.Marshal(map[string]interface{}{"result": totalPower})
+		result, err := jsoniter.ConfigFastest.Marshal(map[string]interface{}{"result": totalPower})
 		if err != nil {
 			RestLogger.Error("Error while marshalling resposne to Json", "error", err)
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -289,15 +287,13 @@ func validatorStatusByAddreesHandlerFn(cliCtx context.CLIContext) http.HandlerFu
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 		var status bool
-		if err = json.Unmarshal(statusBytes, &status); err != nil {
+		if err = jsoniter.ConfigFastest.Unmarshal(statusBytes, &status); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
-		res, err := json.Marshal(map[string]interface{}{"result": status})
+		res, err := jsoniter.ConfigFastest.Marshal(map[string]interface{}{"result": status})
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -504,15 +500,13 @@ func proposerBonusPercentHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 		var _proposerBonusPercent int64
-		if err := json.Unmarshal(res, &_proposerBonusPercent); err != nil {
+		if err := jsoniter.ConfigFastest.Unmarshal(res, &_proposerBonusPercent); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
-		result, err := json.Marshal(_proposerBonusPercent)
+		result, err := jsoniter.ConfigFastest.Marshal(_proposerBonusPercent)
 		if err != nil {
 			RestLogger.Error("Error while marshalling resposne to Json", "error", err)
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())

--- a/staking/client/rest/query.go
+++ b/staking/client/rest/query.go
@@ -175,7 +175,7 @@ func getTotalValidatorPower(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var totalPower uint64
 		if err := json.Unmarshal(totalPowerBytes, &totalPower); err != nil {
@@ -289,7 +289,7 @@ func validatorStatusByAddreesHandlerFn(cliCtx context.CLIContext) http.HandlerFu
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var status bool
 		if err = json.Unmarshal(statusBytes, &status); err != nil {
@@ -504,7 +504,7 @@ func proposerBonusPercentHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var _proposerBonusPercent int64
 		if err := json.Unmarshal(res, &_proposerBonusPercent); err != nil {

--- a/staking/client/rest/query.go
+++ b/staking/client/rest/query.go
@@ -2,15 +2,15 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
-	"github.com/maticnetwork/bor/common"
+	jsoniter "github.com/json-iterator/go"
 
+	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/heimdall/staking/types"
 	hmTypes "github.com/maticnetwork/heimdall/types"
 	hmRest "github.com/maticnetwork/heimdall/types/rest"
@@ -175,6 +175,8 @@ func getTotalValidatorPower(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
 		var totalPower uint64
 		if err := json.Unmarshal(totalPowerBytes, &totalPower); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -286,6 +288,8 @@ func validatorStatusByAddreesHandlerFn(cliCtx context.CLIContext) http.HandlerFu
 		if !hmRest.ReturnNotFoundIfNoContent(w, statusBytes, "No validator found") {
 			return
 		}
+
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var status bool
 		if err = json.Unmarshal(statusBytes, &status); err != nil {
@@ -499,6 +503,8 @@ func proposerBonusPercentHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			RestLogger.Error("Proposer bonus percentage not found ", "Error", err.Error())
 			return
 		}
+
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var _proposerBonusPercent int64
 		if err := json.Unmarshal(res, &_proposerBonusPercent); err != nil {

--- a/staking/client/rest/query.go
+++ b/staking/client/rest/query.go
@@ -175,7 +175,7 @@ func getTotalValidatorPower(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var totalPower uint64
 		if err := json.Unmarshal(totalPowerBytes, &totalPower); err != nil {
@@ -289,7 +289,7 @@ func validatorStatusByAddreesHandlerFn(cliCtx context.CLIContext) http.HandlerFu
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var status bool
 		if err = json.Unmarshal(statusBytes, &status); err != nil {
@@ -504,7 +504,7 @@ func proposerBonusPercentHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var _proposerBonusPercent int64
 		if err := json.Unmarshal(res, &_proposerBonusPercent); err != nil {

--- a/staking/keeper.go
+++ b/staking/keeper.go
@@ -31,7 +31,7 @@ type ModuleCommunicator interface {
 	SetCoins(ctx sdk.Context, addr hmTypes.HeimdallAddress, amt sdk.Coins) sdk.Error
 	GetCoins(ctx sdk.Context, addr hmTypes.HeimdallAddress) sdk.Coins
 	SendCoins(ctx sdk.Context, from hmTypes.HeimdallAddress, to hmTypes.HeimdallAddress, amt sdk.Coins) sdk.Error
-	CreateValiatorSigningInfo(ctx sdk.Context, valID hmTypes.ValidatorID, valSigningInfo hmTypes.ValidatorSigningInfo)
+	CreateValidatorSigningInfo(ctx sdk.Context, valID hmTypes.ValidatorID, valSigningInfo hmTypes.ValidatorSigningInfo)
 }
 
 // Keeper stores all related data
@@ -447,7 +447,7 @@ func (k *Keeper) IterateStakingSequencesAndApplyFn(ctx sdk.Context, f func(seque
 // Slashing api's
 // AddValidatorSigningInfo creates a signing info for validator
 func (k *Keeper) AddValidatorSigningInfo(ctx sdk.Context, valID hmTypes.ValidatorID, valSigningInfo hmTypes.ValidatorSigningInfo) error {
-	k.moduleCommunicator.CreateValiatorSigningInfo(ctx, valID, valSigningInfo)
+	k.moduleCommunicator.CreateValidatorSigningInfo(ctx, valID, valSigningInfo)
 	return nil
 }
 

--- a/staking/module.go
+++ b/staking/module.go
@@ -10,6 +10,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	chainmanagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 	"github.com/maticnetwork/heimdall/helper"
 	stakingCli "github.com/maticnetwork/heimdall/staking/client/cli"
@@ -19,8 +22,6 @@ import (
 	hmTypes "github.com/maticnetwork/heimdall/types"
 	hmModule "github.com/maticnetwork/heimdall/types/module"
 	simTypes "github.com/maticnetwork/heimdall/types/simulation"
-	"github.com/spf13/cobra"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 var (

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -42,9 +42,7 @@ func NewQuerier(keeper Keeper, contractCaller helper.IContractCaller) sdk.Querie
 }
 
 func handleQueryTotalValidatorPower(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(keeper.GetTotalPower(ctx))
+	bz, err := jsoniter.ConfigFastest.Marshal(keeper.GetTotalPower(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -57,9 +55,7 @@ func handleQueryCurrentValidatorSet(ctx sdk.Context, req abci.RequestQuery, keep
 	validatorSet := keeper.GetValidatorSet(ctx)
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(validatorSet)
+	bz, err := jsoniter.ConfigFastest.Marshal(validatorSet)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -80,9 +76,7 @@ func handleQuerySigner(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(validator)
+	bz, err := jsoniter.ConfigFastest.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -103,9 +97,7 @@ func handleQueryValidator(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(validator)
+	bz, err := jsoniter.ConfigFastest.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -123,9 +115,7 @@ func handleQueryValidatorStatus(ctx sdk.Context, req abci.RequestQuery, keeper K
 	status := keeper.IsCurrentValidatorByAddress(ctx, params.SignerAddress)
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(status)
+	bz, err := jsoniter.ConfigFastest.Marshal(status)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -157,9 +147,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(proposers)
+	bz, err := jsoniter.ConfigFastest.Marshal(proposers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -169,10 +157,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 
 func handleQueryCurrentProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	proposer := keeper.GetCurrentProposer(ctx)
-
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(proposer)
+	bz, err := jsoniter.ConfigFastest.Marshal(proposer)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -43,6 +43,7 @@ func NewQuerier(keeper Keeper, contractCaller helper.IContractCaller) sdk.Querie
 
 func handleQueryTotalValidatorPower(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(keeper.GetTotalPower(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -57,6 +58,7 @@ func handleQueryCurrentValidatorSet(ctx sdk.Context, req abci.RequestQuery, keep
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(validatorSet)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -79,6 +81,7 @@ func handleQuerySigner(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -101,6 +104,7 @@ func handleQueryValidator(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -120,6 +124,7 @@ func handleQueryValidatorStatus(ctx sdk.Context, req abci.RequestQuery, keeper K
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(status)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -153,6 +158,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(proposers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -165,6 +171,7 @@ func handleQueryCurrentProposer(ctx sdk.Context, req abci.RequestQuery, keeper K
 	proposer := keeper.GetCurrentProposer(ctx)
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(proposer)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -42,7 +42,7 @@ func NewQuerier(keeper Keeper, contractCaller helper.IContractCaller) sdk.Querie
 }
 
 func handleQueryTotalValidatorPower(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetTotalPower(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -56,7 +56,7 @@ func handleQueryCurrentValidatorSet(ctx sdk.Context, req abci.RequestQuery, keep
 	validatorSet := keeper.GetValidatorSet(ctx)
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validatorSet)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -78,7 +78,7 @@ func handleQuerySigner(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -100,7 +100,7 @@ func handleQueryValidator(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -119,7 +119,7 @@ func handleQueryValidatorStatus(ctx sdk.Context, req abci.RequestQuery, keeper K
 	status := keeper.IsCurrentValidatorByAddress(ctx, params.SignerAddress)
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(status)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -152,7 +152,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(proposers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -164,7 +164,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 func handleQueryCurrentProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	proposer := keeper.GetCurrentProposer(ctx)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(proposer)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -1,12 +1,12 @@
 package staking
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/maticnetwork/heimdall/helper"
@@ -42,6 +42,7 @@ func NewQuerier(keeper Keeper, contractCaller helper.IContractCaller) sdk.Querie
 }
 
 func handleQueryTotalValidatorPower(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetTotalPower(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -55,6 +56,7 @@ func handleQueryCurrentValidatorSet(ctx sdk.Context, req abci.RequestQuery, keep
 	validatorSet := keeper.GetValidatorSet(ctx)
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validatorSet)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -76,6 +78,7 @@ func handleQuerySigner(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -97,6 +100,7 @@ func handleQueryValidator(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -115,6 +119,7 @@ func handleQueryValidatorStatus(ctx sdk.Context, req abci.RequestQuery, keeper K
 	status := keeper.IsCurrentValidatorByAddress(ctx, params.SignerAddress)
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(status)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -147,6 +152,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(proposers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -158,6 +164,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 func handleQueryCurrentProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	proposer := keeper.GetCurrentProposer(ctx)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(proposer)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -42,7 +42,7 @@ func NewQuerier(keeper Keeper, contractCaller helper.IContractCaller) sdk.Querie
 }
 
 func handleQueryTotalValidatorPower(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(keeper.GetTotalPower(ctx))
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -56,7 +56,7 @@ func handleQueryCurrentValidatorSet(ctx sdk.Context, req abci.RequestQuery, keep
 	validatorSet := keeper.GetValidatorSet(ctx)
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validatorSet)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -78,7 +78,7 @@ func handleQuerySigner(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -100,7 +100,7 @@ func handleQueryValidator(ctx sdk.Context, req abci.RequestQuery, keeper Keeper)
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(validator)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -119,7 +119,7 @@ func handleQueryValidatorStatus(ctx sdk.Context, req abci.RequestQuery, keeper K
 	status := keeper.IsCurrentValidatorByAddress(ctx, params.SignerAddress)
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(status)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -152,7 +152,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(proposers)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -164,7 +164,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 func handleQueryCurrentProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	proposer := keeper.GetCurrentProposer(ctx)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(proposer)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/staking/querier.go
+++ b/staking/querier.go
@@ -157,6 +157,7 @@ func handleQueryProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) 
 
 func handleQueryCurrentProposer(ctx sdk.Context, req abci.RequestQuery, keeper Keeper) ([]byte, sdk.Error) {
 	proposer := keeper.GetCurrentProposer(ctx)
+
 	bz, err := jsoniter.ConfigFastest.Marshal(proposer)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/topup/client/rest/query.go
+++ b/topup/client/rest/query.go
@@ -253,7 +253,7 @@ func dividendAccountRootHandlerFn(
 
 		RestLogger.Debug("Fetched Dividend accountRootHash ", "AccountRootHash", accountRootHash)
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		result, err := json.Marshal(&accountRootHash)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
@@ -345,7 +345,7 @@ func VerifyAccountProofHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var accountProofStatus bool
 		if err = json.Unmarshal(res, &accountProofStatus); err != nil {

--- a/topup/client/rest/query.go
+++ b/topup/client/rest/query.go
@@ -2,13 +2,13 @@
 package rest
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/types/rest"
 	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/heimdall/topup/types"
 	hmTypes "github.com/maticnetwork/heimdall/types"
@@ -253,6 +253,7 @@ func dividendAccountRootHandlerFn(
 
 		RestLogger.Debug("Fetched Dividend accountRootHash ", "AccountRootHash", accountRootHash)
 
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		result, err := json.Marshal(&accountRootHash)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
@@ -343,6 +344,8 @@ func VerifyAccountProofHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 			return
 		}
+
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var accountProofStatus bool
 		if err = json.Unmarshal(res, &accountProofStatus); err != nil {

--- a/topup/client/rest/query.go
+++ b/topup/client/rest/query.go
@@ -253,7 +253,7 @@ func dividendAccountRootHandlerFn(
 
 		RestLogger.Debug("Fetched Dividend accountRootHash ", "AccountRootHash", accountRootHash)
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		result, err := json.Marshal(&accountRootHash)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
@@ -345,7 +345,7 @@ func VerifyAccountProofHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		var accountProofStatus bool
 		if err = json.Unmarshal(res, &accountProofStatus); err != nil {

--- a/topup/client/rest/query.go
+++ b/topup/client/rest/query.go
@@ -253,8 +253,7 @@ func dividendAccountRootHandlerFn(
 
 		RestLogger.Debug("Fetched Dividend accountRootHash ", "AccountRootHash", accountRootHash)
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-		result, err := json.Marshal(&accountRootHash)
+		result, err := jsoniter.ConfigFastest.Marshal(&accountRootHash)
 		if err != nil {
 			RestLogger.Error("Error while marshalling response to Json", "error", err)
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -345,15 +344,13 @@ func VerifyAccountProofHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 		var accountProofStatus bool
-		if err = json.Unmarshal(res, &accountProofStatus); err != nil {
+		if err = jsoniter.ConfigFastest.Unmarshal(res, &accountProofStatus); err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
 		}
 
-		res, err = json.Marshal(map[string]interface{}{"result": accountProofStatus})
+		res, err = jsoniter.ConfigFastest.Marshal(map[string]interface{}{"result": accountProofStatus})
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return

--- a/topup/module.go
+++ b/topup/module.go
@@ -13,11 +13,9 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/maticnetwork/heimdall/helper"
-	"github.com/maticnetwork/heimdall/topup/simulation"
-
 	topupCli "github.com/maticnetwork/heimdall/topup/client/cli"
 	topupRest "github.com/maticnetwork/heimdall/topup/client/rest"
-
+	"github.com/maticnetwork/heimdall/topup/simulation"
 	"github.com/maticnetwork/heimdall/topup/types"
 	hmTypes "github.com/maticnetwork/heimdall/types"
 	hmModule "github.com/maticnetwork/heimdall/types/module"

--- a/topup/querier.go
+++ b/topup/querier.go
@@ -84,6 +84,7 @@ func handleQueryDividendAccount(ctx sdk.Context, req abci.RequestQuery, keeper K
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(dividendAccount)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -137,6 +138,7 @@ func handleQueryAccountProof(ctx sdk.Context, req abci.RequestQuery, keeper Keep
 
 		// json record
 		json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 		bz, err := json.Marshal(accountProof)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -164,6 +166,7 @@ func handleQueryVerifyAccountProof(ctx sdk.Context, req abci.RequestQuery, keepe
 
 	// json record
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	bz, err := json.Marshal(accountProofStatus)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/topup/querier.go
+++ b/topup/querier.go
@@ -83,7 +83,7 @@ func handleQueryDividendAccount(ctx sdk.Context, req abci.RequestQuery, keeper K
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(dividendAccount)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -136,7 +136,7 @@ func handleQueryAccountProof(ctx sdk.Context, req abci.RequestQuery, keeper Keep
 		accountProof := hmTypes.NewDividendAccountProof(params.UserAddress, merkleProof, index)
 
 		// json record
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		bz, err := json.Marshal(accountProof)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -163,7 +163,7 @@ func handleQueryVerifyAccountProof(ctx sdk.Context, req abci.RequestQuery, keepe
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(accountProofStatus)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/topup/querier.go
+++ b/topup/querier.go
@@ -2,17 +2,18 @@ package topup
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"math/big"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	checkpointTypes "github.com/maticnetwork/heimdall/checkpoint/types"
 	"github.com/maticnetwork/heimdall/helper"
 	"github.com/maticnetwork/heimdall/topup/types"
 	hmTypes "github.com/maticnetwork/heimdall/types"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // NewQuerier returns a new sdk.Keeper instance.
@@ -82,6 +83,7 @@ func handleQueryDividendAccount(ctx sdk.Context, req abci.RequestQuery, keeper K
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(dividendAccount)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -134,6 +136,7 @@ func handleQueryAccountProof(ctx sdk.Context, req abci.RequestQuery, keeper Keep
 		accountProof := hmTypes.NewDividendAccountProof(params.UserAddress, merkleProof, index)
 
 		// json record
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		bz, err := json.Marshal(accountProof)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -160,6 +163,7 @@ func handleQueryVerifyAccountProof(ctx sdk.Context, req abci.RequestQuery, keepe
 	}
 
 	// json record
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(accountProofStatus)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/topup/querier.go
+++ b/topup/querier.go
@@ -83,9 +83,7 @@ func handleQueryDividendAccount(ctx sdk.Context, req abci.RequestQuery, keeper K
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(dividendAccount)
+	bz, err := jsoniter.ConfigFastest.Marshal(dividendAccount)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}
@@ -137,9 +135,7 @@ func handleQueryAccountProof(ctx sdk.Context, req abci.RequestQuery, keeper Keep
 		accountProof := hmTypes.NewDividendAccountProof(params.UserAddress, merkleProof, index)
 
 		// json record
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-		bz, err := json.Marshal(accountProof)
+		bz, err := jsoniter.ConfigFastest.Marshal(accountProof)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 		}
@@ -165,9 +161,7 @@ func handleQueryVerifyAccountProof(ctx sdk.Context, req abci.RequestQuery, keepe
 	}
 
 	// json record
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
-	bz, err := json.Marshal(accountProofStatus)
+	bz, err := jsoniter.ConfigFastest.Marshal(accountProofStatus)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
 	}

--- a/topup/querier.go
+++ b/topup/querier.go
@@ -83,7 +83,7 @@ func handleQueryDividendAccount(ctx sdk.Context, req abci.RequestQuery, keeper K
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(dividendAccount)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -136,7 +136,7 @@ func handleQueryAccountProof(ctx sdk.Context, req abci.RequestQuery, keeper Keep
 		accountProof := hmTypes.NewDividendAccountProof(params.UserAddress, merkleProof, index)
 
 		// json record
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 		bz, err := json.Marshal(accountProof)
 		if err != nil {
 			return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))
@@ -163,7 +163,7 @@ func handleQueryVerifyAccountProof(ctx sdk.Context, req abci.RequestQuery, keepe
 	}
 
 	// json record
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	bz, err := json.Marshal(accountProofStatus)
 	if err != nil {
 		return nil, sdk.ErrInternal(sdk.AppendMsgToErr("could not marshal result to JSON", err.Error()))

--- a/topup/querier_test.go
+++ b/topup/querier_test.go
@@ -129,6 +129,7 @@ func (suite *QuerierTestSuite) TestHandleQueryDividendAccount() {
 	require.NotNil(t, res)
 
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var divAcc hmTypes.DividendAccount
 	err = json.Unmarshal(res, &divAcc)
 	require.NoError(t, err)

--- a/topup/querier_test.go
+++ b/topup/querier_test.go
@@ -128,10 +128,8 @@ func (suite *QuerierTestSuite) TestHandleQueryDividendAccount() {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var divAcc hmTypes.DividendAccount
-	err = json.Unmarshal(res, &divAcc)
+	err = jsoniter.ConfigFastest.Unmarshal(res, &divAcc)
 	require.NoError(t, err)
 	require.Equal(t, dividendAccount, divAcc)
 }

--- a/topup/querier_test.go
+++ b/topup/querier_test.go
@@ -1,7 +1,6 @@
 package topup_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -10,12 +9,13 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	ethTypes "github.com/maticnetwork/bor/core/types"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	ethTypes "github.com/maticnetwork/bor/core/types"
 	"github.com/maticnetwork/heimdall/app"
 	chainTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 	checkpointTypes "github.com/maticnetwork/heimdall/checkpoint/types"
@@ -128,6 +128,7 @@ func (suite *QuerierTestSuite) TestHandleQueryDividendAccount() {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var divAcc hmTypes.DividendAccount
 	err = json.Unmarshal(res, &divAcc)
 	require.NoError(t, err)

--- a/topup/querier_test.go
+++ b/topup/querier_test.go
@@ -128,7 +128,7 @@ func (suite *QuerierTestSuite) TestHandleQueryDividendAccount() {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var divAcc hmTypes.DividendAccount
 	err = json.Unmarshal(res, &divAcc)
 	require.NoError(t, err)

--- a/topup/querier_test.go
+++ b/topup/querier_test.go
@@ -128,7 +128,7 @@ func (suite *QuerierTestSuite) TestHandleQueryDividendAccount() {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var divAcc hmTypes.DividendAccount
 	err = json.Unmarshal(res, &divAcc)
 	require.NoError(t, err)

--- a/types/address.go
+++ b/types/address.go
@@ -73,6 +73,7 @@ func (aa HeimdallAddress) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallAddress) UnmarshalJSON(data []byte) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/address.go
+++ b/types/address.go
@@ -3,12 +3,13 @@ package types
 import (
 	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/maticnetwork/bor/common"
+	jsoniter "github.com/json-iterator/go"
 	"gopkg.in/yaml.v2"
+
+	"github.com/maticnetwork/bor/common"
 )
 
 const (
@@ -60,6 +61,7 @@ func (aa *HeimdallAddress) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallAddress) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -70,6 +72,7 @@ func (aa HeimdallAddress) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallAddress) UnmarshalJSON(data []byte) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err

--- a/types/address.go
+++ b/types/address.go
@@ -61,7 +61,7 @@ func (aa *HeimdallAddress) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallAddress) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -72,8 +72,9 @@ func (aa HeimdallAddress) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallAddress) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
+
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/types/address.go
+++ b/types/address.go
@@ -61,8 +61,7 @@ func (aa *HeimdallAddress) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallAddress) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Marshal(aa.String())
+	return jsoniter.ConfigFastest.Marshal(aa.String())
 }
 
 // MarshalYAML marshals to YAML using Bech32.
@@ -72,11 +71,8 @@ func (aa HeimdallAddress) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallAddress) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var s string
-
-	if err := json.Unmarshal(data, &s); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(data, &s); err != nil {
 		return err
 	}
 

--- a/types/address.go
+++ b/types/address.go
@@ -61,7 +61,7 @@ func (aa *HeimdallAddress) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallAddress) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -72,7 +72,7 @@ func (aa HeimdallAddress) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallAddress) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/address.go
+++ b/types/address.go
@@ -61,7 +61,7 @@ func (aa *HeimdallAddress) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallAddress) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -72,7 +72,7 @@ func (aa HeimdallAddress) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallAddress) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -41,8 +41,7 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 
 // MarshalJSON this is the point of Bytes.
 func (bz HexBytes) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Marshal(bz.String())
+	return jsoniter.ConfigFastest.Marshal(bz.String())
 }
 
 // MarshalYAML marshals to YAML using Bech32.
@@ -52,11 +51,8 @@ func (bz HexBytes) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON this is the point of Bytes.
 func (bz *HexBytes) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var s string
-
-	if err := json.Unmarshal(data, &s); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(data, &s); err != nil {
 		return err
 	}
 

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -41,7 +41,7 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 
 // MarshalJSON this is the point of Bytes.
 func (bz HexBytes) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(bz.String())
 }
 
@@ -52,7 +52,7 @@ func (bz HexBytes) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON this is the point of Bytes.
 func (bz *HexBytes) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -53,6 +53,7 @@ func (bz HexBytes) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON this is the point of Bytes.
 func (bz *HexBytes) UnmarshalJSON(data []byte) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -2,12 +2,13 @@ package types
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+	"gopkg.in/yaml.v2"
 
 	"github.com/maticnetwork/bor/common"
 	"github.com/maticnetwork/bor/common/hexutil"
-	"gopkg.in/yaml.v2"
 )
 
 // HexBytes the main purpose of HexBytes is to enable HEX-encoding for json/encoding.
@@ -40,6 +41,7 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 
 // MarshalJSON this is the point of Bytes.
 func (bz HexBytes) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(bz.String())
 }
 
@@ -50,6 +52,7 @@ func (bz HexBytes) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON this is the point of Bytes.
 func (bz *HexBytes) UnmarshalJSON(data []byte) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -41,7 +41,7 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 
 // MarshalJSON this is the point of Bytes.
 func (bz HexBytes) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(bz.String())
 }
 
@@ -52,8 +52,9 @@ func (bz HexBytes) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON this is the point of Bytes.
 func (bz *HexBytes) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
+
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/types/bytes.go
+++ b/types/bytes.go
@@ -41,7 +41,7 @@ func (bz *HexBytes) Unmarshal(data []byte) error {
 
 // MarshalJSON this is the point of Bytes.
 func (bz HexBytes) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(bz.String())
 }
 
@@ -52,7 +52,7 @@ func (bz HexBytes) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON this is the point of Bytes.
 func (bz *HexBytes) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/hash.go
+++ b/types/hash.go
@@ -66,6 +66,7 @@ func (aa HeimdallHash) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallHash) UnmarshalJSON(data []byte) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/hash.go
+++ b/types/hash.go
@@ -3,11 +3,12 @@ package types
 import (
 	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 
-	"github.com/maticnetwork/bor/common"
+	jsoniter "github.com/json-iterator/go"
 	"gopkg.in/yaml.v2"
+
+	"github.com/maticnetwork/bor/common"
 )
 
 // Ensure that different address types implement the interface
@@ -53,6 +54,7 @@ func (aa *HeimdallHash) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallHash) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -63,6 +65,7 @@ func (aa HeimdallHash) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallHash) UnmarshalJSON(data []byte) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err

--- a/types/hash.go
+++ b/types/hash.go
@@ -54,7 +54,7 @@ func (aa *HeimdallHash) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallHash) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -65,7 +65,7 @@ func (aa HeimdallHash) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallHash) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/hash.go
+++ b/types/hash.go
@@ -54,8 +54,7 @@ func (aa *HeimdallHash) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallHash) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Marshal(aa.String())
+	return jsoniter.ConfigFastest.Marshal(aa.String())
 }
 
 // MarshalYAML marshals to YAML using Bech32.
@@ -65,11 +64,8 @@ func (aa HeimdallHash) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallHash) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var s string
-
-	if err := json.Unmarshal(data, &s); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(data, &s); err != nil {
 		return err
 	}
 

--- a/types/hash.go
+++ b/types/hash.go
@@ -54,7 +54,7 @@ func (aa *HeimdallHash) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallHash) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -65,8 +65,9 @@ func (aa HeimdallHash) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallHash) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
+
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/types/hash.go
+++ b/types/hash.go
@@ -54,7 +54,7 @@ func (aa *HeimdallHash) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (aa HeimdallHash) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(aa.String())
 }
 
@@ -65,7 +65,7 @@ func (aa HeimdallHash) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (aa *HeimdallHash) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/pubkey.go
+++ b/types/pubkey.go
@@ -82,7 +82,7 @@ func (a *PubKey) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (a PubKey) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(a.String())
 }
 
@@ -93,7 +93,7 @@ func (a PubKey) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (a *PubKey) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/pubkey.go
+++ b/types/pubkey.go
@@ -94,6 +94,7 @@ func (a PubKey) MarshalYAML() (interface{}, error) {
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (a *PubKey) UnmarshalJSON(data []byte) error {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
+
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/pubkey.go
+++ b/types/pubkey.go
@@ -82,7 +82,7 @@ func (a *PubKey) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (a PubKey) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(a.String())
 }
 
@@ -93,8 +93,9 @@ func (a PubKey) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (a *PubKey) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
+
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}

--- a/types/pubkey.go
+++ b/types/pubkey.go
@@ -82,8 +82,7 @@ func (a *PubKey) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (a PubKey) MarshalJSON() ([]byte, error) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-	return json.Marshal(a.String())
+	return jsoniter.ConfigFastest.Marshal(a.String())
 }
 
 // MarshalYAML marshals to YAML using Bech32.
@@ -93,11 +92,8 @@ func (a PubKey) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (a *PubKey) UnmarshalJSON(data []byte) error {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	var s string
-
-	if err := json.Unmarshal(data, &s); err != nil {
+	if err := jsoniter.ConfigFastest.Unmarshal(data, &s); err != nil {
 		return err
 	}
 

--- a/types/pubkey.go
+++ b/types/pubkey.go
@@ -2,8 +2,8 @@ package types
 
 import (
 	"encoding/hex"
-	"encoding/json"
 
+	jsoniter "github.com/json-iterator/go"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
@@ -82,6 +82,7 @@ func (a *PubKey) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (a PubKey) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(a.String())
 }
 
@@ -92,6 +93,7 @@ func (a PubKey) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (a *PubKey) UnmarshalJSON(data []byte) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err

--- a/types/pubkey.go
+++ b/types/pubkey.go
@@ -82,7 +82,7 @@ func (a *PubKey) Unmarshal(data []byte) error {
 
 // MarshalJSON marshals to JSON using Bech32.
 func (a PubKey) MarshalJSON() ([]byte, error) {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(a.String())
 }
 
@@ -93,7 +93,7 @@ func (a PubKey) MarshalYAML() (interface{}, error) {
 
 // UnmarshalJSON unmarshals from JSON assuming Bech32 encoding.
 func (a *PubKey) UnmarshalJSON(data []byte) error {
-	var json = jsoniter.ConfigCompatibleWithStandardLibrary
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	var s string
 
 	if err := json.Unmarshal(data, &s); err != nil {

--- a/types/simulation/types.go
+++ b/types/simulation/types.go
@@ -88,6 +88,7 @@ func NoOpMsg(route string) OperationMsg {
 // log entry text for this operation msg
 func (om OperationMsg) String() string {
 	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	out, err := jsonLib.Marshal(om)
 	if err != nil {
 		panic(err)
@@ -99,6 +100,7 @@ func (om OperationMsg) String() string {
 // MustMarshal Marshals the operation msg, panic on error
 func (om OperationMsg) MustMarshal() json.RawMessage {
 	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
+
 	out, err := jsonLib.Marshal(om)
 	if err != nil {
 		panic(err)

--- a/types/simulation/types.go
+++ b/types/simulation/types.go
@@ -87,9 +87,7 @@ func NoOpMsg(route string) OperationMsg {
 
 // log entry text for this operation msg
 func (om OperationMsg) String() string {
-	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
-
-	out, err := jsonLib.Marshal(om)
+	out, err := jsoniter.ConfigFastest.Marshal(om)
 	if err != nil {
 		panic(err)
 	}
@@ -99,9 +97,7 @@ func (om OperationMsg) String() string {
 
 // MustMarshal Marshals the operation msg, panic on error
 func (om OperationMsg) MustMarshal() json.RawMessage {
-	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
-
-	out, err := jsonLib.Marshal(om)
+	out, err := jsoniter.ConfigFastest.Marshal(om)
 	if err != nil {
 		panic(err)
 	}

--- a/types/simulation/types.go
+++ b/types/simulation/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	jsoniter "github.com/json-iterator/go"
 )
 
 type WeightedProposalContent interface {
@@ -86,7 +87,8 @@ func NoOpMsg(route string) OperationMsg {
 
 // log entry text for this operation msg
 func (om OperationMsg) String() string {
-	out, err := json.Marshal(om)
+	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
+	out, err := jsonLib.Marshal(om)
 	if err != nil {
 		panic(err)
 	}
@@ -96,7 +98,8 @@ func (om OperationMsg) String() string {
 
 // MustMarshal Marshals the operation msg, panic on error
 func (om OperationMsg) MustMarshal() json.RawMessage {
-	out, err := json.Marshal(om)
+	var jsonLib = jsoniter.ConfigCompatibleWithStandardLibrary
+	out, err := jsonLib.Marshal(om)
 	if err != nil {
 		panic(err)
 	}

--- a/types/simulation/types.go
+++ b/types/simulation/types.go
@@ -87,7 +87,7 @@ func NoOpMsg(route string) OperationMsg {
 
 // log entry text for this operation msg
 func (om OperationMsg) String() string {
-	out, err := jsoniter.ConfigFastest.Marshal(om)
+	out, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(om)
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +97,7 @@ func (om OperationMsg) String() string {
 
 // MustMarshal Marshals the operation msg, panic on error
 func (om OperationMsg) MustMarshal() json.RawMessage {
-	out, err := jsoniter.ConfigFastest.Marshal(om)
+	out, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(om)
 	if err != nil {
 		panic(err)
 	}

--- a/version/command.go
+++ b/version/command.go
@@ -31,7 +31,7 @@ var Cmd = &cobra.Command{
 		var bz []byte
 		var err error
 
-		var json = jsoniter.ConfigCompatibleWithStandardLibrary
+		json := jsoniter.ConfigCompatibleWithStandardLibrary
 
 		switch viper.GetString(cli.OutputFlag) {
 		case "json":

--- a/version/command.go
+++ b/version/command.go
@@ -31,11 +31,9 @@ var Cmd = &cobra.Command{
 		var bz []byte
 		var err error
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 		switch viper.GetString(cli.OutputFlag) {
 		case "json":
-			bz, err = json.Marshal(verInfo)
+			bz, err = jsoniter.ConfigFastest.Marshal(verInfo)
 		default:
 			bz, err = yaml.Marshal(&verInfo)
 		}

--- a/version/command.go
+++ b/version/command.go
@@ -1,14 +1,13 @@
 package version
 
 import (
-	"encoding/json"
 	"fmt"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/tendermint/tendermint/libs/cli"
+	"gopkg.in/yaml.v2"
 )
 
 const flagLong = "long"
@@ -31,6 +30,8 @@ var Cmd = &cobra.Command{
 
 		var bz []byte
 		var err error
+
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		switch viper.GetString(cli.OutputFlag) {
 		case "json":

--- a/version/command.go
+++ b/version/command.go
@@ -31,7 +31,7 @@ var Cmd = &cobra.Command{
 		var bz []byte
 		var err error
 
-		json := jsoniter.ConfigCompatibleWithStandardLibrary
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 
 		switch viper.GetString(cli.OutputFlag) {
 		case "json":


### PR DESCRIPTION
This PR replaces the json standard library `encoding/json` with the faster alternative `jsoniter`

The only missing replacement is due to the dependency to the `amino.Codec` of `cosmos-sdk` and `tendermint`, which still uses the methods `cdc.MustMarshalJSON(...)` and `cdc.MustUnmarshalJSON(...)`

Benchmarks are provided within the PR. Here the results:
```
BenchmarkJsonStandardLibrary-12    	                   10129   	     111009 ns/op	   35584 B/op	     376 allocs/op
BenchmarkJsoniterLibraryWithDefaultConfig-12    	   18061	     64152 ns/op	   40466 B/op	     552 allocs/op
BenchmarkJsoniterLibraryWithFastestConfig-12    	   18472	     62357 ns/op	   39174 B/op	     392 allocs/op
```

As claimed by the [official doc](https://github.com/json-iterator/go), the ns/op are significantly reduced (in this case 63533 vs 114246)