### PR TITLE
Fix HaltHeight and HaltTime config/CLI options so that they work

### DIFF
--- a/cmd/heimdalld/service/service.go
+++ b/cmd/heimdalld/service/service.go
@@ -216,7 +216,10 @@ func getNewApp(serverCtx *server.Context) func(logger log.Logger, db dbm.DB, sto
 		helper.InitHeimdallConfig("")
 		helper.UpdateTendermintConfig(serverCtx.Config, viper.GetViper())
 		// create new heimdall app
-		hApp = app.NewHeimdallApp(logger, db, baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString("pruning"))))
+		hApp = app.NewHeimdallApp(logger, db,
+			baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString(flagPruning))),
+			baseapp.SetHaltHeight(viper.GetUint64(FlagHaltHeight)),
+			baseapp.SetHaltTime(viper.GetUint64(FlagHaltTime)))
 
 		return hApp
 	}


### PR DESCRIPTION
The halt-height and halt-time options are useful to sync the heimdall daemon to a predetermined block height or block time and then exit, allowing state at a given point in time to be reproduced for research and debugging purposes.

The Cosmos SDK which is part of heimdall defines these configuration options and implements them in the BaseApp.

However heimdall does not pass the relevant configuration to NewBaseApp() resulting in these options being ignored; this pull request addresses this.

There is additionally one clean up replacing the use of the literal string "pruning" for retrieving a configuration option the constant flagPruning which is already defined in the source code file and is used elsewhere.

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes