### PR TITLE
Fix signature verification of 23 historical mainnet transactions to allow heimdall to sync from genesis

### DIFF
--- a/auth/ante.go
+++ b/auth/ante.go
@@ -143,8 +143,6 @@ func NewAnteHandler(
 			return newCtx, sdk.ErrUnauthorized("wrong number of signers").Result(), true
 		}
 
-		isGenesis := ctx.BlockHeight() == 0
-
 		// fetch first signer, who's going to pay the fees
 		signerAcc, res := GetSignerAcc(newCtx, ak, types.AccAddressToHeimdallAddress(signerAddrs[0]))
 		if !res.IsOK() {
@@ -167,14 +165,15 @@ func NewAnteHandler(
 		stdSigs := stdTx.GetSignatures()
 
 		// check signature, return account with incremented nonce
-		signBytes := GetSignBytes(newCtx.ChainID(), stdTx, signerAcc, isGenesis)
+		signBytes := getSignBytes(newCtx, stdTx, signerAcc)
 
-		signerAcc, res = processSig(newCtx, signerAcc, stdSigs[0], signBytes, simulate, params, sigGasConsumer)
+		updatedAcc, res := processSig(newCtx, signerAcc, stdSigs[0], signBytes, simulate, params, sigGasConsumer)
 		if !res.IsOK() {
+			ak.Logger(ctx).Info("processSig: bad signature", "signerAcc", signerAcc, "sig", stdSigs[0], "signBytes", signBytes, "params", params, "res", res)
 			return newCtx, res, true
 		}
 
-		ak.SetAccount(newCtx, signerAcc)
+		ak.SetAccount(newCtx, updatedAcc)
 
 		// TODO: tx tags (?)
 		return newCtx, sdk.Result{GasWanted: gasForTx}, false // continue...
@@ -311,13 +310,60 @@ func SetGasMeter(simulate bool, ctx sdk.Context, gasLimit uint64) sdk.Context {
 	return ctx.WithGasMeter(sdk.NewGasMeter(gasLimit))
 }
 
-// GetSignBytes returns a slice of bytes to sign over for a given transaction
+// getSignBytes returns a slice of bytes to sign over for a given transaction
 // and an account.
-func GetSignBytes(chainID string, stdTx authTypes.StdTx, acc authTypes.Account, genesis bool) []byte {
-	var accNum uint64
-	if !genesis {
+func getSignBytes(ctx sdk.Context, stdTx authTypes.StdTx, acc authTypes.Account) []byte {
+	blockHeight := ctx.BlockHeight()
+	chainID := ctx.ChainID()
+	sequence := acc.GetSequence()
+
+	var accNum uint64 = 0
+	if blockHeight != 0 {
 		accNum = acc.GetAccountNumber()
 	}
 
-	return authTypes.StdSignBytes(chainID, accNum, acc.GetSequence(), stdTx.Msg, stdTx.Memo)
+	signBytes := authTypes.StdSignBytes(chainID, accNum, sequence, stdTx.Msg, stdTx.Memo)
+
+	// The following twenty three transactions on mainnet were signed with a non-standard
+	// serialisation format which the code fixes up so that the signatures verify
+	// correctly.
+	// Specifically the messages are serialialised to a sorted compact json format which
+	// is then keccak hashed and signed. All of the 23 messages had an empty "data" field
+	// which is normally serialised as "data":"0x" however for these 23 messages the "data"
+	// field was serialised as "data":"0x0" when they were signed.
+	if blockHeight <= 9266259 &&
+		(blockHeight >= 9265930 ||
+		(blockHeight <= 8588888 && blockHeight >= 8587012)) &&
+		chainID == "heimdall-137" {
+		switch {
+		case blockHeight == 8587012 && accNum == 161 && sequence == 10553,
+			blockHeight == 8587037 && accNum == 161 && sequence == 10554,
+			blockHeight == 8587048 && accNum == 161 && sequence == 10555,
+			blockHeight == 8587061 && accNum == 161 && sequence == 10556,
+			blockHeight == 8587111 && accNum == 161 && sequence == 10557,
+			blockHeight == 8587179 && accNum == 161 && sequence == 10560,
+			blockHeight == 8587192 && accNum == 161 && sequence == 10561,
+			blockHeight == 8587241 && accNum == 161 && sequence == 10562,
+			blockHeight == 8587394 && accNum == 161 && sequence == 10563,
+			blockHeight == 8587396 && accNum == 161 && sequence == 10564,
+			blockHeight == 8587452 && accNum == 161 && sequence == 10565,
+			blockHeight == 8587476 && accNum == 161 && sequence == 10566,
+			blockHeight == 8587483 && accNum == 161 && sequence == 10567,
+			blockHeight == 8587497 && accNum == 161 && sequence == 10568,
+			blockHeight == 8588129 && accNum == 2 && sequence == 22281,
+			blockHeight == 8588137 && accNum == 2 && sequence == 22282,
+			blockHeight == 8588746 && accNum == 2 && sequence == 22283,
+			blockHeight == 8588888 && accNum == 2 && sequence == 22284,
+			blockHeight == 9265930 && accNum == 1 && sequence == 1339911,
+			blockHeight == 9265947 && accNum == 1 && sequence == 1339922,
+			blockHeight == 9265999 && accNum == 11 && sequence == 5565,
+			blockHeight == 9266007 && accNum == 1 && sequence == 1339955,
+			blockHeight == 9266259 && accNum == 1 && sequence == 1340079:
+			const old = ",\"data\":\"0x\","
+			const new = ",\"data\":\"0x0\","
+			signBytes = bytes.Replace(signBytes, []byte(old), []byte(new), 1)
+		}
+	}
+
+	return signBytes
 }


### PR DESCRIPTION
# Description

Syncing a new mainnet heimdall node from genesis currently halts with a appHash mismatch after processing block 8587012 which consequently means it is impossible to independently verify heimdall mainnet from genesis or recover without a trusted snapshot.

The cause of the appHash mismatch on block 8587013 is due to a transaction in block 8587012 considered invalid by the current heimdall code base as its transaction signature fails verification. Consequently its state changes are not applied, the appHash is not updated and an appHash mismatch is detected on the next committed block, as application state on the mainnet chain was in fact changed by block 8587012.

Further investigation revealed the reason for the failed signature verification. Heimdall serialises the transaction message into a specific representation which is then keccak hashed and signed; the specific representation is a compact JSON representation with sorted keys and no white space. By changing the serialisation of one field - replacing `"data":"0x"` with `"data":"0x0"` - in the specific representation, the resulting keccak hash passed signature verification.

Twenty two additional transactions in blocks up to 9266259 with invalid signatures were identified which subsequently validated correctly after applying the transformation above. After fixing up the 23 transactions as described above, heimdall was able to sync successfully by replaying all blocks from genesis.

I do not know the reason why or how these 23 irregular transaction signatures came to be verified and included in the mainnet chain last year. This pull request applies the specific limited transformation above to the signing representation generated during signature verification of the 23 blocks indicated above, identifying them by block height, account number, sequence and chain id, allowing heimdall to successfully replay all blocks from genesis to the current head.

## Detail

Without the changes in this pull request, attempting to sync heimdall from mainnet genesis results in a panic due to an appHash mismatch in block 8587013 as can be seen in the debug level heimdall log output below. Note that there is one invalid transaction in block 8587012 due to a signature verification failure, and that the appHash committed at the end of processing of block 8587011 is unchanged at the end of block 8587012 hence the mismatch when applying block 8587013 which had a different appHash after block 8587012 than that computed locally.
```
DEBUG[2023-06-03|16:12:58.971] [Peppermint] Applying block                  module=state height=8587011 numTxs=0
DEBUG[2023-06-03|16:12:58.977] slashing is not enabled. To enable, send a proposal via governance module=x/slashing
DEBUG[2023-06-03|16:12:58.977] [sidechannel] Processing side block          module=main height=8587011 targetHeight=8587009
INFO [2023-06-03|16:12:58.977] Executed block                               module=state height=8587011 validTxs=0 invalidTxs=0
DEBUG[2023-06-03|16:12:58.988] Commit synced                                module=main commit=436F6D6D697449447B5B3138312033362031363820343120313931203230332031333820313837203132302032303820313930203138332031353020323233203934203131392031322037362033352032323120313832203530203234362031383220323033203936203732203134372031313120313435203937203230325D3A3833303730337D
INFO [2023-06-03|16:12:58.988] Committed state                              module=state height=8587011 txs=0 appHash=B524A829BFCB8ABB78D0BEB796DF5E770C4C23DDB632F6B6CB6048936F9161CA
INFO [2023-06-03|16:12:58.988] Indexed block                                module=txindex height=8587011
DEBUG[2023-06-03|16:12:58.995] [Peppermint] Applying block                  module=state height=8587012 numTxs=1
DEBUG[2023-06-03|16:12:58.996] TrySend                                      module=p2p peer=c124ce0b508e8b9ed1c5b6957f362225659b5343@134.65.193.157:26656 channel=64 conn=MConn{134.65.193.157:26656} msgBytes=BB1DC4F208DC928C04
DEBUG[2023-06-03|16:12:59.001] slashing is not enabled. To enable, send a proposal via governance module=x/slashing
DEBUG[2023-06-03|16:12:59.001] [sidechannel] Processing side block          module=main height=8587012 targetHeight=8587010
DEBUG[2023-06-03|16:12:59.001] Invalid tx                                   module=state code=4 log="{\"codespace\":\"sdk\",\"code\":4,\"message\":\"signature verification failed; verify correct account sequence and chain-id\"}"
INFO [2023-06-03|16:12:59.002] Executed block                               module=state height=8587012 validTxs=0 invalidTxs=1
DEBUG[2023-06-03|16:12:59.015] Commit synced                                module=main commit=436F6D6D697449447B5B3138312033362031363820343120313931203230332031333820313837203132302032303820313930203138332031353020323233203934203131392031322037362033352032323120313832203530203234362031383220323033203936203732203134372031313120313435203937203230325D3A3833303730347D
INFO [2023-06-03|16:12:59.015] Committed state                              module=state height=8587012 txs=1 appHash=B524A829BFCB8ABB78D0BEB796DF5E770C4C23DDB632F6B6CB6048936F9161CA
INFO [2023-06-03|16:12:59.016] Indexed block                                module=txindex height=8587012
DEBUG[2023-06-03|16:12:59.023] [Peppermint] Applying block                  module=state height=8587013 numTxs=6
panic: Failed to process committed block (8587013:3D5D7EEECE3143EFAA92A59B295738FF69D0FA41433FA6892F23F0B2CB96C7FB): Wrong Block.Header.AppHash.  Expected B524A829BFCB8ABB78D0BEB796DF5E770C4C23DDB632F6B6CB6048936F9161CA, got F614FBD4E1F3AB75D6E288ABC664F4D692AFC591E644829CB0C1AE9DC081E0B8
```

The encapsulated MsgEventRecord in the failed transaction above recovered from block 8587012:
```
{"account_number": "161",
 "chain_id":       "heimdall-137",
 "memo":           "",
 "msg":           {"type":   "cosmos-sdk/MsgEventRecord",
                   "value": {"block_number":     "14356900",
                             "bor_chain_id":     "137",
                             "contract_address": "0x8397259c983751daf40400790063935a11afa28a",
                             "data":             "0x",
                             "from":             "0xe7e2cb8c81c10ff191a73fe266788c9ce62ec754",
                             "id":               "1807391",
                             "log_index":        "481",
                             "tx_hash":          "0x3f86824cb9250fe0b104702e5c3c73dc7c5f47ee973ba5dacdd113ca762d7d37"}},
 "sequence":       "10553"}
```
The transaction signature:
```
0xf777c5b4c82dd73f1591da99c2aa0cc579f16bf3cebb7efd1c734eaf776291092bc34cbdb1d18adfeaf1d87c531e22c96694a4a204bbaa16a99668de631b609d00
```

The original signed representation of the transaction, its keccak hash and the address recovered from the hash and signature, respectively:
- `{"account_number":"161","chain_id":"heimdall-137","memo":"","msg":{"type":"cosmos-sdk/MsgEventRecord","value":{"block_number":"14356900","bor_chain_id":"137","contract_address":"0x8397259c983751daf40400790063935a11afa28a","data":"0x","from":"0xe7e2cb8c81c10ff191a73fe266788c9ce62ec754","id":"1807391","log_index":"481","tx_hash":"0x3f86824cb9250fe0b104702e5c3c73dc7c5f47ee973ba5dacdd113ca762d7d37"}},"sequence":"10553"}`
- `0x0faee9f917d262343821fa4c73b7892473e123977dac6526f413f64b0fa2bc7c`
- `0xe685c98fdf2208380213532292356e1acdf78aa5`

The signed representation of the transaction with the data field modified as described above, its keccak hash and the address recovered from the hash and signature, respectively:
- `{"account_number":"161","chain_id":"heimdall-137","memo":"","msg":{"type":"cosmos-sdk/MsgEventRecord","value":{"block_number":"14356900","bor_chain_id":"137","contract_address":"0x8397259c983751daf40400790063935a11afa28a","data":"0x0","from":"0xe7e2cb8c81c10ff191a73fe266788c9ce62ec754","id":"1807391","log_index":"481","tx_hash":"0x3f86824cb9250fe0b104702e5c3c73dc7c5f47ee973ba5dacdd113ca762d7d37"}},"sequence":"10553"}`
- `0x43febc7e9d6eee17af477769eefdc0ba6c636f7de0c31d974a4d0a627d4f45d6`
- `0xe7e2cb8c81c10ff191a73fe266788c9ce62ec754`

Note the recovered address from the modified signed representation now matches the sender of the transaction (i.e. the address in "from" field).

For reference, the source of the "value" fields came from the StateSynced event with index 481 (the last one as it happens) in the following Ethereum transaction:
https://etherscan.io/tx/0x3f86824cb9250fe0b104702e5c3c73dc7c5f47ee973ba5dacdd113ca762d7d37#eventlog

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Sync heimdall mainnet genesis successfully with no appHash mismatches.