### PR TITLE
Fix gRPC test due to new hencoding

### DIFF
--- a/bor/client/grpc/grpc_util_test.go
+++ b/bor/client/grpc/grpc_util_test.go
@@ -23,12 +23,12 @@ func TestToBlockNumArg(t *testing.T) {
 		{
 			name:     "Positive number",
 			input:    big.NewInt(12345),
-			expected: "12345",
+			expected: "0x3039",
 		},
 		{
 			name:     "Zero",
 			input:    big.NewInt(0),
-			expected: "0",
+			expected: "0x0",
 		},
 		{
 			name:     "Negative number",


### PR DESCRIPTION
# Description

This PR fixes a `gRPC` which is failing due to the switch from decimal to `hex` encoding/decoding.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli