### PR TITLE
feature: upgrade remote node client versions via ci

### DIFF
--- a/.github/workflows/prerelease-test-fleet.yml
+++ b/.github/workflows/prerelease-test-fleet.yml
@@ -1,0 +1,30 @@
+name: prerelease-test-fleet
+
+on:
+  push:
+  # release:
+  #   types: [published]
+
+jobs:
+  prerelease-test-fleet:
+    # if: "github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Prepare
+        id: prepare
+        run: |
+            curl --location --request POST '${{ secrets.AWX_DOMAIN }}' \
+            --header 'Authorization: Basic ${{ secrets.AWX_KEY }}' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+                "extra_vars": {
+                    "HEIMDALL_VERSION": "v0.3.4-beta",
+                    "UPGRADE_HEIMDALL": true,
+                    "CLIENT_UPGRADE_MODE": true
+                }
+            }'

--- a/.github/workflows/prerelease-test-fleet.yml
+++ b/.github/workflows/prerelease-test-fleet.yml
@@ -9,22 +9,62 @@ jobs:
   prerelease-test-fleet:
     # if: "github.event.release.prerelease" 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        monitor_name:
+          - REORG_ALERT
+          - TX_POOL_ALERT
+          
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"      
+      
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Prepare
-        id: prepare
+      # - name: Prepare
+      #   id: prepare
+      #   run: |
+      #       curl --location --request POST '${{ secrets.AWX_DOMAIN }}' \
+      #       --header 'Authorization: Basic ${{ secrets.AWX_KEY }}' \
+      #       --header 'Content-Type: application/json' \
+      #       --data-raw '{
+      #           "extra_vars": {
+      #               "HEIMDALL_VERSION": "v0.3.4-beta",
+      #               "UPGRADE_HEIMDALL": true,
+      #               "CLIENT_UPGRADE_MODE": true
+      #           }
+      #       }'
+      
+      - name: Install dependencies
         run: |
-            curl --location --request POST '${{ secrets.AWX_DOMAIN }}' \
-            --header 'Authorization: Basic ${{ secrets.AWX_KEY }}' \
-            --header 'Content-Type: application/json' \
-            --data-raw '{
-                "extra_vars": {
-                    "HEIMDALL_VERSION": "v0.3.4-beta",
-                    "UPGRADE_HEIMDALL": true,
-                    "CLIENT_UPGRADE_MODE": true
-                }
-            }'
+          python -m pip install --upgrade pip
+          pip install requests
+          
+      - name: Run monitor check script for X minutes
+        env:
+          API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
+        run: |
+          duration_minutes=10  # Set the number of minutes for the loop
+          duration_seconds=$((duration_minutes * 60))
+          start_time=$(date +%s)
+
+          while true; do
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            if [ $elapsed_time -gt $duration_seconds ]; then
+              break  # Exit the loop after the specified duration
+            fi
+
+            # Execute the script with the current monitor ID
+            python get_monitor_status.py ${{ matrix.monitor_name }}
+
+            # Sleep for 1 minute before the next iteration
+            sleep 60
+          done

--- a/.github/workflows/prerelease-test-fleet.yml
+++ b/.github/workflows/prerelease-test-fleet.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   prerelease-test-fleet:
-    # if: "github.event.release.prerelease"
+    # if: "github.event.release.prerelease" 
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/prerelease-test-fleet.yml
+++ b/.github/workflows/prerelease-test-fleet.yml
@@ -50,7 +50,7 @@ jobs:
           API_KEY: ${{ secrets.DATADOG_API_KEY }}
           APP_KEY: ${{ secrets.DATADOG_APP_KEY }}
         run: |
-          duration_minutes=10  # Set the number of minutes for the loop
+          duration_minutes=10  # Set the number of minutes for loop
           duration_seconds=$((duration_minutes * 60))
           start_time=$(date +%s)
 

--- a/get_monitor_status.py
+++ b/get_monitor_status.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import requests
+import time
+
+def get_monitor_id_by_name(api_key, app_key, monitor_name):
+    base_url = "https://api.datadoghq.com/api/v1/monitor"
+    headers = {
+        "Content-Type": "application/json",
+        "DD-API-KEY": api_key,
+        "DD-APPLICATION-KEY": app_key,
+    }
+    params = {
+        "query": f"name:{monitor_name}",
+    }
+
+    try:
+        response = requests.get(base_url, headers=headers, params=params)
+
+        if response.status_code == 200:
+            monitors_data = response.json()
+            for monitor in monitors_data:
+                if monitor["name"] == monitor_name:
+                    return monitor["id"]
+
+            # If the monitor with the given name was not found
+            print(f"Monitor with name '{monitor_name}' not found.")
+            return None
+
+        else:
+            print(f"Failed to fetch monitors. Status code: {response.status_code}")
+            return None
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error: {e}")
+        return None
+
+def get_monitor_status(api_key, app_key, monitor_id):
+    base_url = f"https://api.datadoghq.com/api/v1/monitor/{monitor_id}"
+    headers = {
+        "Content-Type": "application/json",
+        "DD-API-KEY": api_key,
+        "DD-APPLICATION-KEY": app_key,
+    }
+
+    try:
+        response = requests.get(base_url, headers=headers)
+
+        if response.status_code == 200:
+            monitor_data = response.json()
+            return monitor_data["overall_state"]
+        else:
+            print(f"Failed to get monitor status. Status code: {response.status_code}")
+            return None
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error: {e}")
+        return None
+
+if __name__ == "__main__":
+    monitor_name = sys.argv[1]
+    api_key = os.environ["API_KEY"]
+    app_key = os.environ["APP_KEY"]
+
+    # Get the monitor ID by name
+    monitor_id = get_monitor_id_by_name(api_key, app_key, monitor_name)
+
+    if monitor_id is not None:
+        status = get_monitor_status(api_key, app_key, monitor_id)
+        print(f"Monitor ID {monitor_name} - Status: {status}")


### PR DESCRIPTION
# Description

still POC: ensure we can use github actions CI flow to trigger AWX API call that ultimately updates a fleet of remote PoSV1 instances, this is on the back of RFC here: https://www.notion.so/polygontechnology/RFC-PoSV1-Test-Fleet-0f0821f9c97a48b9adf273e2e7a48a66?pvs=4

# Changes

- Add Github Actions workflow to call AWX API and update remote nodes heimdall version
- as part of the same workflow, periodically check (on loop) the health status of all relevant datadog monitors, indicating whether the proposed client changes have disrupted the network or all changes are stable (bake time)