### PR TITLE
clerk/client/rest :: add : blocktime check in recordListHandlerFn

### DIFF
--- a/clerk/client/rest/query.go
+++ b/clerk/client/rest/query.go
@@ -215,6 +215,21 @@ func recordListHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 				return
 			}
 
+			node, err := cliCtx.GetNode()
+			if err != nil {
+				return
+			}
+
+			status, err := node.Status()
+			if err != nil {
+				return
+			}
+
+			time := status.SyncInfo.LatestBlockTime
+			if toTime > time.Unix() {
+				return
+			}
+
 			logger.Info("Serving event record list", "from-id", fromID, "to-time", toTime)
 
 			// get result by till time-range query


### PR DESCRIPTION
# Description

Handle `heimdalld not in sync` when bor is querying latest state-syncs for syncing blocks. In request we send 'to-time' timestamp. We return `nothing` if `to-time` > `heimdall_latest_block_timestamp`

