### PR TITLE
Don't overwrite heimdall-config in heimdalld init

### DIFF
--- a/cmd/heimdalld/service/init.go
+++ b/cmd/heimdalld/service/init.go
@@ -37,14 +37,6 @@ type initHeimdallConfig struct {
 }
 
 func heimdallInit(_ *server.Context, cdc *codec.Codec, initConfig *initHeimdallConfig, config *cfg.Config) error {
-	// do not execute init if forceInit is false and genesis.json already exists (or we do not have permission to write to file)
-	if !initConfig.forceInit {
-		_, err := os.Stat(config.GenesisFile())
-		if err == nil || !errors.Is(err, os.ErrNotExist) { // https://stackoverflow.com/questions/12518876/how-to-check-if-a-file-exists-in-go
-			return nil
-		}
-	}
-
 	WriteDefaultHeimdallConfig(filepath.Join(config.RootDir, "config/heimdall-config.toml"), helper.GetDefaultHeimdallConfig())
 
 	nodeID, valPubKey, _, err := InitializeNodeValidatorFiles(config)
@@ -52,10 +44,34 @@ func heimdallInit(_ *server.Context, cdc *codec.Codec, initConfig *initHeimdallC
 		return err
 	}
 
-	genesisCreated, err := helper.WriteGenesisFile(initConfig.chain, config.GenesisFile(), cdc)
-	if err != nil {
-		return err
-	} else if genesisCreated {
+	// do not execute init if forceInit is false and genesis.json already exists (or we do not have permission to write to file)
+	writeGenesis := initConfig.forceInit
+
+	if !writeGenesis {
+		// When not forcing, check if genesis file exists
+		_, err := os.Stat(config.GenesisFile())
+		if err != nil && errors.Is(err, os.ErrNotExist) {
+			logger.Info(fmt.Sprintf("Genesis file %v not found, writing genesis file\n", config.GenesisFile()))
+
+			writeGenesis = true
+		} else if err == nil {
+			logger.Info(fmt.Sprintf("Found genesis file %v, skipping writing genesis file\n", config.GenesisFile()))
+		} else {
+			logger.Error(fmt.Sprintf("Error checking if genesis file %v exists: %v\n", config.GenesisFile(), err))
+			return err
+		}
+	} else {
+		logger.Info(fmt.Sprintf("Force writing genesis file to %v\n", config.GenesisFile()))
+	}
+
+	if writeGenesis {
+		genesisCreated, err := helper.WriteGenesisFile(initConfig.chain, config.GenesisFile(), cdc)
+		if err != nil {
+			return err
+		} else if genesisCreated {
+			return nil
+		}
+	} else {
 		return nil
 	}
 
@@ -158,7 +174,7 @@ func initCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 				chain:       viper.GetString(helper.ChainFlag),
 				validatorID: viper.GetInt64(stakingcli.FlagValidatorID),
 				clientHome:  viper.GetString(helper.FlagClientHome),
-				forceInit:   true,
+				forceInit:   viper.GetBool(helper.OverwriteGenesisFlag),
 			}
 			config := ctx.Config
 			config.SetRoot(viper.GetString(cli.HomeFlag))
@@ -170,6 +186,7 @@ func initCmd(ctx *server.Context, cdc *codec.Codec) *cobra.Command {
 	cmd.Flags().String(helper.FlagClientHome, helper.DefaultCLIHome, "client's home directory")
 	cmd.Flags().String(client.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
 	cmd.Flags().Int(stakingcli.FlagValidatorID, 1, "--id=<validator ID here>, if left blank will be assigned 1")
+	cmd.Flags().Bool(helper.OverwriteGenesisFlag, false, "overwrite the genesis.json file if it exists")
 
 	return cmd
 }

--- a/cmd/heimdalld/service/service.go
+++ b/cmd/heimdalld/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -739,7 +740,14 @@ func InitializeNodeValidatorFiles(
 
 // WriteDefaultHeimdallConfig writes default heimdall config to the given path
 func WriteDefaultHeimdallConfig(path string, conf helper.Configuration) {
-	helper.WriteConfigFile(path, &conf)
+	// Don't write if config file in path already exists
+	if _, err := os.Stat(path); err == nil {
+		logger.Info(fmt.Sprintf("Config file %s already exists. Skip writing default heimdall config.", path))
+	} else if errors.Is(err, os.ErrNotExist) {
+		helper.WriteConfigFile(path, &conf)
+	} else {
+		logger.Error("Error while checking for config file", "Error", err)
+	}
 }
 
 func CryptoKeyToPubkey(key crypto.PubKey) hmTypes.PubKey {

--- a/helper/config.go
+++ b/helper/config.go
@@ -32,6 +32,7 @@ const (
 	WithHeimdallConfigFlag = "heimdall-config"
 	HomeFlag               = "home"
 	FlagClientHome         = "home-client"
+	OverwriteGenesisFlag   = "overwrite-genesis"
 	RestServerFlag         = "rest-server"
 	BridgeFlag             = "bridge"
 	LogLevel               = "log_level"


### PR DESCRIPTION
# Description

This commit changes the behavior of heimdalld init command, which will

* not overwrite heimdall-config.toml when the file already exists
* only overwrite genesis.json if flag '--overwrite-genesis' is provided

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

Do the features included by this PR must be enabled only for a subset of nodes?
In case, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
