### PR TITLE
checkpoint: list api increase max limit

### DIFF
--- a/checkpoint/keeper.go
+++ b/checkpoint/keeper.go
@@ -16,6 +16,8 @@ import (
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
+const maxCheckpointListLimit = 10_000 // a checkpoint is ~100 bytes => can fit 10k in 1 MB response
+
 var (
 	DefaultValue = []byte{0x01} // Value to store in CacheCheckpoint and CacheCheckpointACK & ValidatorSetChange Flag
 
@@ -145,8 +147,8 @@ func (k *Keeper) GetCheckpointList(ctx sdk.Context, page uint64, limit uint64) (
 	var checkpoints []hmTypes.Checkpoint
 
 	// have max limit
-	if limit > 20 {
-		limit = 20
+	if limit > maxCheckpointListLimit {
+		limit = maxCheckpointListLimit
 	}
 
 	// get paginated iterator


### PR DESCRIPTION
# Description

The max limit of checkpoint/list api is set to 20 which is very small. E.g. https://heimdall-api.polygon.technology/checkpoints/list?page=1&limit=10000 returns only 20 instead of 10,000.

Checkpoint objects are very small ~100 bytes each. We can fit ~ 10,000 in a 1 MB response size. Feels like this should not be something that can affect the process badly.

Context: Erigon would like to efficiently fetch checkpoints from heimdall for an improved initial sync mechanism. We would like to batch fetch efficiently hence the change.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

```
➜  ~ curl 'http://0.0.0.0:1317/checkpoints/list?page=6&limit=10' | jq | grep "proposer" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2298    0  2298    0     0   178k      0 --:--:-- --:--:-- --:--:--  187k
10
➜  ~ curl 'http://0.0.0.0:1317/checkpoints/list?page=6&limit=10000' | jq | grep "proposer" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2206k    0 2206k    0     0   537k      0 --:--:--  0:00:04 --:--:--  537k
10000
➜  ~ curl 'http://0.0.0.0:1317/checkpoints/list?page=6&limit=1000000' | jq | grep "proposer" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2206k    0 2206k    0     0   503k      0 --:--:--  0:00:04 --:--:--  528k
10000
➜  ~ 

```