### PR TITLE
chore: Remove usage of Mumbai from README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,7 +37,7 @@ In case this PR includes changes that must be applied only to a subset of nodes,
 - [ ] I have added tests to CI
 - [ ] I have tested this code manually on local environment
 - [ ] I have tested this code manually on remote devnet using express-cli
-- [ ] I have tested this code manually on mumbai or amoy
+- [ ] I have tested this code manually on amoy
 - [ ] I have created new e2e tests into express-cli
 
 ### Manual tests

--- a/README.md
+++ b/README.md
@@ -1,46 +1,52 @@
 # Heimdall
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/maticnetwork/heimdall)](https://goreportcard.com/report/github.com/maticnetwork/heimdall) [![CircleCI](https://circleci.com/gh/maticnetwork/heimdall/tree/master.svg?style=shield)](https://circleci.com/gh/maticnetwork/heimdall/tree/master) [![GolangCI](https://golangci.com/badges/github.com/maticnetwork/heimdall.svg)](https://golangci.com/r/github.com/maticnetwork/heimdall)
-
+[![Go Report Card](https://goreportcard.com/badge/github.com/maticnetwork/heimdall)](https://goreportcard.com/report/github.com/maticnetwork/heimdall) [![CircleCI](https://circleci.com/gh/maticnetwork/heimdall/tree/master.svg?style=shield)](https://circleci.com/gh/maticnetwork/heimdall/tree/master) [![GolangCI Lint](https://github.com/maticnetwork/heimdall/actions/workflows/ci.yml/badge.svg)](https://github.com/maticnetwork/heimdall/actions)
 
 Validator node for Matic Network. It uses peppermint, customized [Tendermint](https://github.com/tendermint/tendermint).
 
-### Install from source 
+### Install from source
 
-Make sure you have go1.11+ already installed
+Make sure you have Go v1.20+ already installed.
 
-### Install 
-```bash 
+### Install
+
+```bash
 $ make install
 ```
-### Init-heimdall 
-```bash 
+
+### Init Heimdall
+
+```bash
 $ heimdalld init
 $ heimdalld init --chain=mainnet        Will init with genesis.json for mainnet
-$ heimdalld init --chain=mumbai         Will init with genesis.json for mumbai
 $ heimdalld init --chain=amoy           Will init with genesis.json for amoy
 ```
-### Run-heimdall 
-```bash 
+
+### Run Heimdall
+
+```bash
 $ heimdalld start
 ```
+
 #### Usage
-```
+
+```bash
 $ heimdalld start                       Will start for mainnet by default
 $ heimdalld start --chain=mainnet       Will start for mainnet
-$ heimdalld start --chain=mumbai        Will start for mumbai
 $ heimdalld start --chain=amoy          Will start for amoy
 $ heimdalld start --chain=local         Will start for local with NewSelectionAlgoHeight = 0
 ```
 
 ### Run rest server
-```bash 
-$ heimdalld rest-server 
+
+```bash
+$ heimdalld rest-server
 ```
 
 ### Run bridge
-```bash 
-$ heimdalld bridge 
+
+```bash
+$ heimdalld bridge
 ```
 
 ### Develop using Docker
@@ -52,6 +58,6 @@ docker build -t heimdall .
 docker run heimdall
 ```
 
-### Documentation 
+### Documentation
 
-Latest docs are [here](https://wiki.polygon.technology/docs/category/heimdall) 
+Latest docs are [here](https://docs.polygon.technology/pos/).


### PR DESCRIPTION
Removes usage of Mumbai from README and backports `master` branch.