### PR TITLE
Added logs_writer flag

### DIFF
--- a/bridge/setu/util/common.go
+++ b/bridge/setu/util/common.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -86,7 +85,8 @@ var loggerOnce sync.Once
 func Logger() log.Logger {
 	loggerOnce.Do(func() {
 		defaultLevel := "info"
-		logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+		logsWriter := helper.GetLogsWriter(helper.GetConfig().LogsWriterFile)
+		logger = log.NewTMLogger(log.NewSyncWriter(logsWriter))
 		option, err := log.AllowLevel(viper.GetString("log_level"))
 		if err != nil {
 			// cosmos sdk is using different style of log format

--- a/server/root.go
+++ b/server/root.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"runtime/debug"
 	"time"
 
@@ -40,7 +39,8 @@ func StartRestServer(mainCtx ctx.Context, cdc *codec.Codec, registerRoutesFn fun
 	// init vars for the Light Client Rest server
 	cliCtx := context.NewCLIContext().WithCodec(cdc)
 	router := mux.NewRouter()
-	logger := tmLog.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "rest-server")
+	logsWriter := helper.GetLogsWriter(helper.GetConfig().LogsWriterFile)
+	logger := tmLog.NewTMLogger(log.NewSyncWriter(logsWriter)).With("module", "rest-server")
 
 	registerRoutesFn(cliCtx, router)
 
@@ -77,7 +77,7 @@ func StartRestServer(mainCtx ctx.Context, cdc *codec.Codec, registerRoutesFn fun
 	})
 
 	// Setup gRPC server
-	gRPCLogger := tmLog.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "gRPC-server")
+	gRPCLogger := tmLog.NewTMLogger(log.NewSyncWriter(logsWriter)).With("module", "gRPC-server")
 	if err := gRPC.SetupGRPCServer(mainCtx, cdc, viper.GetString(FlagGrpcAddr), gRPCLogger); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Added a new flag to print logs in a file if required, This will be useful when running bor-heimdall together as a single process after this [PR](https://github.com/maticnetwork/bor/pull/646) is merged. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
