### PR TITLE
Handle account sequence correctly in bridge

### DIFF
--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -7,12 +7,13 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	authTypes "github.com/maticnetwork/heimdall/auth/types"
+	"github.com/maticnetwork/heimdall/helper"
 
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
 // Setup initializes a new App. A Nop logger is set in App.
-func Setup(isCheckTx bool) *HeimdallApp {
+func Setup(isCheckTx bool, testOpts ...*helper.TestOpts) *HeimdallApp {
 	db := dbm.NewMemDB()
 	app := NewHeimdallApp(log.NewNopLogger(), db)
 
@@ -26,12 +27,15 @@ func Setup(isCheckTx bool) *HeimdallApp {
 		}
 
 		// Initialize the chain
-		app.InitChain(
-			abci.RequestInitChain{
-				Validators:    []abci.ValidatorUpdate{},
-				AppStateBytes: stateBytes,
-			},
-		)
+		req := abci.RequestInitChain{
+			Validators:    []abci.ValidatorUpdate{},
+			AppStateBytes: stateBytes,
+		}
+
+		if len(testOpts) > 0 && testOpts[0] != nil {
+			req.ChainId = testOpts[0].GetChainId()
+		}
+		app.InitChain(req)
 	}
 
 	return app

--- a/bridge/setu/broadcaster/broadcaster_test.go
+++ b/bridge/setu/broadcaster/broadcaster_test.go
@@ -1,61 +1,296 @@
 package broadcaster
 
 import (
-	"os"
-	"strconv"
+	"bytes"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
 	"testing"
 
+	cosmosCtx "github.com/cosmos/cosmos-sdk/client/context"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/golang/mock/gomock"
 	"github.com/maticnetwork/heimdall/app"
+	authTypes "github.com/maticnetwork/heimdall/auth/types"
+	borTypes "github.com/maticnetwork/heimdall/bor/types"
 	checkpointTypes "github.com/maticnetwork/heimdall/checkpoint/types"
 	"github.com/maticnetwork/heimdall/helper"
+	helperMocks "github.com/maticnetwork/heimdall/helper/mocks"
 	hmTypes "github.com/maticnetwork/heimdall/types"
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/crypto/secp256k1"
+)
+
+var (
+	privKey                = secp256k1.GenPrivKey()
+	pubKey                 = privKey.PubKey()
+	address                = pubKey.Address()
+	defaultBalance         = sdk.NewIntFromBigInt(big.NewInt(10).Exp(big.NewInt(10), big.NewInt(18), nil))
+	testChainId            = "testChainId"
+	dummyTenderMintNodeUrl = "http://localhost:26657"
+	dummyHeimdallServerUrl = "https://dummy-heimdall-api-testnet.polygon.technology"
+	getAccountUrl          = dummyHeimdallServerUrl + "/auth/accounts/" + address.String()
+	getAccountResponse     = fmt.Sprintf(`
+	{
+		"height": "11384869",
+		"result": {
+		  "type": "auth/Account",
+		  "value": {
+			"address": "0x%s",
+			"coins": [
+			  {
+				"denom": "matic",
+				"amount": "10000000000000000000"
+			  }
+			],
+			"public_key": {
+				"type": "tendermint/PubKeySecp256k1",
+				"value": "BE/WIL+R3P+8YlGBfxqPdb+jWlWdAiocPOBYNXoXqYOlQ0+QiJudDIMLhDqovssOvS9REFaUYn6pXE0YGD3nb5k="
+			  },
+			"account_number": "0",
+			"sequence": "0"
+		  }
+		}
+	  }
+	  `, address.String())
+
+	getAccountUpdatedResponse = fmt.Sprintf(`
+	{
+		"height": "11384869",
+		"result": {
+		  "type": "auth/Account",
+		  "value": {
+			"address": "0x%s",
+			"coins": [
+			  {
+				"denom": "matic",
+				"amount": "10000000000000000000"
+			  }
+			],
+			"public_key": {
+				"type": "tendermint/PubKeySecp256k1",
+				"value": "BE/WIL+R3P+8YlGBfxqPdb+jWlWdAiocPOBYNXoXqYOlQ0+QiJudDIMLhDqovssOvS9REFaUYn6pXE0YGD3nb5k="
+			  },
+			"account_number": "0",
+			"sequence": "1"
+		  }
+		}
+	  }
+	  `, address.String())
+
+	msgs = []sdk.Msg{
+		checkpointTypes.NewMsgCheckpointBlock(
+			hmTypes.BytesToHeimdallAddress([]byte(address)),
+			0,
+			63,
+			hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"),
+			hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d"),
+			"borChainID",
+		),
+		checkpointTypes.NewMsgMilestoneBlock(
+			hmTypes.BytesToHeimdallAddress([]byte(address)),
+			0,
+			63,
+			hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"),
+			"testBorChainID",
+			"testMilestoneID",
+		),
+		checkpointTypes.NewMsgMilestoneTimeout(
+			hmTypes.BytesToHeimdallAddress([]byte(address)),
+		),
+		borTypes.NewMsgProposeSpan(
+			1,
+			hmTypes.BytesToHeimdallAddress([]byte(address)),
+			0,
+			63,
+			"testBorChainID",
+			common.Hash(hmTypes.BytesToHeimdallHash([]byte("randseed"))),
+		),
+	}
 )
 
 // Parallel test - to check BroadcastToHeimdall synchronisation
 func TestBroadcastToHeimdall(t *testing.T) {
 	t.Parallel()
 
-	cdc := app.MakeCodec()
-	// cli context
-	tendermintNode := "tcp://localhost:26657"
-	viper.Set(helper.TendermintNodeFlag, tendermintNode)
+	viper.Set(helper.TendermintNodeFlag, dummyTenderMintNodeUrl)
 	viper.Set("log_level", "info")
-	// cliCtx := cliContext.NewCLIContext().WithCodec(cdc)
-	// cliCtx.BroadcastMode = client.BroadcastSync
-	// cliCtx.TrustNode = true
 
-	helper.InitHeimdallConfig(os.ExpandEnv("$HOME/.heimdalld"))
+	configuration := helper.GetDefaultHeimdallConfig()
+	configuration.TendermintRPCUrl = dummyTenderMintNodeUrl
+	configuration.HeimdallServerURL = dummyHeimdallServerUrl
+	helper.SetTestConfig(configuration)
+	helper.SetTestPrivPubKey(privKey)
 
-	_txBroadcaster := NewTxBroadcaster(cdc)
+	mockCtrl := prepareMockData(t)
+	defer mockCtrl.Finish()
 
-	testData := []checkpointTypes.MsgCheckpoint{
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 0, EndBlock: 63, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 64, EndBlock: 1024, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 1025, EndBlock: 2048, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
-		{Proposer: hmTypes.BytesToHeimdallAddress(helper.GetAddress()), StartBlock: 2049, EndBlock: 3124, RootHash: hmTypes.HexToHeimdallHash("0x5bd83f679c8ce7c48d6fa52ce41532fcacfbbd99d5dab415585f397bf44a0b6e"), AccountRootHash: hmTypes.HexToHeimdallHash("0xd10b5c16c25efe0b0f5b3d75038834223934ae8c2ec2b63a62bbe42aa21e2d2d")},
+	testOpts := helper.NewTestOpts(nil, testChainId)
+	heimdallApp, sdkCtx, _ := createTestApp(false, testOpts)
+	testOpts.SetApplication(heimdallApp)
+	txBroadcaster := NewTxBroadcaster(heimdallApp.Codec())
+	txBroadcaster.CliCtx.Simulate = true
+
+	testCases := []struct {
+		name       string
+		msg        sdk.Msg
+		op         func(*app.HeimdallApp) error
+		expResCode uint32
+		expErr     bool
+		tearDown   func(*app.HeimdallApp) error
+	}{
+		{
+			name: "successful broadcast",
+			msg:  msgs[0],
+
+			op:         nil,
+			expResCode: 0,
+			expErr:     false,
+		},
+		{
+			name: "failed broadcast (insufficient funds for fees)",
+			msg:  msgs[1],
+			op: func(hApp *app.HeimdallApp) error {
+				acc := hApp.AccountKeeper.GetAccount(sdkCtx, hmTypes.BytesToHeimdallAddress([]byte(address)))
+				// reduce account balance to 0
+				if err := acc.SetCoins(sdk.Coins{}); err != nil {
+					return err
+				}
+				hApp.AccountKeeper.SetAccount(sdkCtx, acc)
+				return nil
+			},
+			expResCode: 5,
+			expErr:     true,
+			tearDown: func(hApp *app.HeimdallApp) error {
+				acc := hApp.AccountKeeper.GetAccount(sdkCtx, hmTypes.BytesToHeimdallAddress([]byte(address)))
+				// reset account balance
+				if err := acc.SetCoins(sdk.Coins{sdk.Coin{Denom: authTypes.FeeToken, Amount: defaultBalance}}); err != nil {
+					return err
+				}
+				hApp.AccountKeeper.SetAccount(sdkCtx, acc)
+				return nil
+			},
+		},
+		{
+			name: "failed broadcast (invalid sequence number)",
+			msg:  msgs[2],
+			op: func(hApp *app.HeimdallApp) error {
+				acc := hApp.AccountKeeper.GetAccount(sdkCtx, hmTypes.BytesToHeimdallAddress([]byte(address)))
+				txBroadcaster.lastSeqNo = acc.GetSequence() + 1
+				return nil
+			},
+			expResCode: 4,
+			expErr:     true,
+		},
 	}
 
-	for index, test := range testData { //nolint
-		index := index
-		test := test
+	for _, tc := range testCases {
+		if tc.expErr {
+			updateMockData(t)
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.op != nil {
+				err := tc.op(heimdallApp)
+				require.NoError(t, err)
+			}
+			txRes, err := txBroadcaster.BroadcastToHeimdall(tc.msg, nil, testOpts)
+			require.NoError(t, err)
+			require.Equal(t, tc.expResCode, txRes.Code)
+			accSeq, err := heimdallApp.AccountKeeper.GetSequence(sdkCtx, hmTypes.BytesToHeimdallAddress([]byte(address)))
+			require.NoError(t, err)
+			require.Equal(t, txBroadcaster.lastSeqNo, accSeq)
 
-		t.Run(strconv.Itoa(index), func(t *testing.T) {
-			t.Parallel()
-
-			// create and send checkpoint message
-			msg := checkpointTypes.NewMsgCheckpointBlock(
-				test.Proposer,
-				test.StartBlock,
-				test.EndBlock,
-				test.RootHash,
-				test.AccountRootHash,
-				test.BorChainID,
-			)
-
-			err := _txBroadcaster.BroadcastToHeimdall(msg, nil)
-			assert.Empty(t, err, "Error broadcasting tx to heimdall", err)
+			if tc.tearDown != nil {
+				err := tc.tearDown(heimdallApp)
+				require.NoError(t, err)
+			}
 		})
 	}
+}
+
+func createTestApp(isCheckTx bool, testOpts *helper.TestOpts) (*app.HeimdallApp, sdk.Context, cosmosCtx.CLIContext) {
+	app := app.Setup(isCheckTx, testOpts)
+	ctx := app.BaseApp.NewContext(true, abci.Header{ChainID: testOpts.GetChainId()})
+	app.BankKeeper.SetSendEnabled(ctx, true)
+	app.AccountKeeper.SetParams(ctx, authTypes.DefaultParams())
+	app.CheckpointKeeper.SetParams(ctx, checkpointTypes.DefaultParams())
+	app.BorKeeper.SetParams(ctx, borTypes.DefaultParams())
+
+	coins := sdk.Coins{sdk.Coin{Denom: authTypes.FeeToken, Amount: defaultBalance}}
+	acc := authTypes.NewBaseAccount(hmTypes.BytesToHeimdallAddress([]byte(address)),
+		coins,
+		pubKey,
+		0,
+		0)
+
+	app.AccountKeeper.SetAccount(ctx, acc)
+	return app, ctx, cosmosCtx.NewCLIContext().WithCodec(app.Codec())
+}
+
+func prepareMockData(t *testing.T) *gomock.Controller {
+	t.Helper()
+
+	mockCtrl := gomock.NewController(t)
+
+	mockHttpClient := helperMocks.NewMockHTTPClient(mockCtrl)
+	mockHttpClient.EXPECT().Get(getAccountUrl).Return(prepareResponse(getAccountResponse), nil).AnyTimes()
+	helper.Client = mockHttpClient
+	return mockCtrl
+}
+
+func updateMockData(t *testing.T) *gomock.Controller {
+	t.Helper()
+
+	mockCtrl := gomock.NewController(t)
+
+	mockHttpClient := helperMocks.NewMockHTTPClient(mockCtrl)
+	mockHttpClient.EXPECT().Get(getAccountUrl).Return(prepareResponse(getAccountUpdatedResponse), nil).AnyTimes()
+	helper.Client = mockHttpClient
+	return mockCtrl
+}
+
+func prepareResponse(body string) *http.Response {
+	return &http.Response{
+		Status:           "200 OK",
+		StatusCode:       200,
+		Proto:            "",
+		ProtoMajor:       0,
+		ProtoMinor:       0,
+		Header:           nil,
+		Body:             newResettableReadCloser(body),
+		ContentLength:    0,
+		TransferEncoding: nil,
+		Close:            false,
+		Uncompressed:     false,
+		Trailer:          nil,
+		Request:          nil,
+		TLS:              nil,
+	}
+}
+
+// resettableReadCloser resets the reader to the beginning of the data when Close is called.
+// this is useful for reusing the response body more than once in tests.
+type resettableReadCloser struct {
+	data []byte
+	r    io.Reader
+}
+
+func newResettableReadCloser(body string) *resettableReadCloser {
+	return &resettableReadCloser{
+		data: []byte(body),
+		r:    bytes.NewReader([]byte(body)),
+	}
+}
+
+func (r *resettableReadCloser) Read(p []byte) (n int, err error) {
+	return r.r.Read(p)
+}
+
+func (r *resettableReadCloser) Close() error {
+	r.r = bytes.NewReader(r.data)
+	return nil
 }

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"strconv"
@@ -302,9 +303,16 @@ func (cp *CheckpointProcessor) sendCheckpointAckToHeimdall(eventName string, che
 		)
 
 		// return broadcast to heimdall
-		if err = cp.txBroadcaster.BroadcastToHeimdall(msg, event); err != nil {
+		txRes, err := cp.txBroadcaster.BroadcastToHeimdall(msg, event)
+		if err != nil {
 			cp.Logger.Error("Error while broadcasting checkpoint-ack to heimdall", "error", err)
 			return err
+		}
+
+		if txRes.Code != uint32(sdk.CodeOK) {
+			cp.Logger.Error("checkpoint-ack tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+			return fmt.Errorf("checkpoint-ack tx failed, tx response code: %d", txRes.Code)
+
 		}
 	}
 
@@ -481,9 +489,15 @@ func (cp *CheckpointProcessor) createAndSendCheckpointToHeimdall(checkpointConte
 	)
 
 	// return broadcast to heimdall
-	if err := cp.txBroadcaster.BroadcastToHeimdall(msg, nil); err != nil {
+	txRes, err := cp.txBroadcaster.BroadcastToHeimdall(msg, nil)
+	if err != nil {
 		cp.Logger.Error("Error while broadcasting checkpoint to heimdall", "error", err)
 		return err
+	}
+
+	if txRes.Code != uint32(sdk.CodeOK) {
+		cp.Logger.Error("Checkpoint tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+		return fmt.Errorf("checkpoint tx failed, tx response code: %d", txRes.Code)
 	}
 
 	return nil
@@ -661,9 +675,16 @@ func (cp *CheckpointProcessor) proposeCheckpointNoAck() (err error) {
 	)
 
 	// return broadcast to heimdall
-	if err := cp.txBroadcaster.BroadcastToHeimdall(msg, nil); err != nil {
+	txRes, err := cp.txBroadcaster.BroadcastToHeimdall(msg, nil)
+	if err != nil {
 		cp.Logger.Error("Error while broadcasting checkpoint-no-ack to heimdall", "msg", msg, "error", err)
 		return err
+	}
+
+	if txRes.Code != uint32(sdk.CodeOK) {
+		cp.Logger.Error("Checkpoint No-Ack tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+		return fmt.Errorf("checkpoint-no-ack tx failed, tx response code: %d", txRes.Code)
+
 	}
 
 	cp.Logger.Info("No-ack transaction sent successfully")

--- a/bridge/setu/processor/clerk.go
+++ b/bridge/setu/processor/clerk.go
@@ -157,7 +157,7 @@ func (cp *ClerkProcessor) sendStateSyncedToHeimdall(eventName string, logBytes s
 
 		_, BroadcastToHeimdallSpan := tracing.StartSpan(sendStateSyncedToHeimdallCtx, "BroadcastToHeimdall")
 		// return broadcast to heimdall
-		err = cp.txBroadcaster.BroadcastToHeimdall(msg, event)
+		_, err = cp.txBroadcaster.BroadcastToHeimdall(msg, event)
 		tracing.EndSpan(BroadcastToHeimdallSpan)
 
 		if err != nil {

--- a/bridge/setu/processor/milestone.go
+++ b/bridge/setu/processor/milestone.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/maticnetwork/heimdall/bridge/setu/util"
 	chainmanagerTypes "github.com/maticnetwork/heimdall/chainmanager/types"
 	milestoneTypes "github.com/maticnetwork/heimdall/checkpoint/types"
@@ -189,11 +190,17 @@ func (mp *MilestoneProcessor) createAndSendMilestoneToHeimdall(milestoneContext 
 	)
 
 	//broadcast to heimdall
-	if err := mp.txBroadcaster.BroadcastToHeimdall(msg, nil); err != nil {
+	txRes, err := mp.txBroadcaster.BroadcastToHeimdall(msg, nil)
+	if err != nil {
 		mp.Logger.Error("Error while broadcasting milestone to heimdall", "error", err)
 		return err
 	}
 
+	if txRes.Code != uint32(sdk.CodeOK) {
+		mp.Logger.Error("milestone tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+		return fmt.Errorf("milestone tx failed, tx response code: %v", txRes.Code)
+
+	}
 	return nil
 }
 
@@ -270,9 +277,15 @@ func (mp *MilestoneProcessor) createAndSendMilestoneTimeoutToHeimdall() error {
 	)
 
 	// return broadcast to heimdall
-	if err := mp.txBroadcaster.BroadcastToHeimdall(msg, nil); err != nil {
+	txRes, err := mp.txBroadcaster.BroadcastToHeimdall(msg, nil)
+	if err != nil {
 		mp.Logger.Error("Error while broadcasting milestone timeout to heimdall", "error", err)
 		return err
+	}
+
+	if txRes.Code != uint32(sdk.CodeOK) {
+		mp.Logger.Error("milestone timeout tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+		return fmt.Errorf("milestone timeout tx failed, tx response code: %v", txRes.Code)
 	}
 
 	return nil

--- a/bridge/setu/processor/processor_test.go
+++ b/bridge/setu/processor/processor_test.go
@@ -86,7 +86,7 @@ func TestBroadcastWhenTxInMempool(t *testing.T) {
 			assert.Equal(t, inMempool, expectedStatus[index])
 			if !inMempool {
 				t.Log("Tx not in mempool, broadcasting")
-				err = _txBroadcaster.BroadcastToHeimdall(tx, nil)
+				_, err := _txBroadcaster.BroadcastToHeimdall(tx, nil)
 				assert.Empty(t, err, "Error broadcasting tx to heimdall", err)
 			} else {
 				t.Log("Tx is already in mempool, not broadcasting")

--- a/bridge/setu/processor/span.go
+++ b/bridge/setu/processor/span.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -123,9 +124,16 @@ func (sp *SpanProcessor) propose(lastSpan *types.Span, nextSpanMsg *types.Span) 
 		}
 
 		// return broadcast to heimdall
-		if err := sp.txBroadcaster.BroadcastToHeimdall(msg, nil); err != nil {
+		txRes, err := sp.txBroadcaster.BroadcastToHeimdall(msg, nil)
+		if err != nil {
 			sp.Logger.Error("Error while broadcasting span to heimdall", "spanId", nextSpanMsg.ID, "startBlock", nextSpanMsg.StartBlock, "endBlock", nextSpanMsg.EndBlock, "error", err)
 			return
+		}
+
+		if txRes.Code != uint32(sdk.CodeOK) {
+			sp.Logger.Error("span tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+			return
+
 		}
 	}
 }

--- a/bridge/setu/processor/staking.go
+++ b/bridge/setu/processor/staking.go
@@ -132,9 +132,16 @@ func (sp *StakingProcessor) sendValidatorJoinToHeimdall(eventName string, logByt
 		)
 
 		// return broadcast to heimdall
-		if err := sp.txBroadcaster.BroadcastToHeimdall(msg, event); err != nil {
+		txRes, err := sp.txBroadcaster.BroadcastToHeimdall(msg, event)
+		if err != nil {
 			sp.Logger.Error("Error while broadcasting unstakeInit to heimdall", "validatorId", event.ValidatorId.Uint64(), "error", err)
 			return err
+		}
+
+		if txRes.Code != uint32(sdk.CodeOK) {
+			sp.Logger.Error("validator-join tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+			return fmt.Errorf("validator-join tx failed, tx response code: %v", txRes.Code)
+
 		}
 	}
 
@@ -203,9 +210,16 @@ func (sp *StakingProcessor) sendUnstakeInitToHeimdall(eventName string, logBytes
 		)
 
 		// return broadcast to heimdall
-		if err := sp.txBroadcaster.BroadcastToHeimdall(msg, event); err != nil {
+		txRes, err := sp.txBroadcaster.BroadcastToHeimdall(msg, event)
+		if err != nil {
 			sp.Logger.Error("Error while broadcasting unstakeInit to heimdall", "validatorId", event.ValidatorId.Uint64(), "error", err)
 			return err
+		}
+
+		if txRes.Code != uint32(sdk.CodeOK) {
+			sp.Logger.Error("unstakeInit tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+			return fmt.Errorf("unstakeInit tx failed, tx response code: %v", txRes.Code)
+
 		}
 	}
 
@@ -270,9 +284,15 @@ func (sp *StakingProcessor) sendStakeUpdateToHeimdall(eventName string, logBytes
 		)
 
 		// return broadcast to heimdall
-		if err := sp.txBroadcaster.BroadcastToHeimdall(msg, event); err != nil {
+		txRes, err := sp.txBroadcaster.BroadcastToHeimdall(msg, event)
+		if err != nil {
 			sp.Logger.Error("Error while broadcasting stakeupdate to heimdall", "validatorId", event.ValidatorId.Uint64(), "error", err)
 			return err
+		}
+
+		if txRes.Code != uint32(sdk.CodeOK) {
+			sp.Logger.Error("stakeupdate tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+			return fmt.Errorf("stakeupdate tx failed, tx response code: %v", txRes.Code)
 		}
 	}
 
@@ -346,9 +366,15 @@ func (sp *StakingProcessor) sendSignerChangeToHeimdall(eventName string, logByte
 		)
 
 		// return broadcast to heimdall
-		if err := sp.txBroadcaster.BroadcastToHeimdall(msg, event); err != nil {
+		txRes, err := sp.txBroadcaster.BroadcastToHeimdall(msg, event)
+		if err != nil {
 			sp.Logger.Error("Error while broadcasting signerChainge to heimdall", "msg", msg, "validatorId", event.ValidatorId.Uint64(), "error", err)
 			return err
+		}
+
+		if txRes.Code != uint32(sdk.CodeOK) {
+			sp.Logger.Error("signerChange tx failed on heimdall", "txHash", txRes.TxHash, "code", txRes.Code)
+			return fmt.Errorf("signerChange tx failed, tx response code: %v", txRes.Code)
 		}
 	}
 

--- a/helper/config.go
+++ b/helper/config.go
@@ -470,6 +470,18 @@ func SetTestConfig(_conf Configuration) {
 	conf = _conf
 }
 
+// TEST PURPOSE ONLY
+// SetTestPrivPubKey sets test priv and pub key for testing
+func SetTestPrivPubKey(privKey secp256k1.PrivKeySecp256k1) {
+	privObject = privKey
+	privObject.PubKey()
+	pubKey, ok := privObject.PubKey().(secp256k1.PubKeySecp256k1)
+	if !ok {
+		panic("pub key is not of type secp256k1.PubKeySecp256k1")
+	}
+	pubObject = pubKey
+}
+
 //
 // Get main/matic clients
 //

--- a/helper/test_helpers.go
+++ b/helper/test_helpers.go
@@ -1,0 +1,33 @@
+package helper
+
+import (
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+type TestOpts struct {
+	app     abci.Application
+	chainId string
+}
+
+func NewTestOpts(app abci.Application, chainId string) *TestOpts {
+	return &TestOpts{
+		app:     app,
+		chainId: chainId,
+	}
+}
+
+func (t *TestOpts) SetApplication(app abci.Application) {
+	t.app = app
+}
+
+func (t *TestOpts) GetApplication() abci.Application {
+	return t.app
+}
+
+func (t *TestOpts) SetChainId(chainId string) {
+	t.chainId = chainId
+}
+
+func (t *TestOpts) GetChainId() string {
+	return t.chainId
+}

--- a/helper/util.go
+++ b/helper/util.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/crypto/tmhash"
+	"github.com/tendermint/tendermint/rpc/client/mock"
 	tmTypes "github.com/tendermint/tendermint/types"
 
 	authTypes "github.com/maticnetwork/heimdall/auth/types"
@@ -304,14 +305,27 @@ func BroadcastMsgsWithCLI(cliCtx context.CLIContext, msgs []sdk.Msg) error {
 }
 
 // BuildAndBroadcastMsgs creates transaction and broadcasts it
-func BuildAndBroadcastMsgs(cliCtx context.CLIContext, txBldr authTypes.TxBuilder, msgs []sdk.Msg) (sdk.TxResponse, error) {
-	txBytes, err := GetSignedTxBytes(cliCtx, txBldr, msgs)
+func BuildAndBroadcastMsgs(cliCtx context.CLIContext,
+	txBldr authTypes.TxBuilder,
+	msgs []sdk.Msg,
+	testOpts ...*TestOpts,
+) (sdk.TxResponse, error) {
+	txBytes, err := GetSignedTxBytes(cliCtx, txBldr, msgs, testOpts...)
 	if err != nil {
 		return sdk.TxResponse{}, err
 	}
 	// just simulate
 	if cliCtx.Simulate {
-		return sdk.TxResponse{TxHash: "0x" + hex.EncodeToString(txBytes)}, nil
+		if len(testOpts) == 0 || testOpts[0].app == nil {
+			return sdk.TxResponse{TxHash: "0x" + hex.EncodeToString(txBytes)}, nil
+		}
+
+		m := mock.ABCIApp{
+			App: testOpts[0].app,
+		}
+
+		res, err := m.BroadcastTxSync(txBytes)
+		return sdk.NewResponseFormatBroadcastTx(res), err
 	}
 	// broadcast to a Tendermint node
 	return BroadcastTxBytes(cliCtx, txBytes, "")
@@ -344,10 +358,18 @@ func BuildAndBroadcastMsgsWithCLI(cliCtx context.CLIContext, txBldr authTypes.Tx
 }
 
 // GetSignedTxBytes returns signed tx bytes
-func GetSignedTxBytes(cliCtx context.CLIContext, txBldr authTypes.TxBuilder, msgs []sdk.Msg) ([]byte, error) {
+func GetSignedTxBytes(cliCtx context.CLIContext,
+	txBldr authTypes.TxBuilder,
+	msgs []sdk.Msg,
+	testOpts ...*TestOpts,
+) ([]byte, error) {
 	// just simulate (useful for testing)
 	if cliCtx.Simulate {
-		return nil, nil
+		if len(testOpts) == 0 || testOpts[0].chainId == "" {
+			return nil, nil
+		}
+		txBldr := txBldr.WithChainID(testOpts[0].chainId)
+		return txBldr.BuildAndSign(GetPrivKey(), msgs)
 	}
 
 	txBldr, err := PrepareTxBuilder(cliCtx, txBldr)

--- a/helper/util.go
+++ b/helper/util.go
@@ -368,7 +368,7 @@ func GetSignedTxBytes(cliCtx context.CLIContext,
 		if len(testOpts) == 0 || testOpts[0].chainId == "" {
 			return nil, nil
 		}
-		txBldr := txBldr.WithChainID(testOpts[0].chainId)
+		txBldr = txBldr.WithChainID(testOpts[0].chainId)
 		return txBldr.BuildAndSign(GetPrivKey(), msgs)
 	}
 


### PR DESCRIPTION
# Description

The job of the `broadcaster` component is, as the name suggests, to broadcast txs to tendermint. The ante handler is executed during `checkTx` (invoked by tendermint) and enforces some sanity checks on the tx sent (ensuring enough balance, correct signature, etc.) and at successful verification, increments the account sequence (akin to nonce). 
If any of the checks were to fail, the appropriate error code is baked in `sdk.TxResponse`.

Currently, the `broadcaster` doesn't account for a failed sanity clause (and only checks for errors that pop up _during_ the broadcast itself). This results in an incorrect increment of the bridge's "cached" account sequence and hence causes mismatch with the DB. This PR aims to fix this. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli

