### PR TITLE
Remove 'edit' from github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches:
       - "**"
-    types: [opened, synchronize, edited]
+    types: [opened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
This change will prevent github workflow from re-running when the description of the PR is edited.