### PR TITLE
dev: chg: minor fix to slightly change PR template structure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Please provide a detailed description of what was done in this PR
 - [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
 - [ ] New feature (non-breaking change that adds functionality)
 - [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
+- [ ] Changes only for a subset of nodes
 
 # Breaking changes
 
@@ -15,8 +16,7 @@ Please complete this section if any breaking changes have been made, otherwise d
 
 # Nodes audience
 
-Do the features included by this PR must be enabled only for a subset of nodes?
-In case, please specify how you handled it (e.g. by adding a flag with a default value...)
+In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)
 
 # Checklist
 


### PR DESCRIPTION
# Description

Small correction on the order of the checks in the PR template, as suggested dy @cffls 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Nodes audience

Do the features included by this PR must be enabled only for a subset of nodes?
In case, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli