### PR TITLE
make genesis export deterministic

### DIFF
--- a/cmd/heimdallcli/main.go
+++ b/cmd/heimdallcli/main.go
@@ -33,7 +33,6 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/libs/cli"
-	"github.com/tendermint/tendermint/libs/common"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/privval"
 	tmTypes "github.com/tendermint/tendermint/types"
@@ -356,7 +355,6 @@ func generateMarshalledAppState(happ *app.HeimdallApp, chainID, genesisTime stri
 	}
 
 	consensusParams := tmTypes.DefaultConsensusParams()
-	genesisTime := time.Now().UTC().Format(time.RFC3339Nano)
 
 	consensusParamsData, err := tmTypes.GetCodec().MarshalJSON(consensusParams)
 	if err != nil {

--- a/cmd/heimdallcli/main.go
+++ b/cmd/heimdallcli/main.go
@@ -265,6 +265,10 @@ func exportCmd(ctx *server.Context, _ *codec.Codec) *cobra.Command {
 		"heimdall-80002 (for amoy), "+
 		"devnet (for any local devnet)")
 
+	// Make flags required
+	_ = cmd.MarkFlagRequired(cli.HomeFlag)
+	_ = cmd.MarkFlagRequired(client.FlagChainID)
+
 	return cmd
 }
 

--- a/cmd/heimdallcli/main.go
+++ b/cmd/heimdallcli/main.go
@@ -209,16 +209,10 @@ func exportCmd(ctx *server.Context, _ *codec.Codec) *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 
 			config := ctx.Config
-			if viper.GetString(cli.HomeFlag) == "" {
-				panic("home flag is not set")
-			}
 			config.SetRoot(viper.GetString(cli.HomeFlag))
 
 			// create chain id and genesis time
 			chainID := viper.GetString(client.FlagChainID)
-			if chainID == "" {
-				panic("chain-id flag is not set")
-			}
 
 			genesisTimes := map[string]string{
 				"heimdall-137":   "2020-05-30T04:28:03.177054Z",    // mainnet

--- a/cmd/heimdallcli/main_test.go
+++ b/cmd/heimdallcli/main_test.go
@@ -38,7 +38,7 @@ func TestModulesStreamedGenesisExport(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	err = generateMarshalledAppState(happ, "test-chain", 2, &buf)
+	err = generateMarshalledAppState(happ, "test-chain", "", 2, &buf)
 	require.NoError(t, err)
 
 	marshaledAppState := buf.Bytes()


### PR DESCRIPTION
# Description

Fix the genesis export command by making it deterministic.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on mumbai or amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
