### PR TITLE
fix: log/service stopped

### DIFF
--- a/cmd/heimdalld/service/service.go
+++ b/cmd/heimdalld/service/service.go
@@ -206,8 +206,6 @@ func NewHeimdallService(pCtx context.Context, args []string) {
 		// Note: Handle with #870
 		panic(err)
 	}
-
-	logger.Info("Heimdall services stopped")
 }
 
 func getNewApp(serverCtx *server.Context) func(logger log.Logger, db dbm.DB, storeTracer io.Writer) abci.Application {
@@ -531,6 +529,7 @@ func startInProcess(cmd *cobra.Command, shutdownCtx context.Context, ctx *server
 		return err
 	}
 
+	logger.Info("Heimdall services stopped")
 	return nil
 }
 

--- a/cmd/heimdalld/service/service.go
+++ b/cmd/heimdalld/service/service.go
@@ -530,6 +530,7 @@ func startInProcess(cmd *cobra.Command, shutdownCtx context.Context, ctx *server
 	}
 
 	logger.Info("Heimdall services stopped")
+
 	return nil
 }
 


### PR DESCRIPTION
# Description
The log of `Heimdall services stopped` was in a wrong place where it printed this log where any `heimdalld` sub-command (e.g., `version`, `init`) has called.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests
Following we test the `version` sub-command. 
#### out of this PR
```
/usr/bin/heimdalld version
1.0.1
INFO [2023-10-02|14:09:17.940] Heimdall services stopped                    module=cmd/heimdalld
```
#### in this PR
```
/usr/bin/heimdalld version
1.0.1
```
The same would apply to all other sub-commands.