### PR TITLE
Prevent checkpoint submission prior to the apocalypse

### DIFF
--- a/bridge/setu/listener/rootchain_log.go
+++ b/bridge/setu/listener/rootchain_log.go
@@ -44,11 +44,12 @@ func (rl *RootChainListener) handleNewHeaderBlockLog(vLog types.Log, selectedEve
 	logBytes, err := jsoniter.ConfigFastest.Marshal(vLog)
 	if err != nil {
 		rl.Logger.Error("Failed to marshal log", "Error", err)
+		return
 	}
 
-	if isCurrentValidator, delay := util.CalculateTaskDelay(rl.cliCtx, selectedEvent); isCurrentValidator {
-		rl.SendTaskWithDelay("sendCheckpointAckToHeimdall", selectedEvent.Name, logBytes, delay, selectedEvent)
-	}
+	_, delay := util.CalculateTaskDelay(rl.cliCtx, selectedEvent)
+	rl.SendTaskWithDelay("sendCheckpointAckToHeimdall", selectedEvent.Name, logBytes, delay, selectedEvent)
+
 }
 
 func (rl *RootChainListener) handleStakedLog(vLog types.Log, selectedEvent *abi.Event) {

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -109,6 +109,16 @@ func (cp *CheckpointProcessor) startPollingForNoAck(ctx context.Context, interva
 // 2. check if checkpoint has to be proposed for given headerblock
 // 3. if so, propose checkpoint to heimdall.
 func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (err error) {
+	status, err := helper.GetNodeStatus(cp.cliCtx)
+	if err != nil {
+		return err
+	}
+
+	if status.SyncInfo.LatestBlockHeight >= helper.GetCheckpointHaltHeight() {
+		cp.Logger.Info("Halting checkpoint submission prior to apocalypse", "latestBlockHeight", status.SyncInfo.LatestBlockHeight)
+		return nil
+	}
+
 	var header = types.Header{}
 	if err = header.UnmarshalJSON([]byte(headerBlockStr)); err != nil {
 		cp.Logger.Error("Error while unmarshalling the header block", "error", err)

--- a/bridge/setu/processor/checkpoint.go
+++ b/bridge/setu/processor/checkpoint.go
@@ -115,7 +115,7 @@ func (cp *CheckpointProcessor) sendCheckpointToHeimdall(headerBlockStr string) (
 	}
 
 	if status.SyncInfo.LatestBlockHeight >= helper.GetCheckpointHaltHeight() {
-		cp.Logger.Info("Halting checkpoint submission prior to apocalypse", "latestBlockHeight", status.SyncInfo.LatestBlockHeight)
+		cp.Logger.Info("Halting checkpoint submission prior to apocalypse height", "latestBlockHeight", status.SyncInfo.LatestBlockHeight)
 		return nil
 	}
 

--- a/checkpoint/handler.go
+++ b/checkpoint/handler.go
@@ -80,7 +80,7 @@ func handleMsgCheckpoint(ctx sdk.Context, msg types.MsgCheckpoint, k Keeper, _ h
 	logger := k.Logger(ctx)
 
 	if ctx.BlockHeight() >= helper.GetCheckpointHaltHeight() {
-		logger.Error("Checkpoints not allowed 300 blocks prior to apocalypse hardfork")
+		logger.Error("Halting checkpoint submission prior to apocalypse height")
 		return common.ErrCheckpointNotAllowed(k.Codespace()).Result()
 
 	}

--- a/checkpoint/handler.go
+++ b/checkpoint/handler.go
@@ -79,6 +79,12 @@ func handleMsgCheckpointAdjust(ctx sdk.Context, msg types.MsgCheckpointAdjust, k
 func handleMsgCheckpoint(ctx sdk.Context, msg types.MsgCheckpoint, k Keeper, _ helper.IContractCaller) sdk.Result {
 	logger := k.Logger(ctx)
 
+	if ctx.BlockHeight() >= helper.GetApocalypseHeight()-300 {
+		logger.Error("Checkpoints not allowed 300 blocks prior to apocalypse hardfork")
+		return common.ErrCheckpointNotAllowed(k.Codespace()).Result()
+
+	}
+
 	//nolint:gosec
 	timeStamp := uint64(ctx.BlockTime().Unix())
 	params := k.GetParams(ctx)

--- a/checkpoint/handler.go
+++ b/checkpoint/handler.go
@@ -79,7 +79,7 @@ func handleMsgCheckpointAdjust(ctx sdk.Context, msg types.MsgCheckpointAdjust, k
 func handleMsgCheckpoint(ctx sdk.Context, msg types.MsgCheckpoint, k Keeper, _ helper.IContractCaller) sdk.Result {
 	logger := k.Logger(ctx)
 
-	if ctx.BlockHeight() >= helper.GetApocalypseHeight()-300 {
+	if ctx.BlockHeight() >= helper.GetCheckpointHaltHeight() {
 		logger.Error("Checkpoints not allowed 300 blocks prior to apocalypse hardfork")
 		return common.ErrCheckpointNotAllowed(k.Codespace()).Result()
 

--- a/checkpoint/side_handler.go
+++ b/checkpoint/side_handler.go
@@ -95,7 +95,7 @@ func SideHandleMsgCheckpointAdjust(ctx sdk.Context, k Keeper, msg types.MsgCheck
 func SideHandleMsgCheckpoint(ctx sdk.Context, k Keeper, msg types.MsgCheckpoint, contractCaller helper.IContractCaller) (result abci.ResponseDeliverSideTx) {
 	// logger
 	logger := k.Logger(ctx)
-	if ctx.BlockHeight() >= helper.GetApocalypseHeight()-300 {
+	if ctx.BlockHeight() >= helper.GetCheckpointHaltHeight() {
 		logger.Error("Checkpoints not allowed 300 blocks prior to apocalypse hardfork")
 		result.Result = abci.SideTxResultType_No
 		return
@@ -281,7 +281,7 @@ func PostHandleMsgCheckpointAdjust(ctx sdk.Context, k Keeper, msg types.MsgCheck
 func PostHandleMsgCheckpoint(ctx sdk.Context, k Keeper, msg types.MsgCheckpoint, sideTxResult abci.SideTxResultType) sdk.Result {
 	logger := k.Logger(ctx)
 
-	if ctx.BlockHeight() >= helper.GetApocalypseHeight()-300 {
+	if ctx.BlockHeight() >= helper.GetCheckpointHaltHeight() {
 		logger.Error("Checkpoints not allowed 300 blocks prior to apocalypse hardfork")
 		return common.ErrCheckpointNotAllowed(k.Codespace()).Result()
 

--- a/checkpoint/side_handler.go
+++ b/checkpoint/side_handler.go
@@ -93,10 +93,9 @@ func SideHandleMsgCheckpointAdjust(ctx sdk.Context, k Keeper, msg types.MsgCheck
 
 // SideHandleMsgCheckpoint handles MsgCheckpoint message for external call
 func SideHandleMsgCheckpoint(ctx sdk.Context, k Keeper, msg types.MsgCheckpoint, contractCaller helper.IContractCaller) (result abci.ResponseDeliverSideTx) {
-	// logger
 	logger := k.Logger(ctx)
 	if ctx.BlockHeight() >= helper.GetCheckpointHaltHeight() {
-		logger.Error("Checkpoints not allowed 300 blocks prior to apocalypse hardfork")
+		logger.Error("Halting checkpoint submission prior to apocalypse height")
 		result.Result = abci.SideTxResultType_No
 		return
 	}
@@ -282,7 +281,7 @@ func PostHandleMsgCheckpoint(ctx sdk.Context, k Keeper, msg types.MsgCheckpoint,
 	logger := k.Logger(ctx)
 
 	if ctx.BlockHeight() >= helper.GetCheckpointHaltHeight() {
-		logger.Error("Checkpoints not allowed 300 blocks prior to apocalypse hardfork")
+		logger.Error("Halting checkpoint submission prior to apocalypse height")
 		return common.ErrCheckpointNotAllowed(k.Codespace()).Result()
 
 	}

--- a/cmd/heimdalld/service/service.go
+++ b/cmd/heimdalld/service/service.go
@@ -214,7 +214,7 @@ func getNewApp(serverCtx *server.Context) func(logger log.Logger, db dbm.DB, sto
 		// create new heimdall app
 		hApp = app.NewHeimdallApp(logger, db,
 			baseapp.SetPruning(store.NewPruningOptionsFromString(viper.GetString(flagPruning))),
-			baseapp.SetHaltHeight(uint64(helper.GetApocalypseHeight()+1)))
+			baseapp.SetHaltHeight(uint64(helper.GetApocalypseHeight()+1))) //nolint:gosec
 
 		return hApp
 	}

--- a/common/error.go
+++ b/common/error.go
@@ -33,6 +33,7 @@ const (
 	CodeCheckpointBuffer        CodeType = 1512
 	CodeCheckpointAlreadyExists CodeType = 1513
 	CodeInvalidNoAckProposer    CodeType = 1505
+	CodeCheckpointNotAllowed    CodeType = 1514
 
 	CodeOldValidator        CodeType = 2500
 	CodeNoValidator         CodeType = 2501
@@ -166,6 +167,10 @@ func ErrTooManyNoACK(codespace sdk.CodespaceType) sdk.Error {
 
 func ErrBadTimeStamp(codespace sdk.CodespaceType) sdk.Error {
 	return newError(codespace, CodeBadTimeStamp, "Invalid time stamp. It must be in near past.")
+}
+
+func ErrCheckpointNotAllowed(codespace sdk.CodespaceType) sdk.Error {
+	return newError(codespace, CodeCheckpointNotAllowed, "Submission of checkpoint not allowed")
 }
 
 // -----------Milestone Errors

--- a/helper/config.go
+++ b/helper/config.go
@@ -244,7 +244,7 @@ var jorvikHeight int64 = 0
 
 var danelawHeight int64 = 0
 
-var apocalypseHeight int64 = 200
+var apocalypseHeight int64 = 400
 
 type ChainManagerAddressMigration struct {
 	MaticTokenAddress     hmTypes.HeimdallAddress

--- a/helper/config.go
+++ b/helper/config.go
@@ -244,7 +244,9 @@ var jorvikHeight int64 = 0
 
 var danelawHeight int64 = 0
 
-var apocalypseHeight int64 = 400
+var apocalypseHeight int64 = 900
+
+var checkpointHaltHeightDiff int64 = 500
 
 type ChainManagerAddressMigration struct {
 	MaticTokenAddress     hmTypes.HeimdallAddress
@@ -607,7 +609,7 @@ func GetApocalypseHeight() int64 {
 
 // GetCheckpointHaltHeight returns height at which checkpointing will be halted
 func GetCheckpointHaltHeight() int64 {
-	return GetApocalypseHeight() - 300
+	return GetApocalypseHeight() - checkpointHaltHeightDiff
 }
 
 func GetChainManagerAddressMigration(blockNum int64) (ChainManagerAddressMigration, bool) {

--- a/helper/config.go
+++ b/helper/config.go
@@ -605,6 +605,11 @@ func GetApocalypseHeight() int64 {
 	return apocalypseHeight
 }
 
+// GetCheckpointHaltHeight returns height at which checkpointing will be halted
+func GetCheckpointHaltHeight() int64 {
+	return GetApocalypseHeight() - 300
+}
+
 func GetChainManagerAddressMigration(blockNum int64) (ChainManagerAddressMigration, bool) {
 	chainMigration := chainManagerAddressMigrations[conf.Chain]
 	if chainMigration == nil {

--- a/simulation/simulate.go
+++ b/simulation/simulate.go
@@ -14,6 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 
+	"github.com/maticnetwork/heimdall/helper"
 	"github.com/maticnetwork/heimdall/types/simulation"
 )
 
@@ -141,7 +142,7 @@ func SimulateFromSeed(
 	}
 
 	// TODO: split up the contents of this for loop into new functions
-	for height := config.InitialBlockHeight; height < config.NumBlocks+config.InitialBlockHeight && !stopEarly; height++ {
+	for height := config.InitialBlockHeight; height < config.NumBlocks+config.InitialBlockHeight && !stopEarly && height <= int(helper.GetApocalypseHeight()); height++ {
 		// Log the header time for future lookup
 		pastTimes = append(pastTimes, header.Time)
 		pastVoteInfos = append(pastVoteInfos, request.LastCommitInfo.Votes)


### PR DESCRIPTION
# Description

This PR attempts to halt checkpoint submission 300 blocks prior to the apocalypse HF. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes


# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [x] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply


## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

