### PR TITLE
packaging: don't delete provided files

### DIFF
--- a/packaging/deb/heimdalld/DEBIAN/postrm
+++ b/packaging/deb/heimdalld/DEBIAN/postrm
@@ -1,7 +1,1 @@
 #!/bin/bash
-#
-###################
-# Remove heimdall installation
-###################
-sudo rm -rf /usr/bin/heimdallcli
-sudo rm -rf /usr/bin/heimdalld

--- a/packaging/templates/package_scripts/postrm.binary
+++ b/packaging/templates/package_scripts/postrm.binary
@@ -1,7 +1,1 @@
 #!/bin/bash
-#
-###################
-# Remove heimdall installation
-###################
-sudo rm -rf /usr/bin/heimdallcli
-sudo rm -rf /usr/bin/heimdalld


### PR DESCRIPTION
# Description

resolves #1029

Postrm script should not delete files, that are provided by deb package. Without this fix, when updating the deb package to newer version, the system is left without those files.

# Changes

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Nodes audience

Does not apply.

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
  - I can't assign reviewers
- [ ] I have added sufficient documentation in code
  - Should I? The documentation is in `man dpkg`.
- [X] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

None.

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

- Install a deb package
- Update to a newer version
- `test -f /usr/bin/heimdallcli && test -f /usr/bin/heimdalld`
