### PR TITLE
mardizzone/hotfix-snyk: remove vcs build when running snyk

### DIFF
--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -13,6 +13,7 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          GOFLAGS: "-buildvcs=false"
         with:
           args: --org=${{ secrets.SNYK_ORG }} --severity-threshold=medium --sarif-file-output=snyk.sarif
       - name: Upload result to GitHub Code Scanning
@@ -31,7 +32,6 @@ jobs:
         uses: snyk/actions/golang@master
         continue-on-error: true
         env:
-          GOFLAGS: "-buildvcs=false"
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -32,7 +32,7 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          GOFLAGS: '-buildvcs=false'
+          GOFLAGS: -buildvcs=false
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -31,8 +31,8 @@ jobs:
         uses: snyk/actions/golang@master
         continue-on-error: true
         env:
+          GOFLAGS: "-buildvcs=false"
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          GOFLAGS: -buildvcs=false
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -32,7 +32,7 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          GOFLAGS: “-buildvcs=false”
+          GOFLAGS: "-buildvcs=false"
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -32,6 +32,7 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          GOFLAGS: “-buildvcs=false”
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test

--- a/.github/workflows/security-ci.yml
+++ b/.github/workflows/security-ci.yml
@@ -32,7 +32,7 @@ jobs:
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          GOFLAGS: "-buildvcs=false"
+          GOFLAGS: '-buildvcs=false'
         with:
           args: --org=${{ secrets.SNYK_ORG }} --sarif-file-output=snyk.sarif
           command: code test


### PR DESCRIPTION
# Description

Starting with `v1.18`, Go introduced version control (VCS). See [v1.18 release notes](https://tip.golang.org/doc/go1.18)
If the VCS status can't be determined for a dependency, `go list` (which Snyk tests rely upon) will fail. 

Since the pipeline is using `snyk/actions/golang@master`, it is using `docker://snyk/snyk:golang` which currently uses GOLANG_VERSION=1.20

Waiting for `snyk` team to provide a fix, they suggest to add the following to the pipeline
```
env:
    GOFLAGS: “-buildvcs=false”
```

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Tested on Security CI pipeline