### PR TITLE
POS-1114 and POS-1180: fix UnstakeInit bug and use constants for smart contracts' events

### DIFF
--- a/bridge/setu/listener/rootchain_events.go
+++ b/bridge/setu/listener/rootchain_events.go
@@ -19,7 +19,9 @@ import (
 const (
 	blocksRange   = 1000
 	maxIterations = 1 // 1 iteration (1000 blocks) on rootchain is roughly 3.3 hours, which is enough for backtracking
+)
 
+const (
 	// smart contracts' events names
 	stateSyncedEvent = "StateSynced"
 	stakeUpdateEvent = "StakeUpdate"

--- a/bridge/setu/listener/rootchain_events.go
+++ b/bridge/setu/listener/rootchain_events.go
@@ -19,6 +19,8 @@ import (
 const (
 	blocksRange   = 1000
 	maxIterations = 1 // 1 iteration (1000 blocks) on rootchain is roughly 3.3 hours, which is enough for backtracking
+	stateSyncedEvent = "StateSynced"
+	stakeUpdateEvent = "StakeUpdate"
 )
 
 var (
@@ -47,7 +49,7 @@ func (rl *RootChainListener) getLatestStateID(ctx context.Context) (*big.Int, er
 	}
 
 	var event statesender.StatesenderStateSynced
-	if err = helper.UnpackLog(rl.stateSenderAbi, &event, "StateSynced", latestEvent); err != nil {
+	if err = helper.UnpackLog(rl.stateSenderAbi, &event, stateSyncedEvent, latestEvent); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +104,7 @@ func (rl *RootChainListener) getStateSync(ctx context.Context, stateId int64) (*
 	}
 
 	var event statesender.StatesenderStateSynced
-	if err = helper.UnpackLog(rl.stateSenderAbi, &event, "StateSynced", &events[0]); err != nil {
+	if err = helper.UnpackLog(rl.stateSenderAbi, &event, stateSyncedEvent, &events[0]); err != nil {
 		return nil, err
 	}
 
@@ -132,7 +134,7 @@ func (rl *RootChainListener) getLatestNonce(ctx context.Context, validatorId uin
 	}
 
 	var event stakinginfo.StakinginfoStakeUpdate
-	if err = helper.UnpackLog(rl.stakingInfoAbi, &event, "StakeUpdate", latestEvent); err != nil {
+	if err = helper.UnpackLog(rl.stakingInfoAbi, &event, stakeUpdateEvent, latestEvent); err != nil {
 		return 0, err
 	}
 
@@ -166,7 +168,7 @@ func (rl *RootChainListener) getStakeUpdate(ctx context.Context, validatorId, no
 	}
 
 	var event stakinginfo.StakinginfoStakeUpdate
-	if err = helper.UnpackLog(rl.stakingInfoAbi, &event, "StakeUpdate", &events[0]); err != nil {
+	if err = helper.UnpackLog(rl.stakingInfoAbi, &event, stakeUpdateEvent, &events[0]); err != nil {
 		return nil, err
 	}
 

--- a/bridge/setu/listener/rootchain_events.go
+++ b/bridge/setu/listener/rootchain_events.go
@@ -19,6 +19,8 @@ import (
 const (
 	blocksRange   = 1000
 	maxIterations = 1 // 1 iteration (1000 blocks) on rootchain is roughly 3.3 hours, which is enough for backtracking
+
+	// smart contracts' events names
 	stateSyncedEvent = "StateSynced"
 	stakeUpdateEvent = "StakeUpdate"
 )

--- a/helper/call.go
+++ b/helper/call.go
@@ -27,6 +27,7 @@ import (
 	"github.com/maticnetwork/heimdall/types"
 )
 
+// smart contracts' events names
 const (
 	newHeaderBlockEvent = "NewHeaderBlock"
 	topUpFeeEvent = "TopUpFee"

--- a/helper/call.go
+++ b/helper/call.go
@@ -618,7 +618,7 @@ func (c *ContractCaller) DecodeValidatorExitEvent(contractAddress common.Address
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "unStakeInit", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, "UnstakeInit", vLog); err != nil {
 				return nil, err
 			}
 

--- a/helper/call.go
+++ b/helper/call.go
@@ -27,6 +27,18 @@ import (
 	"github.com/maticnetwork/heimdall/types"
 )
 
+const (
+	newHeaderBlockEvent = "NewHeaderBlock"
+	topUpFeeEvent = "TopUpFee"
+	stakedEvent = "Staked"
+	stakeUpdateEvent = "StakeUpdate"
+	UnstakeInitEvent = "UnstakeInit"
+	signerChangeEvent = "SignerChange"
+	stateSyncedEvent = "StateSynced"
+	slashedEvent = "Slashed"
+	unJailedEvent = "UnJailed"
+)
+
 // ContractsABIsMap is a cached map holding the ABIs of the contracts
 var ContractsABIsMap = make(map[string]*abi.ABI)
 
@@ -515,7 +527,7 @@ func (c *ContractCaller) DecodeNewHeaderBlockEvent(contractAddress common.Addres
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.RootChainABI, event, "NewHeaderBlock", vLog); err != nil {
+			if err := UnpackLog(&c.RootChainABI, event, newHeaderBlockEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -541,7 +553,7 @@ func (c *ContractCaller) DecodeValidatorTopupFeesEvent(contractAddress common.Ad
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "TopUpFee", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, topUpFeeEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -566,7 +578,7 @@ func (c *ContractCaller) DecodeValidatorJoinEvent(contractAddress common.Address
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "Staked", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, stakedEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -592,7 +604,7 @@ func (c *ContractCaller) DecodeValidatorStakeUpdateEvent(contractAddress common.
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "StakeUpdate", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, stakeUpdateEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -618,7 +630,7 @@ func (c *ContractCaller) DecodeValidatorExitEvent(contractAddress common.Address
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "UnstakeInit", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, UnstakeInitEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -644,7 +656,7 @@ func (c *ContractCaller) DecodeSignerUpdateEvent(contractAddress common.Address,
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "SignerChange", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, signerChangeEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -670,7 +682,7 @@ func (c *ContractCaller) DecodeStateSyncedEvent(contractAddress common.Address, 
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StateSenderABI, event, "StateSynced", vLog); err != nil {
+			if err := UnpackLog(&c.StateSenderABI, event, stateSyncedEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -698,7 +710,7 @@ func (c *ContractCaller) DecodeSlashedEvent(contractAddress common.Address, rece
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "Slashed", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, slashedEvent, vLog); err != nil {
 				return nil, err
 			}
 
@@ -724,7 +736,7 @@ func (c *ContractCaller) DecodeUnJailedEvent(contractAddress common.Address, rec
 		if uint64(vLog.Index) == logIndex && bytes.Equal(vLog.Address.Bytes(), contractAddress.Bytes()) {
 			found = true
 
-			if err := UnpackLog(&c.StakingInfoABI, event, "UnJailed", vLog); err != nil {
+			if err := UnpackLog(&c.StakingInfoABI, event, unJailedEvent, vLog); err != nil {
 				return nil, err
 			}
 

--- a/helper/call.go
+++ b/helper/call.go
@@ -30,14 +30,14 @@ import (
 // smart contracts' events names
 const (
 	newHeaderBlockEvent = "NewHeaderBlock"
-	topUpFeeEvent = "TopUpFee"
-	stakedEvent = "Staked"
-	stakeUpdateEvent = "StakeUpdate"
-	UnstakeInitEvent = "UnstakeInit"
-	signerChangeEvent = "SignerChange"
-	stateSyncedEvent = "StateSynced"
-	slashedEvent = "Slashed"
-	unJailedEvent = "UnJailed"
+	topUpFeeEvent       = "TopUpFee"
+	stakedEvent         = "Staked"
+	stakeUpdateEvent    = "StakeUpdate"
+	UnstakeInitEvent    = "UnstakeInit"
+	signerChangeEvent   = "SignerChange"
+	stateSyncedEvent    = "StateSynced"
+	slashedEvent        = "Slashed"
+	unJailedEvent       = "UnJailed"
 )
 
 // ContractsABIsMap is a cached map holding the ABIs of the contracts


### PR DESCRIPTION
# Description

This PR fixes the bug related to `UnstakeInit` and introduces constants to use when unpacking logs originated from smart contracts events instead of plain strings.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [x] I have created new e2e tests into express-cli