### PR TITLE
POS-2399: ganache bug workaround to reduce `smoke_test` time in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
 
         - name: Run smoke tests
           run: |
+            echo "Funding ganache accounts..."
             timeout 10m bash heimdall/integration-tests/fund_ganache_accounts.sh
             echo "Deposit 100 matic for each account to bor network"
             cd matic-cli/devnet/code/contracts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
 
         - name: Run smoke tests
           run: |
+            timeout 10m bash heimdall/integration-tests/fund_ganache_accounts.sh
             echo "Deposit 100 matic for each account to bor network"
             cd matic-cli/devnet/code/contracts
             npm run truffle exec scripts/deposit.js -- --network development $(jq -r .root.tokens.MaticToken contractAddresses.json) 100000000000000000000

--- a/integration-tests/fund_ganache_accounts.sh
+++ b/integration-tests/fund_ganache_accounts.sh
@@ -1,27 +1,19 @@
 #!/bin/bash
 
-EthAmount='10'
-machine0='localhost'
+host='localhost'
 
 echo "Transferring funds from ganache account[0] to others..."
 
 signersFile="matic-cli/devnet/devnet/signer-dump.json"
+signersDump=$(jq . $signersFile)
+signersLength=$(jq '. | length' $signersFile)
 
-signerDump=$(cat $signersFile | jq -c '.')
+rootChainWeb3="http://${host}:9545"
 
-echo "src: $signersFile"
-echo "signerDump: $signerDump"
-
-rootChainWeb3="http://${machine0}:9545"
-
-for ((i = 1; i < ${#signerDump[@]}; i++)); do
-  to_address=$(echo "$signerDump" | jq -r ".[$i].address")
-  from_address=$(echo "$signerDump" | jq -r ".[0].address")
-  echo "Transferring funds from $from_address to $to_address"
-
-  txReceipt=$(curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"'"$to_address"'","from":"'"$from_address"'","value":"'$EthAmount'"}],"id":1}' -H "Content-Type: application/json" $rootChainWeb3)
-
+for ((i = 1; i < signersLength; i++)); do
+  to_address=$(echo "$signersDump" | jq -r ".[$i].address")
+  from_address=$(echo "$signersDump" | jq -r ".[0].address")
+  txReceipt=$(curl $rootChainWeb3 -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"'"$to_address"'","from":"'"$from_address"'","value":"0xDE0B6B3A7640000"}],"id":1}' -H "Content-Type: application/json")
   txHash=$(echo "$txReceipt" | jq -r '.result')
-
-  echo "📍Funds transferred from $from_address to $to_address with txHash $txHash"
+  echo "Funds transferred from $from_address to $to_address with txHash: $txHash"
 done

--- a/integration-tests/fund_ganache_accounts.sh
+++ b/integration-tests/fund_ganache_accounts.sh
@@ -2,7 +2,7 @@
 
 host='localhost'
 
-echo "Transferring funds from ganache account[0] to others..."
+echo "Transferring 1 ETH from ganache account[0] to all others..."
 
 signersFile="matic-cli/devnet/devnet/signer-dump.json"
 signersDump=$(jq . $signersFile)

--- a/integration-tests/fund_ganache_accounts.sh
+++ b/integration-tests/fund_ganache_accounts.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+EthAmount='10'
+machine0='localhost'
+
+echo "📍Transferring funds from ganache account[0] to others..."
+
+src="${machine0}:~/matic-cli/devnet/devnet/signer-dump.json"
+
+signerDump=$(cat $src | jq -c '.')
+
+rootChainWeb3="http://${machine0}:9545"
+
+for ((i = 1; i < ${#signerDump[@]}; i++)); do
+  to_address=$(echo $signerDump | jq -r ".[$i].address")
+  from_address=$(echo $signerDump | jq -r ".[0].address")
+
+  txReceipt=$(curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"'$to_address'","from":"'$from_address'","value":"'$EthAmount'"}],"id":1}' -H "Content-Type: application/json" $rootChainWeb3)
+
+  txHash=$(echo $txReceipt | jq -r '.result')
+
+  echo "📍Funds transferred from $from_address to $to_address with txHash $txHash"
+done

--- a/integration-tests/fund_ganache_accounts.sh
+++ b/integration-tests/fund_ganache_accounts.sh
@@ -5,7 +5,7 @@ machine0='localhost'
 
 echo "📍Transferring funds from ganache account[0] to others..."
 
-src="${machine0}:~/matic-cli/devnet/devnet/signer-dump.json"
+src="matic-cli/devnet/devnet/signer-dump.json"
 
 signerDump=$(cat $src | jq -c '.')
 

--- a/integration-tests/fund_ganache_accounts.sh
+++ b/integration-tests/fund_ganache_accounts.sh
@@ -3,21 +3,25 @@
 EthAmount='10'
 machine0='localhost'
 
-echo "📍Transferring funds from ganache account[0] to others..."
+echo "Transferring funds from ganache account[0] to others..."
 
-src="matic-cli/devnet/devnet/signer-dump.json"
+signersFile="matic-cli/devnet/devnet/signer-dump.json"
 
-signerDump=$(cat $src | jq -c '.')
+signerDump=$(cat $signersFile | jq -c '.')
+
+echo "src: $signersFile"
+echo "signerDump: $signerDump"
 
 rootChainWeb3="http://${machine0}:9545"
 
 for ((i = 1; i < ${#signerDump[@]}; i++)); do
-  to_address=$(echo $signerDump | jq -r ".[$i].address")
-  from_address=$(echo $signerDump | jq -r ".[0].address")
+  to_address=$(echo "$signerDump" | jq -r ".[$i].address")
+  from_address=$(echo "$signerDump" | jq -r ".[0].address")
+  echo "Transferring funds from $from_address to $to_address"
 
-  txReceipt=$(curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"'$to_address'","from":"'$from_address'","value":"'$EthAmount'"}],"id":1}' -H "Content-Type: application/json" $rootChainWeb3)
+  txReceipt=$(curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"'"$to_address"'","from":"'"$from_address"'","value":"'$EthAmount'"}],"id":1}' -H "Content-Type: application/json" $rootChainWeb3)
 
-  txHash=$(echo $txReceipt | jq -r '.result')
+  txHash=$(echo "$txReceipt" | jq -r '.result')
 
   echo "📍Funds transferred from $from_address to $to_address with txHash $txHash"
 done


### PR DESCRIPTION
# Description

Often, the checkpoints submission during the `e2e tests` in the CI takes a very long time (35+ mins) due to lack of funds in ganache accounts (with `index > 0`), which ends up in checkpoints submission failure, and subsequent rotation until it's `accounts[0]` turn. 
This PR introduces a new script to fund the ganache accounts right before the `e2e tests`, to reduce the checkpoint submission time from 35+ mins to around 2 mins.  

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai
- [ ] I have created new e2e tests into express-cli