### PR TITLE
auth: update error type when milestone tx arrives before HF

### DIFF
--- a/auth/ante.go
+++ b/auth/ante.go
@@ -87,7 +87,7 @@ func NewAnteHandler(
 		//Check whether the chain has reached the hard fork length to execute milestone msgs
 		if ctx.BlockHeight() < helper.GetAalborgHardForkHeight() && (stdTx.Msg.Type() == checkpointTypes.EventTypeMilestone || stdTx.Msg.Type() == checkpointTypes.EventTypeMilestoneTimeout) {
 			newCtx = SetGasMeter(simulate, ctx, 0)
-			return newCtx, sdk.ErrInternal("tx must be StdTx").Result(), true
+			return newCtx, sdk.ErrTxDecode("error decoding transaction").Result(), true
 		}
 
 		// get account params

--- a/auth/ante_test.go
+++ b/auth/ante_test.go
@@ -427,7 +427,7 @@ func (suite *AnteTestSuite) TestMilestoneHardFork() {
 	ctx = ctx.WithBlockHeight(int64(-1))
 	// test good tx from one signer
 	tx = types.NewTestTx(ctx, sdk.Msg(&msgTimeout), priv1, acc1.GetAccountNumber(), uint64(0))
-	checkInvalidTx(t, anteHandler, ctx, tx, false, sdk.CodeInternal)
+	checkInvalidTx(t, anteHandler, ctx, tx, false, sdk.CodeTxDecode)
 
 	acc1 = happ.AccountKeeper.GetAccount(ctx, acc1.GetAddress())
 	require.Equal(t, amt1, (acc1.GetCoins()).AmountOf(authTypes.FeeToken))


### PR DESCRIPTION
# Description
This PR includes the fix for the error which is returned when the milestone transaction 
get included in the block before the hardfork block

