### PR TITLE
ValidateTxResult: accept single transaction blocks as currently produced by heimdall as valid

### DIFF
--- a/helper/query.go
+++ b/helper/query.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -112,6 +113,16 @@ func ValidateTxResult(cliCtx cosmosContext.CLIContext, resTx *ctypes.ResultTx) e
 		}
 
 		err = resTx.Proof.Validate(check.Header.DataHash)
+
+		// Accept if only one tx in block and data hash matches tx hash
+		if err != nil &&
+			check.Header.NumTxs == 1 &&
+			bytes.Equal(check.Header.DataHash, resTx.Hash) &&
+			bytes.Equal(check.Header.DataHash, resTx.Tx.Hash()) &&
+			resTx.Index == 0 {
+			err = nil
+		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
# Description

This is a minimal fix for issue #1026 affecting only heimdall and not the underlying tendermint/peppermint.

ValidateTxResult() is modified such that where the merkle proof fails verification, if the transaction is the only transaction block and the block header root hash matches the hash of the transaction, the transaction is considered valid.

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [X] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

Any node running the heimdall rest server or the heimdall CLI tool.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [X] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Run `heimdallcli query tx --chain-id=heimdall-137 [TXID]` and similar queries - ensure transactions from single transaction blocks are reported as valid.
