### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/helper/call.go
+++ b/helper/call.go
@@ -893,7 +893,7 @@ func (c *ContractCaller) GetSpanDetails(id *big.Int, validatorSetInstance *valid
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return d.Number, d.StartBlock, d.EndBlock, err
+	return d.Number, d.StartBlock, d.EndBlock, nil
 }
 
 // CurrentStateCounter get state counter

--- a/slashing/types/infohash.go
+++ b/slashing/types/infohash.go
@@ -63,7 +63,7 @@ func slashInfoToModified(slashInfo *hmTypes.ValidatorSlashingInfo) (modifiedSlas
 		IsJailed:      jailedByte,
 	}
 
-	return modifiedSlashInfo, err
+	return modifiedSlashInfo, nil
 }
 
 func RLPDecodeSlashInfos(encodedSlashInfo []byte) ([]*hmTypes.ValidatorSlashingInfo, error) {
@@ -105,5 +105,5 @@ func modifiedToSlashInfo(modifiedSlashInfo *ModifiedSlashInfo) (slashInfo *hmTyp
 		IsJailed:      jailedBool,
 	}
 
-	return slashInfo, err
+	return slashInfo, nil
 }


### PR DESCRIPTION
# Description

Since we have already checked err before and returned when err != nil, err must be nil here.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [x] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

# Cross repository changes

- [ ] This PR requires changes to bor 
  - In case link the PR here:
- [ ] This PR requires changes to matic-cli
  - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
