### PR TITLE
checkpoint: fix numerical key ordering

### DIFF
--- a/checkpoint/genesis.go
+++ b/checkpoint/genesis.go
@@ -2,7 +2,6 @@ package checkpoint
 
 import (
 	"errors"
-	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -44,10 +43,6 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 		if err := keeper.SetCheckpointBuffer(ctx, *data.BufferedCheckpoint); err != nil {
 			keeper.Logger(ctx).Error("InitGenesis | SetCheckpointBuffer", "error", err)
 		}
-	}
-
-	if err := keeper.MigrateCheckpointKeyV2(ctx); err != nil {
-		panic(fmt.Errorf("checkpoint key v2 migration failed: %w", err))
 	}
 
 	// Set initial ack count

--- a/checkpoint/genesis.go
+++ b/checkpoint/genesis.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"errors"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -43,6 +44,10 @@ func InitGenesis(ctx sdk.Context, keeper Keeper, data types.GenesisState) {
 		if err := keeper.SetCheckpointBuffer(ctx, *data.BufferedCheckpoint); err != nil {
 			keeper.Logger(ctx).Error("InitGenesis | SetCheckpointBuffer", "error", err)
 		}
+	}
+
+	if err := keeper.MigrateCheckpointKeyV2(ctx); err != nil {
+		panic(fmt.Errorf("checkpoint key v2 migration failed: %w", err))
 	}
 
 	// Set initial ack count


### PR DESCRIPTION
# Description

Problem: we would like to use the checkpoints/list heimdall provides to fetch checkpoints in bulk. However we noticed one issue with it. The list of checkpoints returned on a page are not ordered correctly.

Example: https://heimdall-api.polygon.technology/checkpoints/list?page=1&limit=10
<img width="1671" alt="Screenshot 2024-03-28 at 13 08 18" src="https://github.com/maticnetwork/heimdall/assets/94537774/a57ea510-381c-4b26-a66f-7d049c27cef4">

After digging through the code I suspect the issue is coming from how we persist the checkpoint number key in the DB. Under the hood I believe that the store uses an AVL tree (or some sort of balanced binary tree) and the iterator used in the checkpoint/list API traverses that tree in order based on the key. 

Unfortunately currently we store the key using `[]byte(strconv.FormatUint(checkpointNumber, 10))` which results in a lexicographical sort in the AVL tree instead of a numerical one (i.e. checkpoint number 2 > checkpoint number 10). I suspect we need to use `sdk.Uint64ToBigEndian(checkpointNumber)` instead.

This is a simple fix however it necessitates a data migration - all existing checkpoint key-value pairs need to be moved to a new key-value pair using the correct numerical byte representation of the key. There are only 60k checkpoints on mainnet so such a migration should in theory be quick and unnoticeable.

I'm not sure what the best way to apply such migrations in the cosmos sdk is so please do let me know if you have any suggestions of how to do the migration in a better way than the current solution. Also note, this is pending testing which I haven't started yet - I first would like to start the conversation and get some initial feedback whether this is the right direction before investing more time into this.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
