### PR TITLE
Return checkpoint IDs in `checkpoints/list`

### DIFF
--- a/checkpoint/client/rest/query.go
+++ b/checkpoint/client/rest/query.go
@@ -640,7 +640,7 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		checkpointWithID := &CheckpointWithID{
+		checkpointWithID := &hmTypes.CheckpointWithID{
 			ID:         ackCount,
 			Proposer:   checkpointUnmarshal.Proposer,
 			StartBlock: checkpointUnmarshal.StartBlock,
@@ -663,17 +663,6 @@ func latestCheckpointHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 		cliCtx = cliCtx.WithHeight(height)
 		rest.PostProcessResponse(w, cliCtx, resWithID)
 	}
-}
-
-// Temporary Checkpoint struct to store the Checkpoint ID
-type CheckpointWithID struct {
-	ID         uint64                  `json:"id"`
-	Proposer   hmTypes.HeimdallAddress `json:"proposer"`
-	StartBlock uint64                  `json:"start_block"`
-	EndBlock   uint64                  `json:"end_block"`
-	RootHash   hmTypes.HeimdallHash    `json:"root_hash"`
-	BorChainID string                  `json:"bor_chain_id"`
-	TimeStamp  uint64                  `json:"timestamp"`
 }
 
 //swagger:parameters checkpointById
@@ -726,7 +715,7 @@ func checkpointByNumberHandlerFunc(cliCtx context.CLIContext) http.HandlerFunc {
 			return
 		}
 
-		checkpointWithID := &CheckpointWithID{
+		checkpointWithID := &hmTypes.CheckpointWithID{
 			ID:         number,
 			Proposer:   checkpointUnmarshal.Proposer,
 			StartBlock: checkpointUnmarshal.StartBlock,

--- a/checkpoint/keeper.go
+++ b/checkpoint/keeper.go
@@ -140,11 +140,11 @@ func (k *Keeper) GetCheckpointByNumber(ctx sdk.Context, number uint64) (hmTypes.
 }
 
 // GetCheckpointList returns all checkpoints with params like page and limit
-func (k *Keeper) GetCheckpointList(ctx sdk.Context, page uint64, limit uint64) ([]hmTypes.Checkpoint, error) {
+func (k *Keeper) GetCheckpointList(ctx sdk.Context, page uint64, limit uint64) ([]hmTypes.CheckpointWithID, error) {
 	store := ctx.KVStore(k.storeKey)
 
 	// create headers
-	var checkpoints []hmTypes.Checkpoint
+	var checkpoints []hmTypes.CheckpointWithID
 
 	// have max limit
 	if limit > maxCheckpointListLimit {
@@ -158,7 +158,22 @@ func (k *Keeper) GetCheckpointList(ctx sdk.Context, page uint64, limit uint64) (
 	for ; iterator.Valid(); iterator.Next() {
 		var checkpoint hmTypes.Checkpoint
 		if err := k.cdc.UnmarshalBinaryBare(iterator.Value(), &checkpoint); err == nil {
-			checkpoints = append(checkpoints, checkpoint)
+			id, err := strconv.Atoi(string(iterator.Key()[1:]))
+			if err != nil {
+				continue
+			}
+
+			checkpointWithID := hmTypes.CheckpointWithID{
+				ID:         uint64(id),
+				Proposer:   checkpoint.Proposer,
+				StartBlock: checkpoint.StartBlock,
+				EndBlock:   checkpoint.EndBlock,
+				RootHash:   checkpoint.RootHash,
+				BorChainID: checkpoint.BorChainID,
+				TimeStamp:  checkpoint.TimeStamp,
+			}
+
+			checkpoints = append(checkpoints, checkpointWithID)
 		}
 	}
 

--- a/checkpoint/keeper.go
+++ b/checkpoint/keeper.go
@@ -158,13 +158,13 @@ func (k *Keeper) GetCheckpointList(ctx sdk.Context, page uint64, limit uint64) (
 	for ; iterator.Valid(); iterator.Next() {
 		var checkpoint hmTypes.Checkpoint
 		if err := k.cdc.UnmarshalBinaryBare(iterator.Value(), &checkpoint); err == nil {
-			id, err := strconv.Atoi(string(iterator.Key()[1:]))
+			id, err := strconv.ParseUint(string(iterator.Key()[1:]), 10, 64)
 			if err != nil {
 				continue
 			}
 
 			checkpointWithID := hmTypes.CheckpointWithID{
-				ID:         uint64(id),
+				ID:         id,
 				Proposer:   checkpoint.Proposer,
 				StartBlock: checkpoint.StartBlock,
 				EndBlock:   checkpoint.EndBlock,

--- a/checkpoint/keeper.go
+++ b/checkpoint/keeper.go
@@ -158,7 +158,7 @@ func (k *Keeper) GetCheckpointList(ctx sdk.Context, page uint64, limit uint64) (
 	for ; iterator.Valid(); iterator.Next() {
 		var checkpoint hmTypes.Checkpoint
 		if err := k.cdc.UnmarshalBinaryBare(iterator.Value(), &checkpoint); err == nil {
-			id, err := strconv.ParseUint(string(iterator.Key()[1:]), 10, 64)
+			id, err := GetCheckpointIDFromKey(iterator.Key())
 			if err != nil {
 				continue
 			}
@@ -210,6 +210,11 @@ func (k *Keeper) GetLastCheckpoint(ctx sdk.Context) (hmTypes.Checkpoint, error) 
 func GetCheckpointKey(checkpointNumber uint64) []byte {
 	checkpointNumberBytes := []byte(strconv.FormatUint(checkpointNumber, 10))
 	return append(CheckpointKey, checkpointNumberBytes...)
+}
+
+// GetCheckpointIDFromKey get the checkpoint ID from the DB key
+func GetCheckpointIDFromKey(key []byte) (uint64, error) {
+	return strconv.ParseUint(string(key[1:]), 10, 64)
 }
 
 // HasStoreValue check if value exists in store or not

--- a/checkpoint/keeper_test.go
+++ b/checkpoint/keeper_test.go
@@ -100,6 +100,10 @@ func (suite *KeeperTestSuite) TestGetCheckpointList() {
 	result, err := keeper.GetCheckpointList(ctx, uint64(1), uint64(20))
 	require.NoError(t, err)
 	require.LessOrEqual(t, count, len(result))
+
+	for i := range count {
+		require.Equal(t, uint64(i+1), result[i].ID)
+	}
 }
 
 func (suite *KeeperTestSuite) TestHasStoreValue() {

--- a/types/header.go
+++ b/types/header.go
@@ -15,6 +15,16 @@ type Checkpoint struct {
 	TimeStamp  uint64          `json:"timestamp"`
 }
 
+type CheckpointWithID struct {
+	ID         uint64          `json:"id"`
+	Proposer   HeimdallAddress `json:"proposer"`
+	StartBlock uint64          `json:"start_block"`
+	EndBlock   uint64          `json:"end_block"`
+	RootHash   HeimdallHash    `json:"root_hash"`
+	BorChainID string          `json:"bor_chain_id"`
+	TimeStamp  uint64          `json:"timestamp"`
+}
+
 // Milestone block header struct
 type Milestone struct {
 	Proposer    HeimdallAddress `json:"proposer"`


### PR DESCRIPTION
# Description

Return checkpoint IDs in `checkpoints/list` similar to `checkpoint/{number}`. In Erigon at the moment, we have to infer the checkpoint ID by checking its index in a sorted list of checkpoints. Returning the checkpoint ID will let us rely on Heimdall's IDs and reduce the chance of any discrepancies.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [x] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

```
curl -s http://localhost:1317/checkpoints/list\?page\=1\&limit\=5 | jq
{
  "height": "4449411",
  "result": [
    {
      "id": 1,
      "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
      "start_block": 0,
      "end_block": 114,
      "root_hash": "0x767b9ed2c10b2aaf7d39df9a1142b9de3a4e246db5c28fe2697ed2e92cf4a061",
      "bor_chain_id": "80002",
      "timestamp": 1700396194
    },
    {
      "id": 10,
      "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
      "start_block": 4979,
      "end_block": 5746,
      "root_hash": "0x3d1715ce689ac4d27683efd775198b8369d0f625e051562b8727e6056c6c33cb",
      "bor_chain_id": "80002",
      "timestamp": 1700408441
    },
    {
      "id": 100,
      "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
      "start_block": 94579,
      "end_block": 95346,
      "root_hash": "0x7c85b133d23ef1f504c154dd0e1b5940829bf2b4070dc99c54037c0d84e87b3a",
      "bor_chain_id": "80002",
      "timestamp": 1700598942
    },
    {
      "id": 1000,
      "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
      "start_block": 988531,
      "end_block": 989554,
      "root_hash": "0x272b4e4593d5fb4f4784b19ae010d930470b26db5b2907f15af53c7463236fe3",
      "bor_chain_id": "80002",
      "timestamp": 1704308393
    },
    {
      "id": 1001,
      "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
      "start_block": 989555,
      "end_block": 990578,
      "root_hash": "0x3d2c446fd7cd45ed941738d62f45d006c5b10674ba784e471e38974e28e49885",
      "bor_chain_id": "80002",
      "timestamp": 1704309293
    }
  ]
}
```
The checkpoints were matched to the ones returned by `checkpoint/{number}`.

```
for i in 1 10 100 1000 1001; do
  curl -s http://localhost:1317/checkpoints/$i | jq
done
{
  "height": "4449440",
  "result": {
    "id": 1,
    "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
    "start_block": 0,
    "end_block": 114,
    "root_hash": "0x767b9ed2c10b2aaf7d39df9a1142b9de3a4e246db5c28fe2697ed2e92cf4a061",
    "bor_chain_id": "80002",
    "timestamp": 1700396194
  }
}
{
  "height": "4449440",
  "result": {
    "id": 10,
    "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
    "start_block": 4979,
    "end_block": 5746,
    "root_hash": "0x3d1715ce689ac4d27683efd775198b8369d0f625e051562b8727e6056c6c33cb",
    "bor_chain_id": "80002",
    "timestamp": 1700408441
  }
}
{
  "height": "4449440",
  "result": {
    "id": 100,
    "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
    "start_block": 94579,
    "end_block": 95346,
    "root_hash": "0x7c85b133d23ef1f504c154dd0e1b5940829bf2b4070dc99c54037c0d84e87b3a",
    "bor_chain_id": "80002",
    "timestamp": 1700598942
  }
}
{
  "height": "4449440",
  "result": {
    "id": 1000,
    "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
    "start_block": 988531,
    "end_block": 989554,
    "root_hash": "0x272b4e4593d5fb4f4784b19ae010d930470b26db5b2907f15af53c7463236fe3",
    "bor_chain_id": "80002",
    "timestamp": 1704308393
  }
}
{
  "height": "4449440",
  "result": {
    "id": 1001,
    "proposer": "0x6ab3d36c46ecfb9b9c0bd51cb1c3da5a2c81cea6",
    "start_block": 989555,
    "end_block": 990578,
    "root_hash": "0x3d2c446fd7cd45ed941738d62f45d006c5b10674ba784e471e38974e28e49885",
    "bor_chain_id": "80002",
    "timestamp": 1704309293
  }
}
```
