### PR TITLE
helper: use finalized for receipt calculation

### DIFF
--- a/helper/call.go
+++ b/helper/call.go
@@ -497,20 +497,38 @@ func (c *ContractCaller) GetConfirmedTxReceipt(tx common.Hash, requiredConfirmat
 		receipt, _ = receiptCache.(*ethTypes.Receipt)
 	}
 
-	Logger.Debug("Tx included in block", "block", receipt.BlockNumber.Uint64(), "tx", tx)
+	receiptBlockNumber := receipt.BlockNumber.Uint64()
 
-	// get main chain block
-	latestBlk, err := c.GetMainChainBlock(nil)
+	Logger.Debug("Tx included in block", "block", receiptBlockNumber, "tx", tx)
+
+	// fetch the last finalized main chain block (available post-merge)
+	latestFinalizedBlock, err := c.GetMainChainFinalizedBlock()
 	if err != nil {
-		Logger.Error("error getting latest block from main chain", "error", err)
-		return nil, err
+		Logger.Error("error getting latest finalized block from main chain", "error", err)
 	}
 
-	Logger.Debug("Latest block on main chain obtained", "Block", latestBlk.Number.Uint64())
+	// If latest finalized block is available, use it to check if receipt is finalized or not.
+	// Else, fallback to the `requiredConfirmations` value
+	if latestFinalizedBlock != nil {
+		Logger.Debug("Latest finalized block on main chain obtained", "Block", latestFinalizedBlock.Number.Uint64(), "receipt block", receiptBlockNumber)
 
-	diff := latestBlk.Number.Uint64() - receipt.BlockNumber.Uint64()
-	if diff < requiredConfirmations {
-		return nil, errors.New("not enough confirmations")
+		if receiptBlockNumber > latestFinalizedBlock.Number.Uint64() {
+			return nil, errors.New("not enough confirmations")
+		}
+	} else {
+		// get current/latest main chain block
+		latestBlk, err := c.GetMainChainBlock(nil)
+		if err != nil {
+			Logger.Error("error getting latest block from main chain", "error", err)
+			return nil, err
+		}
+
+		Logger.Debug("Latest block on main chain obtained", "Block", latestBlk.Number.Uint64(), "receipt block", receiptBlockNumber)
+
+		diff := latestBlk.Number.Uint64() - receiptBlockNumber
+		if diff < requiredConfirmations {
+			return nil, errors.New("not enough confirmations")
+		}
 	}
 
 	return receipt, nil


### PR DESCRIPTION
# Description

This PR adds the check in receipt calculation to account for finalized tag in main chain (eth). This change was mistakenly removed in the milestone's PR. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply