### PR TITLE
Fix:SignBytes representation of empty string data field in the event-…

### DIFF
--- a/auth/ante.go
+++ b/auth/ante.go
@@ -167,7 +167,7 @@ func NewAnteHandler(
 		stdSigs := stdTx.GetSignatures()
 
 		// check signature, return account with incremented nonce
-		signBytes := GetSignBytes(newCtx.ChainID(), stdTx, signerAcc, isGenesis)
+		signBytes := GetSignBytes(ctx, newCtx.ChainID(), stdTx, signerAcc, isGenesis)
 
 		signerAcc, res = processSig(newCtx, signerAcc, stdSigs[0], signBytes, simulate, params, sigGasConsumer)
 		if !res.IsOK() {
@@ -313,11 +313,24 @@ func SetGasMeter(simulate bool, ctx sdk.Context, gasLimit uint64) sdk.Context {
 
 // GetSignBytes returns a slice of bytes to sign over for a given transaction
 // and an account.
-func GetSignBytes(chainID string, stdTx authTypes.StdTx, acc authTypes.Account, genesis bool) []byte {
+func GetSignBytes(ctx sdk.Context, chainID string, stdTx authTypes.StdTx, acc authTypes.Account, genesis bool) []byte {
 	var accNum uint64
 	if !genesis {
 		accNum = acc.GetAccountNumber()
 	}
 
-	return authTypes.StdSignBytes(chainID, accNum, acc.GetSequence(), stdTx.Msg, stdTx.Memo)
+	signBytes := authTypes.StdSignBytes(chainID, accNum, acc.GetSequence(), stdTx.Msg, stdTx.Memo)
+
+	if ctx.BlockHeight() > helper.GetNewHexToStringAlgoHeight() {
+		return signBytes
+	}
+
+	const new = ",\"data\":\"0x\","
+	const old = ",\"data\":\"0x0\","
+
+	if bytes.Contains(signBytes, []byte(new)) {
+		signBytes = bytes.Replace(signBytes, []byte(new), []byte(old), 1)
+	}
+
+	return signBytes
 }

--- a/auth/ante.go
+++ b/auth/ante.go
@@ -325,11 +325,12 @@ func GetSignBytes(ctx sdk.Context, chainID string, stdTx authTypes.StdTx, acc au
 		return signBytes
 	}
 
-	const new = ",\"data\":\"0x\","
-	const old = ",\"data\":\"0x0\","
+	const newData = ",\"data\":\"0x\","
 
-	if bytes.Contains(signBytes, []byte(new)) {
-		signBytes = bytes.Replace(signBytes, []byte(new), []byte(old), 1)
+	const oldData = ",\"data\":\"0x0\","
+
+	if bytes.Contains(signBytes, []byte(newData)) {
+		signBytes = bytes.Replace(signBytes, []byte(newData), []byte(oldData), 1)
 	}
 
 	return signBytes

--- a/cmd/heimdalld/service/service.go
+++ b/cmd/heimdalld/service/service.go
@@ -216,7 +216,10 @@ func getNewApp(serverCtx *server.Context) func(logger log.Logger, db dbm.DB, sto
 		helper.InitHeimdallConfig("")
 		helper.UpdateTendermintConfig(serverCtx.Config, viper.GetViper())
 		// create new heimdall app
-		hApp = app.NewHeimdallApp(logger, db, baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString("pruning"))))
+		hApp = app.NewHeimdallApp(logger, db,
+			baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString(flagPruning))),
+			baseapp.SetHaltHeight(viper.GetUint64(FlagHaltHeight)),
+			baseapp.SetHaltTime(viper.GetUint64(FlagHaltTime)))
 
 		return hApp
 	}

--- a/helper/config.go
+++ b/helper/config.go
@@ -208,6 +208,8 @@ var newSelectionAlgoHeight int64 = 0
 
 var spanOverrideHeight int64 = 0
 
+var newHexToStringAlgoHeight int64 = 0
+
 type ChainManagerAddressMigration struct {
 	MaticTokenAddress     hmTypes.HeimdallAddress
 	RootChainAddress      hmTypes.HeimdallAddress
@@ -371,12 +373,17 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFLag string) {
 	case MainChain:
 		newSelectionAlgoHeight = 375300
 		spanOverrideHeight = 8664000
+		newHexToStringAlgoHeight = 9266260
+
 	case MumbaiChain:
 		newSelectionAlgoHeight = 282500
 		spanOverrideHeight = 10205000
+		newHexToStringAlgoHeight = 0
 	default:
 		newSelectionAlgoHeight = 0
 		spanOverrideHeight = 0
+		newHexToStringAlgoHeight = 0
+
 	}
 }
 
@@ -493,6 +500,11 @@ func GetNewSelectionAlgoHeight() int64 {
 // GetSpanOverrideHeight returns spanOverrideHeight
 func GetSpanOverrideHeight() int64 {
 	return spanOverrideHeight
+}
+
+// GetNewHexToStringAlgoHeight returns newHexToStringAlgoHeight
+func GetNewHexToStringAlgoHeight() int64 {
+	return newHexToStringAlgoHeight
 }
 
 func GetChainManagerAddressMigration(blockNum int64) (ChainManagerAddressMigration, bool) {

--- a/helper/config.go
+++ b/helper/config.go
@@ -383,7 +383,6 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFLag string) {
 		newSelectionAlgoHeight = 0
 		spanOverrideHeight = 0
 		newHexToStringAlgoHeight = 0
-
 	}
 }
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -378,7 +378,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFLag string) {
 	case MumbaiChain:
 		newSelectionAlgoHeight = 282500
 		spanOverrideHeight = 10205000
-		newHexToStringAlgoHeight = 0
+		newHexToStringAlgoHeight = 10630672
 	default:
 		newSelectionAlgoHeight = 0
 		spanOverrideHeight = 0


### PR DESCRIPTION
# Description
In v0.2.11 -> v0.2.12 transition, algorithm for the string conversion of HexBytes for the data field of event-record was changed. It impacted the conversion in the case when the HexBytes represented the empty string.Due to this it was causing the sync issue. This PR includes changes which rectified that issue "
I would like to thank @svenski123 for reporting this issue and also putting his effort to research out the best solution for this.
#1004 




# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [.] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

This PR change should be applied to all the nodes who are syncing from the scatch
# Checklist

- [.] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [.] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply


