### PR TITLE
checkpoint/client: revert with 503 status code until HF

### DIFF
--- a/checkpoint/client/rest/query_milestone.go
+++ b/checkpoint/client/rest/query_milestone.go
@@ -10,6 +10,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/maticnetwork/heimdall/checkpoint/types"
+	"github.com/maticnetwork/heimdall/helper"
 	hmRest "github.com/maticnetwork/heimdall/types/rest"
 )
 
@@ -29,7 +30,14 @@ func milestoneLatestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		// fetch checkpoint
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
+			return
+		}
+
+		// Fetch latest milestone
 		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryLatestMilestone), nil)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
@@ -43,15 +51,22 @@ func milestoneLatestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	}
 }
 
-// swagger:route GET /checkpoints/count checkpoint checkpointCount
-// It returns the checkpoint counts
+// swagger:route GET /milestone/count milestone milestoneCount
+// It returns the milestone count
 // responses:
 //
-//	200: checkpointCountResponse
+//	200: milestoneCountResponse
 func milestoneCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		if !ok {
+			return
+		}
+
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
 			return
 		}
 
@@ -94,6 +109,13 @@ func milestoneByNumberHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
+			return
+		}
+
 		// get milestone number
 		number, ok := rest.ParseUint64OrReturnBadRequest(w, vars["number"])
 		if !ok {
@@ -126,7 +148,13 @@ func latestNoAckMilestoneHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		// fetch checkpoint
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
+			return
+		}
+
 		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryLatestNoAckMilestone), nil)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
@@ -163,6 +191,13 @@ func noAckMilestoneByIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		if !ok {
+			return
+		}
+
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
 			return
 		}
 
@@ -204,6 +239,13 @@ func noAckMilestoneByIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 func milestoneByIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
+
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
+			return
+		}
 
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		if !ok {

--- a/checkpoint/client/rest/query_milestone.go
+++ b/checkpoint/client/rest/query_milestone.go
@@ -30,15 +30,16 @@ func milestoneLatestHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		// Fetch latest milestone
+		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryLatestMilestone), nil)
+
 		// Return status code 503 (Service Unavailable) if HF hasn't been activated
-		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+		if height < helper.GetAalborgHardForkHeight() {
 			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
 
 			return
 		}
 
-		// Fetch latest milestone
-		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryLatestMilestone), nil)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 
@@ -63,14 +64,15 @@ func milestoneCountHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		countBytes, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryCount), nil)
+
 		// Return status code 503 (Service Unavailable) if HF hasn't been activated
-		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+		if height < helper.GetAalborgHardForkHeight() {
 			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
 
 			return
 		}
 
-		countBytes, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryCount), nil)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
@@ -109,13 +111,6 @@ func milestoneByNumberHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		// Return status code 503 (Service Unavailable) if HF hasn't been activated
-		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
-			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
-
-			return
-		}
-
 		// get milestone number
 		number, ok := rest.ParseUint64OrReturnBadRequest(w, vars["number"])
 		if !ok {
@@ -128,8 +123,16 @@ func milestoneByNumberHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		// query checkpoint
+		// query milestone
 		res, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryMilestoneByNumber), queryParams)
+
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
+			return
+		}
+
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -148,6 +151,8 @@ func latestNoAckMilestoneHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
+		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryLatestNoAckMilestone), nil)
+
 		// Return status code 503 (Service Unavailable) if HF hasn't been activated
 		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
 			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
@@ -155,7 +160,6 @@ func latestNoAckMilestoneHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryLatestNoAckMilestone), nil)
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusInternalServerError, err.Error())
 			return
@@ -194,13 +198,6 @@ func noAckMilestoneByIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		// Return status code 503 (Service Unavailable) if HF hasn't been activated
-		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
-			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
-
-			return
-		}
-
 		// get milestone number
 		id := vars["id"]
 
@@ -211,6 +208,14 @@ func noAckMilestoneByIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		}
 
 		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryNoAckMilestoneByID), queryID)
+
+		// Return status code 503 (Service Unavailable) if HF hasn't been activated
+		if height < helper.GetAalborgHardForkHeight() {
+			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
+
+			return
+		}
+
 		if err != nil {
 			hmRest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
@@ -239,13 +244,6 @@ func noAckMilestoneByIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 func milestoneByIDHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-
-		// Return status code 503 (Service Unavailable) if HF hasn't been activated
-		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
-			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
-
-			return
-		}
 
 		cliCtx, ok := rest.ParseQueryHeightOrReturnBadRequest(w, cliCtx, r)
 		if !ok {

--- a/checkpoint/client/rest/query_milestone.go
+++ b/checkpoint/client/rest/query_milestone.go
@@ -154,7 +154,7 @@ func latestNoAckMilestoneHandlerFn(cliCtx context.CLIContext) http.HandlerFunc {
 		result, height, err := cliCtx.QueryWithData(fmt.Sprintf("custom/%s/%s", types.QuerierRoute, types.QueryLatestNoAckMilestone), nil)
 
 		// Return status code 503 (Service Unavailable) if HF hasn't been activated
-		if cliCtx.Height < helper.GetAalborgHardForkHeight() {
+		if height < helper.GetAalborgHardForkHeight() {
 			hmRest.WriteErrorResponse(w, http.StatusServiceUnavailable, "Aalborg hardfork not activated yet")
 
 			return

--- a/helper/config.go
+++ b/helper/config.go
@@ -396,7 +396,7 @@ func InitHeimdallConfigWith(homeDir string, heimdallConfigFileFromFLag string) {
 		newSelectionAlgoHeight = 375300
 		spanOverrideHeight = 8664000
 		newHexToStringAlgoHeight = 9266260
-		aalborgHeight = 15950759 //NOTE:IT IS NOT CONFIRMED,WILL CHANGE THIS VALUE IN FUTURE
+		aalborgHeight = 15950759
 	case MumbaiChain:
 		newSelectionAlgoHeight = 282500
 		spanOverrideHeight = 10205000


### PR DESCRIPTION
# Description

This PR reverts the calls related to the upcoming `Aalborg` hard fork with status code 503 until the hard fork block number kicks in. This is to notify bor about whether the HF has kicked in or not. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it