### PR TITLE
helper: change newHexToStringAlgoHeight height for mumbai

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -378,7 +378,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFLag string) {
 	case MumbaiChain:
 		newSelectionAlgoHeight = 282500
 		spanOverrideHeight = 10205000
-		newHexToStringAlgoHeight = 10630672
+		newHexToStringAlgoHeight = 12048023
 	default:
 		newSelectionAlgoHeight = 0
 		spanOverrideHeight = 0


### PR DESCRIPTION
# Description

This PR fixes`newHexToStringAlgoHeight` block height for Mumbai.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

