### PR TITLE
Log misspell

### DIFF
--- a/bor/handler.go
+++ b/bor/handler.go
@@ -51,7 +51,7 @@ func HandleMsgProposeSpan(ctx sdk.Context, msg types.MsgProposeSpan, k Keeper) s
 
 	// Validate span continuity
 	if lastSpan.ID+1 != msg.ID || msg.StartBlock != lastSpan.EndBlock+1 || msg.EndBlock < msg.StartBlock {
-		k.Logger(ctx).Error("Blocks not in countinuity",
+		k.Logger(ctx).Error("Blocks not in continuity",
 			"lastSpanId", lastSpan.ID,
 			"spanId", msg.ID,
 			"lastSpanStartBlock", lastSpan.StartBlock,
@@ -60,7 +60,7 @@ func HandleMsgProposeSpan(ctx sdk.Context, msg types.MsgProposeSpan, k Keeper) s
 			"spanEndBlock", msg.EndBlock,
 		)
 
-		return common.ErrSpanNotInCountinuity(k.Codespace()).Result()
+		return common.ErrSpanNotInContinuity(k.Codespace()).Result()
 	}
 
 	// Validate Span duration

--- a/checkpoint/handler.go
+++ b/checkpoint/handler.go
@@ -113,7 +113,7 @@ func handleMsgCheckpoint(ctx sdk.Context, msg types.MsgCheckpoint, k Keeper, con
 
 		// check if new checkpoint's start block start from current tip
 		if lastCheckpoint.EndBlock+1 != msg.StartBlock {
-			logger.Error("Checkpoint not in countinuity",
+			logger.Error("Checkpoint not in continuity",
 				"currentTip", lastCheckpoint.EndBlock,
 				"startBlock", msg.StartBlock)
 

--- a/checkpoint/handler_test.go
+++ b/checkpoint/handler_test.go
@@ -126,7 +126,7 @@ func (suite *HandlerTestSuite) TestHandleMsgCheckpoint() {
 		require.True(t, !got.IsOK(), errs.CodeToDefaultMsg(got.Code))
 	})
 
-	suite.Run("Checkpoint not in countinuity", func() {
+	suite.Run("Checkpoint not in continuity", func() {
 		headerId := uint64(10000)
 
 		err = keeper.AddCheckpoint(ctx, headerId, header)

--- a/checkpoint/side_handler.go
+++ b/checkpoint/side_handler.go
@@ -297,7 +297,7 @@ func PostHandleMsgCheckpoint(ctx sdk.Context, k Keeper, msg types.MsgCheckpoint,
 
 		// check if new checkpoint's start block start from current tip
 		if lastCheckpoint.EndBlock+1 != msg.StartBlock {
-			logger.Error("Checkpoint not in countinuity",
+			logger.Error("Checkpoint not in continuity",
 				"currentTip", lastCheckpoint.EndBlock,
 				"startBlock", msg.StartBlock)
 

--- a/common/error.go
+++ b/common/error.go
@@ -112,7 +112,7 @@ func ErrOldCheckpoint(codespace sdk.CodespaceType) sdk.Error {
 }
 
 func ErrDisCountinuousCheckpoint(codespace sdk.CodespaceType) sdk.Error {
-	return newError(codespace, CodeDisCountinuousCheckpoint, "Checkpoint not in countinuity")
+	return newError(codespace, CodeDisCountinuousCheckpoint, "Checkpoint not in continuity")
 }
 
 func ErrNoACK(codespace sdk.CodespaceType, expiresAt uint64) sdk.Error {
@@ -215,7 +215,7 @@ func ErrInvalidBorChainID(codespace sdk.CodespaceType) sdk.Error {
 	return newError(codespace, CodeInvalidBorChainID, "Invalid Bor chain id")
 }
 
-func ErrSpanNotInCountinuity(codespace sdk.CodespaceType) sdk.Error {
+func ErrSpanNotInContinuity(codespace sdk.CodespaceType) sdk.Error {
 	return newError(codespace, CodeSpanNotCountinuous, "Span not countinuous")
 }
 
@@ -287,7 +287,7 @@ func CodeToDefaultMsg(code CodeType) string {
 	case CodeOldCheckpoint:
 		return "Checkpoint already received for given start and end block"
 	case CodeDisCountinuousCheckpoint:
-		return "Checkpoint not in countinuity"
+		return "Checkpoint not in continuity"
 	case CodeNoCheckpointBuffer:
 		return "Checkpoint buffer Not Found"
 	case CodeOldValidator:
@@ -358,9 +358,9 @@ func ErrSlashInfoDetails(codespace sdk.CodespaceType) sdk.Error {
 }
 
 func ErrTickNotInContinuity(codespace sdk.CodespaceType) sdk.Error {
-	return newError(codespace, CodeTickNotInContinuity, "Tick not in countinuity")
+	return newError(codespace, CodeTickNotInContinuity, "Tick not in continuity")
 }
 
 func ErrTickAckNotInContinuity(codespace sdk.CodespaceType) sdk.Error {
-	return newError(codespace, CodeTickAckNotInContinuity, "Tick-ack not in countinuity")
+	return newError(codespace, CodeTickAckNotInContinuity, "Tick-ack not in continuity")
 }

--- a/slashing/handler.go
+++ b/slashing/handler.go
@@ -58,7 +58,7 @@ func handlerMsgTick(ctx sdk.Context, msg types.MsgTick, k Keeper, contractCaller
 	// check if tick msgs are in continuity
 	tickCount := k.GetTickCount(ctx)
 	if msg.ID != tickCount+1 {
-		k.Logger(ctx).Error("Tick not in countinuity", "msgID", msg.ID, "expectedMsgID", tickCount+1)
+		k.Logger(ctx).Error("Tick not in continuity", "msgID", msg.ID, "expectedMsgID", tickCount+1)
 		return hmCommon.ErrTickNotInContinuity(k.Codespace()).Result()
 	}
 
@@ -169,7 +169,7 @@ func handleMsgTickAck(ctx sdk.Context, msg types.MsgTickAck, k Keeper, contractC
 	// check if tick ack msgs are in continuity
 	tickCount := k.GetTickCount(ctx)
 	if msg.ID != tickCount {
-		k.Logger(ctx).Error("Tick-ack not in countinuity", "msgID", msg.ID, "expectedMsgID", tickCount)
+		k.Logger(ctx).Error("Tick-ack not in continuity", "msgID", msg.ID, "expectedMsgID", tickCount)
 		return hmCommon.ErrTickAckNotInContinuity(k.Codespace()).Result()
 	}
 

--- a/slashing/side_handler.go
+++ b/slashing/side_handler.go
@@ -159,7 +159,7 @@ func PostHandleMsgTick(ctx sdk.Context, k Keeper, msg types.MsgTick, sideTxResul
 	// check for replay - tick should be in conitunity
 	tickCount := k.GetTickCount(ctx)
 	if msg.ID != tickCount+1 {
-		k.Logger(ctx).Error("Tick not in countinuity. may be due to replay", "msgID", msg.ID, "expectedMsgID", tickCount+1)
+		k.Logger(ctx).Error("Tick not in continuity. may be due to replay", "msgID", msg.ID, "expectedMsgID", tickCount+1)
 		return hmCommon.ErrTickNotInContinuity(k.Codespace()).Result()
 	}
 
@@ -241,7 +241,7 @@ func PostHandleMsgTickAck(ctx sdk.Context, k Keeper, msg types.MsgTickAck, sideT
 	// check if tick ack msgs are in continuity.
 	tickCount := k.GetTickCount(ctx)
 	if msg.ID != tickCount {
-		k.Logger(ctx).Error("Tick-ack not in countinuity.", "msgID", msg.ID, "expectedMsgID", tickCount)
+		k.Logger(ctx).Error("Tick-ack not in continuity.", "msgID", msg.ID, "expectedMsgID", tickCount)
 		return hmCommon.ErrTickAckNotInContinuity(k.Codespace()).Result()
 	}
 


### PR DESCRIPTION
# Description

The following misspelling was found in the logs, therefore I tried to fix it.
```
Blocks not in countinuity
```
That should be:
```
Blocks not in continuity
```
However, this value has been changed in the whole source code, including minor functions and error messages.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Additional comments

It's not a serious PR, it can be ignored.