### PR TITLE
Add 'heimdall' user during package installation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -179,6 +179,8 @@ nfpms:
     description: Polygon Blockchain
     license: GPLv3 LGPLv3
 
+    bindir: /usr/local/bin
+
     formats:
       - apk
       - deb
@@ -194,6 +196,13 @@ nfpms:
       - src: builder/files/genesis-testnet-v4.json
         dst: /etc/heimdall/genesis-testnet-v4.json
         type: config
+      - dst: /var/lib/heimdall
+        type: dir
+        file_info:
+          mode: 0777
+
+    scripts:
+      postinstall: builder/files/heimdall-post-install.sh
 
     overrides:
       rpm:
@@ -212,7 +221,6 @@ dockers:
     ids:
       - heimdalld-linux-amd64
       - heimdallcli-linux-amd64
-      - bridge-linux-amd64
     build_flag_templates:
       - --platform=linux/amd64
     extra_files:
@@ -228,7 +236,6 @@ dockers:
     ids:
       - heimdalld-linux-arm64
       - heimdallcli-linux-arm64
-      - bridge-linux-arm64
     build_flag_templates:
       - --platform=linux/arm64/v8
     extra_files:

--- a/builder/files/heimdall-post-install.sh
+++ b/builder/files/heimdall-post-install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+PKG="heimdall"
+
+if ! getent passwd $PKG >/dev/null ; then
+    adduser --disabled-password --disabled-login --shell /usr/sbin/nologin --quiet --system --no-create-home --home /nonexistent $PKG
+    echo "Created system user $PKG"
+fi
+

--- a/builder/files/heimdalld.service
+++ b/builder/files/heimdalld.service
@@ -8,10 +8,9 @@
   WorkingDirectory=/usr/local/bin
   ExecStart=/usr/local/bin/heimdalld start --home /var/lib/heimdall \
     --chain=mainnet \
-    --bridge --all \
     --rest-server
   Type=simple
-  User=ubuntu
   LimitNOFILE=65536
+  User=heimdall
 [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
This change will check and create a new 'heimdall' user when a heimdall binary is installed on a user's machine.