### PR TITLE
bor: increase max limit for list span api

### DIFF
--- a/bor/keeper.go
+++ b/bor/keeper.go
@@ -19,6 +19,8 @@ import (
 	hmTypes "github.com/maticnetwork/heimdall/types"
 )
 
+const maxSpanListLimit = 150 // a span is ~6 KB => we can fit 150 spans in 1 MB response
+
 var (
 	LastSpanIDKey         = []byte{0x35} // Key to store last span start block
 	SpanPrefixKey         = []byte{0x36} // prefix key to store span
@@ -153,8 +155,8 @@ func (k *Keeper) GetSpanList(ctx sdk.Context, page uint64, limit uint64) ([]hmTy
 	store := ctx.KVStore(k.storeKey)
 
 	// have max limit
-	if limit > 20 {
-		limit = 20
+	if limit > maxSpanListLimit {
+		limit = maxSpanListLimit
 	}
 
 	// get paginated iterator


### PR DESCRIPTION
# Description

The max limit of spans/list api is set to 20 which is very small. Currently each span is around 6 KB, we can fit ~160 in a 1 MB response size. This PR sets the limit to 150 to account for future span size growth. 

Context: Erigon would like to efficiently fetch spans from heimdall for an improved initial sync mechanism. We would like to batch fetch spans cut down the number of requests sent to the heimdall service.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

```
➜  ~ curl 'http://localhost:1317/bor/span/list?page=1&limit=10' | jq | grep "span_id" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  132k    0  132k    0     0   173k      0 --:--:-- --:--:-- --:--:--  173k
      10
➜  ~ curl 'http://localhost:1317/bor/span/list?page=1&limit=150' | jq | grep "span_id" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2830k    0 2830k    0     0  12.7M      0 --:--:-- --:--:-- --:--:-- 12.7M
     150
➜  ~ curl 'http://localhost:1317/bor/span/list?page=1&limit=200' | jq | grep "span_id" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2830k    0 2830k    0     0  18.6M      0 --:--:-- --:--:-- --:--:-- 18.6M
     150
```