### PR TITLE
Fix DefaultBorGRPCUrl

### DIFF
--- a/helper/config.go
+++ b/helper/config.go
@@ -83,7 +83,7 @@ const (
 	// RPC Endpoints
 	DefaultMainRPCUrl = "http://localhost:9545"
 	DefaultBorRPCUrl  = "http://localhost:8545"
-	DefaultBorGRPCUrl = "http://localhost:3131"
+	DefaultBorGRPCUrl = "localhost:3131"
 
 	// RPC Timeouts
 	DefaultEthRPCTimeout = 5 * time.Second


### PR DESCRIPTION
# Description

Fixes the `DefaultBorGRPCUrl`, just for clarity, since it would work anyway considered the `removePrefix` function.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply