### PR TITLE
POS-2399: ganache bug workaround to reduce `smoke_test` time in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
 
         - name: Run smoke tests
           run: |
+            echo "Funding ganache accounts..."
+            timeout 10m bash heimdall/integration-tests/fund_ganache_accounts.sh
             echo "Deposit 100 matic for each account to bor network"
             cd matic-cli/devnet/code/contracts
             npm run truffle exec scripts/deposit.js -- --network development $(jq -r .root.tokens.MaticToken contractAddresses.json) 100000000000000000000

--- a/integration-tests/fund_ganache_accounts.sh
+++ b/integration-tests/fund_ganache_accounts.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+host='localhost'
+
+echo "Transferring 1 ETH from ganache account[0] to all others..."
+
+signersFile="matic-cli/devnet/devnet/signer-dump.json"
+signersDump=$(jq . $signersFile)
+signersLength=$(jq '. | length' $signersFile)
+
+rootChainWeb3="http://${host}:9545"
+
+for ((i = 1; i < signersLength; i++)); do
+  to_address=$(echo "$signersDump" | jq -r ".[$i].address")
+  from_address=$(echo "$signersDump" | jq -r ".[0].address")
+  txReceipt=$(curl $rootChainWeb3 -X POST --data '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"'"$to_address"'","from":"'"$from_address"'","value":"0xDE0B6B3A7640000"}],"id":1}' -H "Content-Type: application/json")
+  txHash=$(echo "$txReceipt" | jq -r '.result')
+  echo "Funds transferred from $from_address to $to_address with txHash: $txHash"
+done


### PR DESCRIPTION
# Description

This PR cherry picks the implementation of the workaround for the ganache bug to reduce the `smoke_test` execution time during CI. 
This has been running fine on `develop` for some time now.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [x] I have added tests to CI
- [x] I have tested this code manually on local environment
- [x] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli